### PR TITLE
Local Whisper STT migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ data/verses-for-embedding.json
 
 # ML models and embeddings (downloaded, not committed)
 models/*
+.venv/
 .env
 .superpowers/
 embeddings/*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Rhema listens to a live sermon audio feed, transcribes speech in real time, dete
 
 ## Features
 
-- **Real-time speech-to-text** via Deepgram (WebSocket streaming + REST fallback)
+- **Real-time speech-to-text** via whisper.cpp (local default) with optional Deepgram fallback
 - **Multi-strategy verse detection**
   - Direct reference parsing (Aho-Corasick automaton + fuzzy matching)
   - Semantic search (Qwen3-0.6B ONNX embeddings + HNSW vector index)
@@ -31,14 +31,14 @@ Rhema listens to a live sermon audio feed, transcribes speech in real time, dete
 | **AI/ML** | ONNX Runtime (Qwen3-0.6B embeddings), Aho-Corasick, Fuse.js |
 | **Database** | SQLite via rusqlite (bundled) with FTS5 |
 | **Broadcast** | NDI 6 SDK via dynamic loading (libloading FFI) |
-| **STT** | Deepgram WebSocket + REST (tokio-tungstenite) |
+| **STT** | whisper.cpp via `whisper-rs` (local default) + Deepgram fallback |
 
 ### Rust Crates
 
 | Crate | Purpose |
 |---|---|
 | `rhema-audio` | Audio device enumeration, capture, VAD (cpal) |
-| `rhema-stt` | Deepgram STT streaming + REST fallback |
+| `rhema-stt` | whisper.cpp local transcription + Deepgram fallback |
 | `rhema-bible` | SQLite Bible DB, FTS5 search, cross-references |
 | `rhema-detection` | Verse detection pipeline: direct, semantic, quotation, ensemble merger, sentence buffer, sermon context, reading mode |
 | `rhema-broadcast` | NDI video frame output via FFI |
@@ -51,7 +51,7 @@ Rhema listens to a live sermon audio feed, transcribes speech in real time, dete
 - [Rust](https://rustup.rs/) toolchain (stable, 1.77.2+)
 - [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/) (platform-specific system dependencies)
 - [Python 3](https://www.python.org/) (for downloading copyrighted translations and embedding model export)
-- [Deepgram API key](https://deepgram.com/) (for speech-to-text)
+- [Deepgram API key](https://deepgram.com/) (optional, for cloud fallback only)
 
 ## Getting Started
 
@@ -86,20 +86,39 @@ Reads all JSON files from `data/sources/`, creates `data/rhema.db` with FTS5 sea
 bun run build:bible
 ```
 
-### Step 3: Set up environment
+### Step 3: Download the local Whisper.cpp model
 
-Create a `.env` file in the project root:
+This app uses whisper.cpp locally by default. Download the balanced English model into `models/whisper/`:
+
+```bash
+bun run download:whisper-model
+```
+
+The default is `ggml-small.en.bin`, which is the recommended starting point for local transcription.
+If you want a faster smoke test first, download the tiny model instead:
+
+```bash
+WHISPER_MODEL=tiny.en bun run download:whisper-model
+```
+
+To force the app to use it, set `WHISPER_MODEL=tiny.en` before launching Rhema.
+
+On macOS, the build enables Metal/Core ML support in whisper-rs automatically.
+
+### Step 4 (optional): Set up Deepgram fallback
+
+Create a `.env` file in the project root only if you want cloud fallback or to force Deepgram mode:
 
 ```
 DEEPGRAM_API_KEY=your_key_here
 ```
 
-### Step 4 (optional): Download & export ONNX model
+### Step 5 (optional): Download & export ONNX model
 
 Required for semantic search (both precomputing embeddings and runtime detection). Uses `optimum-cli` to export Qwen3-Embedding-0.6B from HuggingFace to ONNX format and quantize to INT8 for ARM64.
 
 ```bash
-pip install optimum-onnx
+pip install optimum-onnx onnxruntime
 bun run download:model
 ```
 
@@ -114,7 +133,7 @@ To re-quantize separately:
 bun run quantize:model
 ```
 
-### Step 5 (optional): Precompute verse embeddings for semantic search
+### Step 6 (optional): Precompute verse embeddings for semantic search
 
 First, export KJV verses from the database to JSON:
 
@@ -126,7 +145,7 @@ Then compute embeddings. There are three methods — Option A is recommended:
 
 **Option A — Python + ONNX Runtime (recommended):**
 
-Uses the **exact same ONNX model** the Tauri app loads at runtime, guaranteeing embeddings are in the same vector space. Auto-selects INT8 quantized model if available, falls back to FP32. Requires the ONNX model from Step 4.
+Uses the **exact same ONNX model** the Tauri app loads at runtime, guaranteeing embeddings are in the same vector space. Auto-selects INT8 quantized model if available, falls back to FP32. Requires the ONNX model from Step 5.
 
 ```bash
 pip install onnxruntime tokenizers numpy
@@ -144,7 +163,7 @@ bun run precompute:embeddings-py
 
 **Option C — Rust ONNX binary (CPU only):**
 
-Same ONNX model as Option A, compiled as a Rust binary. Requires the ONNX model from Step 4.
+Same ONNX model as Option A, compiled as a Rust binary. Requires the ONNX model from Step 5.
 
 ```bash
 bun run precompute:embeddings
@@ -152,7 +171,7 @@ bun run precompute:embeddings
 
 All three produce binary files in `embeddings/`: `kjv-qwen3-0.6b.bin` (embeddings) and `kjv-qwen3-0.6b-ids.bin` (verse IDs).
 
-### Step 6 (optional): Download NDI SDK for broadcast output
+### Step 7 (optional): Download NDI SDK for broadcast output
 
 ```bash
 bun run download:ndi-sdk
@@ -190,7 +209,7 @@ rhema/
 ├── src-tauri/                    # Rust backend (Tauri v2)
 │   ├── crates/
 │   │   ├── audio/                # Audio capture & metering (cpal)
-│   │   ├── stt/                  # Deepgram STT (WebSocket + REST)
+│   │   ├── stt/                  # Local whisper.cpp STT + Deepgram fallback
 │   │   ├── bible/                # SQLite Bible DB, search, cross-references
 │   │   ├── detection/            # Verse detection pipeline
 │   │   │   ├── direct/           # Aho-Corasick + fuzzy reference parsing
@@ -207,9 +226,11 @@ rhema/
 │   ├── precompute-embeddings.py  # Embeddings via sentence-transformers (GPU)
 │   ├── precompute-embeddings-onnx.py  # Embeddings via ONNX Runtime (recommended)
 │   ├── download-model.ts         # Export & quantize Qwen3 ONNX model
+│   ├── download-whisper-model.ts # Download whisper.cpp ggml model into models/whisper/
 │   ├── download-ndi-sdk.ts       # Download NDI SDK libraries
 │   └── schema.sql                # Database schema
 ├── models/                       # ML models (gitignored)
+│   └── whisper/                  # whisper.cpp ggml model downloads
 ├── embeddings/                   # Precomputed vectors (gitignored)
 ├── sdk/ndi/                      # NDI SDK files (downloaded)
 └── build/                        # Vite build output
@@ -228,6 +249,7 @@ rhema/
 | `typecheck` | TypeScript type checking |
 | `preview` | Preview production build |
 | `download:bible-data` | Download public domain Bible translations + cross-references |
+| `download:whisper-model` | Download the local whisper.cpp ggml model into `models/whisper/` |
 | `build:bible` | Build SQLite Bible database from JSON sources |
 | `download:model` | Export Qwen3-Embedding-0.6B to ONNX + quantize to INT8 |
 | `export:verses` | Export KJV verses to JSON for embedding precomputation |
@@ -243,4 +265,4 @@ Create a `.env` file in the project root:
 
 | Variable | Required | Description |
 |---|---|---|
-| `DEEPGRAM_API_KEY` | Yes | API key for Deepgram speech-to-text |
+| `DEEPGRAM_API_KEY` | No | Optional Deepgram speech-to-text fallback or cloud-only mode |

--- a/data/download-model.ts
+++ b/data/download-model.ts
@@ -4,8 +4,8 @@
  * IMPORTANT: The onnx-community export has KV cache inputs (text-generation format).
  * We need to export it ourselves using optimum-cli with --task feature-extraction.
  *
- * This script runs the optimum-cli export, which requires Python with optimum-onnx installed:
- *   pip install optimum-onnx
+ * This script runs the optimum-cli export, which requires Python with optimum-onnx and onnxruntime installed:
+ *   pip install optimum-onnx onnxruntime
  *
  * Run: bun run data/download-model.ts
  */
@@ -41,7 +41,7 @@ async function main() {
   const exitCode = await proc.exited
   if (exitCode !== 0) {
     console.error("\n❌ Export failed. Make sure optimum-onnx is installed:")
-    console.error("   pip install optimum-onnx")
+    console.error("   pip install optimum-onnx onnxruntime")
     process.exit(1)
   }
 

--- a/data/download-whisper-model.ts
+++ b/data/download-whisper-model.ts
@@ -1,0 +1,60 @@
+/**
+ * Downloads a whisper.cpp ggml model into models/whisper/.
+ *
+ * Default: ggml-small.en.bin
+ * For a faster smoke test, run:
+ *   WHISPER_MODEL=tiny.en bun run download:whisper-model
+ *
+ * Run: bun run download:whisper-model
+ */
+
+import { mkdir } from "node:fs/promises"
+import { join } from "node:path"
+
+const MODELS_DIR = join(import.meta.dir, "..", "models", "whisper")
+const BASE_URL = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main"
+
+function normalizeModelName(raw: string): string {
+  const trimmed = raw.trim()
+  if (trimmed.startsWith("ggml-") && trimmed.endsWith(".bin")) {
+    return trimmed
+  }
+
+  const stripped = trimmed.replace(/^ggml-/, "").replace(/\.bin$/, "")
+  return `ggml-${stripped}.bin`
+}
+
+async function main() {
+  const requestedModel = process.env.WHISPER_MODEL ?? process.argv[2] ?? "small.en"
+  const fileName = normalizeModelName(requestedModel)
+  const dest = join(MODELS_DIR, fileName)
+  const url = `${BASE_URL}/${fileName}`
+
+  await mkdir(MODELS_DIR, { recursive: true })
+
+  const file = Bun.file(dest)
+  if (await file.exists()) {
+    console.log(`\n✓ whisper.cpp model already exists: ${dest}`)
+    return
+  }
+
+  console.log(`\n=== Downloading whisper.cpp model: ${fileName} ===\n`)
+  console.log(`Source: ${url}`)
+  console.log(`Target: ${dest}\n`)
+
+  const response = await fetch(url, { redirect: "follow" })
+  if (!response.ok) {
+    throw new Error(`Failed to download ${fileName}: HTTP ${response.status}`)
+  }
+
+  const buffer = await response.arrayBuffer()
+  await Bun.write(dest, buffer)
+
+  const sizeMB = (buffer.byteLength / 1024 / 1024).toFixed(1)
+  console.log(`\n✅ Saved ${dest} (${sizeMB} MB)\n`)
+}
+
+main().catch((err) => {
+  console.error("❌ whisper.cpp model download failed:", err)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "tauri": "tauri",
     "test": "vitest",
     "download:bible-data": "bun run data/download-sources.ts",
+    "download:whisper-model": "bun run data/download-whisper-model.ts",
     "build:bible": "bun run data/build-bible-db.ts",
     "download:model": "bun run data/download-model.ts",
     "export:verses": "bun run data/compute-embeddings.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -265,6 +265,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -610,6 +612,15 @@ dependencies = [
  "glob",
  "libc",
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1425,6 +1436,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -4055,12 +4072,14 @@ dependencies = [
  "futures-util",
  "log",
  "reqwest 0.12.28",
+ "rhema-audio",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "url",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -6186,6 +6205,28 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
 ]
 
 [[package]]

--- a/src-tauri/crates/stt/Cargo.toml
+++ b/src-tauri/crates/stt/Cargo.toml
@@ -14,7 +14,14 @@ reqwest = { version = "0.12", features = ["json"], optional = true }
 url = "2"
 futures-util = "0.3"
 crossbeam-channel = "0.5"
+rhema-audio = { path = "../audio" }
 
 [features]
 default = ["rest-fallback"]
 rest-fallback = ["reqwest"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+whisper-rs = { version = "0.16", features = ["metal", "coreml"] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+whisper-rs = "0.16"

--- a/src-tauri/crates/stt/src/backend.rs
+++ b/src-tauri/crates/stt/src/backend.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::types::TranscriptionBackend;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalModelStatus {
+    pub model_name: String,
+    pub model_path: Option<PathBuf>,
+    pub exists: bool,
+    pub size_bytes: Option<u64>,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptionStatus {
+    pub backend: TranscriptionBackend,
+    pub recommended_backend: TranscriptionBackend,
+    pub local_model: LocalModelStatus,
+    pub deepgram_key_configured: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::local::local_model_status;
+    use std::fs;
+
+    #[test]
+    fn local_model_status_detects_expected_model_path() {
+        let unique = format!(
+            "rhema-stt-local-model-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos()
+        );
+        let base_dir = std::env::temp_dir().join(unique);
+        let model_path = base_dir.join("models/whisper/ggml-small.en.bin");
+
+        fs::create_dir_all(model_path.parent().expect("model parent")).expect("create model dir");
+        fs::write(&model_path, b"abc").expect("write model file");
+
+        let status = local_model_status(&base_dir);
+
+        assert!(status.exists);
+        assert_eq!(status.model_name, "ggml-small.en.bin");
+        assert_eq!(status.model_path.as_ref(), Some(&model_path));
+        assert_eq!(status.size_bytes, Some(3));
+        assert!(status.note.contains("Local Whisper.cpp model"));
+
+        let _ = fs::remove_dir_all(&base_dir);
+    }
+}

--- a/src-tauri/crates/stt/src/deepgram.rs
+++ b/src-tauri/crates/stt/src/deepgram.rs
@@ -10,6 +10,8 @@ use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 use url::Url;
 
+use rhema_audio::AudioFrame;
+
 use crate::error::SttError;
 use crate::keyterms::bible_keyterms;
 use crate::types::{SttConfig, TranscriptEvent, Word};
@@ -93,7 +95,7 @@ impl DeepgramClient {
     /// Connect to Deepgram and stream audio from `audio_rx`, emitting transcript events to `event_tx`.
     pub async fn connect(
         &self,
-        audio_rx: Receiver<Vec<i16>>,
+        audio_rx: Receiver<AudioFrame>,
         event_tx: mpsc::Sender<TranscriptEvent>,
     ) -> Result<(), SttError> {
         if self.config.api_key.is_empty() {
@@ -151,7 +153,7 @@ impl DeepgramClient {
     /// Attempt a single WebSocket connection and run send/receive loops.
     async fn try_connect(
         &self,
-        audio_rx: Receiver<Vec<i16>>,
+        audio_rx: Receiver<AudioFrame>,
         event_tx: mpsc::Sender<TranscriptEvent>,
         cancelled: Arc<AtomicBool>,
     ) -> Result<(), SttError> {
@@ -219,8 +221,8 @@ impl DeepgramClient {
                     }
 
                     match audio_rx.recv_timeout(Duration::from_millis(50)) {
-                        Ok(samples) => {
-                            for sample in &samples {
+                        Ok(frame) => {
+                            for sample in &frame.samples {
                                 batch_buf.extend_from_slice(&sample.to_le_bytes());
                             }
                             if batch_buf.len() >= batch_byte_threshold {

--- a/src-tauri/crates/stt/src/error.rs
+++ b/src-tauri/crates/stt/src/error.rs
@@ -11,9 +11,18 @@ pub enum SttError {
     #[error("API key is missing")]
     ApiKeyMissing,
 
+    #[error("Local Whisper model is missing: {0}")]
+    LocalModelMissing(String),
+
+    #[error("Local Whisper model failed to load: {0}")]
+    LocalModelLoadFailed(String),
+
     #[error("Send error: {0}")]
     SendError(String),
 
     #[error("Parse error: {0}")]
     ParseError(String),
+
+    #[error("Unsupported transcription backend: {0}")]
+    UnsupportedBackend(String),
 }

--- a/src-tauri/crates/stt/src/keyterms.rs
+++ b/src-tauri/crates/stt/src/keyterms.rs
@@ -76,11 +76,10 @@ pub fn bible_keyterms() -> Vec<String> {
 
     // Common abbreviations
     let abbreviations = [
-        "Gen", "Exod", "Lev", "Num", "Deut", "Josh", "Judg", "Sam", "Kgs", "Chr", "Neh",
-        "Esth", "Ps", "Prov", "Eccl", "Isa", "Jer", "Lam", "Ezek", "Dan", "Hos", "Obad",
-        "Mic", "Nah", "Hab", "Zeph", "Hag", "Zech", "Mal", "Matt", "Mk", "Lk", "Jn", "Rom",
-        "Cor", "Gal", "Eph", "Phil", "Col", "Thess", "Tim", "Tit", "Phlm", "Heb", "Jas",
-        "Pet", "Rev",
+        "Gen", "Exod", "Lev", "Num", "Deut", "Josh", "Judg", "Sam", "Kgs", "Chr", "Neh", "Esth",
+        "Ps", "Prov", "Eccl", "Isa", "Jer", "Lam", "Ezek", "Dan", "Hos", "Obad", "Mic", "Nah",
+        "Hab", "Zeph", "Hag", "Zech", "Mal", "Matt", "Mk", "Lk", "Jn", "Rom", "Cor", "Gal", "Eph",
+        "Phil", "Col", "Thess", "Tim", "Tit", "Phlm", "Heb", "Jas", "Pet", "Rev",
     ];
     terms.extend(abbreviations.iter().map(|s| s.to_string()));
 

--- a/src-tauri/crates/stt/src/lib.rs
+++ b/src-tauri/crates/stt/src/lib.rs
@@ -1,12 +1,16 @@
+pub mod backend;
 pub mod deepgram;
 pub mod error;
 pub mod keyterms;
+pub mod local;
 pub mod rest;
 pub mod types;
 
+pub use backend::{LocalModelStatus, TranscriptionStatus};
 pub use deepgram::DeepgramClient;
 pub use error::SttError;
 pub use keyterms::bible_keyterms;
-pub use types::{SttConfig, TranscriptEvent, Word};
+pub use local::LocalWhisperClient;
+pub use types::{SttConfig, TranscriptEvent, TranscriptionBackend, Word};
 
 pub use rest::DeepgramRestClient;

--- a/src-tauri/crates/stt/src/local.rs
+++ b/src-tauri/crates/stt/src/local.rs
@@ -1,0 +1,509 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crossbeam_channel::Receiver;
+use tokio::sync::mpsc;
+use whisper_rs::{
+    FullParams, SamplingStrategy, SegmentCallbackData, WhisperContext, WhisperContextParameters,
+};
+
+use crate::backend::LocalModelStatus;
+use crate::error::SttError;
+use crate::types::TranscriptEvent;
+use rhema_audio::{
+    vad::{Vad, VadConfig, VadTransition},
+    AudioFrame,
+};
+
+const DEFAULT_MODEL_DIR: &str = "models/whisper";
+const DEFAULT_MODEL_NAME: &str = "ggml-small.en.bin";
+const MODEL_CANDIDATES: &[&str] = &["ggml-small.en.bin", "ggml-base.en.bin", "ggml-tiny.en.bin"];
+
+const PARTIAL_FRAME_INTERVAL: usize = 16;
+const MIN_PARTIAL_SAMPLES: usize = 16_000;
+
+fn model_prompt() -> &'static str {
+    "Bible verses, chapter and verse references, Jesus Christ, God, Lord, Holy Spirit, Genesis, Matthew, Mark, Luke, John, Romans, Revelation."
+}
+
+fn normalize_whisper_model_name(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.starts_with("ggml-") && trimmed.ends_with(".bin") {
+        trimmed.to_string()
+    } else {
+        let stripped_prefix = trimmed.strip_prefix("ggml-").unwrap_or(trimmed);
+        let stripped_suffix = stripped_prefix
+            .strip_suffix(".bin")
+            .unwrap_or(stripped_prefix);
+        format!("ggml-{stripped_suffix}.bin")
+    }
+}
+
+pub fn whisper_model_candidates(base_dir: &Path) -> Vec<PathBuf> {
+    let whisper_dir = base_dir.join(DEFAULT_MODEL_DIR);
+    let mut candidates = Vec::new();
+
+    if let Ok(env_path) = std::env::var("WHISPER_MODEL_PATH") {
+        candidates.push(PathBuf::from(env_path));
+    }
+
+    if let Ok(model_name) = std::env::var("WHISPER_MODEL") {
+        candidates.push(whisper_dir.join(normalize_whisper_model_name(&model_name)));
+    }
+
+    candidates.push(whisper_dir.join(DEFAULT_MODEL_NAME));
+    for name in MODEL_CANDIDATES {
+        let candidate = whisper_dir.join(name);
+        if !candidates.iter().any(|existing| existing == &candidate) {
+            candidates.push(candidate);
+        }
+    }
+
+    candidates
+}
+
+pub fn resolve_whisper_model(base_dir: &Path) -> Option<PathBuf> {
+    whisper_model_candidates(base_dir)
+        .into_iter()
+        .find(|path| path.exists())
+}
+
+pub fn local_model_status(base_dir: &Path) -> LocalModelStatus {
+    let model_path = resolve_whisper_model(base_dir);
+    let exists = model_path.is_some();
+    let size_bytes = model_path
+        .as_ref()
+        .and_then(|path| std::fs::metadata(path).ok())
+        .map(|meta| meta.len());
+
+    let model_name = model_path
+        .as_ref()
+        .and_then(|path| path.file_name())
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| DEFAULT_MODEL_NAME.to_string());
+
+    let note = if exists {
+        "Local Whisper.cpp model is ready.".to_string()
+    } else {
+        format!(
+            "Missing local model. Run `bun run download:whisper-model` to download {} into models/whisper/.",
+            DEFAULT_MODEL_NAME
+        )
+    };
+
+    LocalModelStatus {
+        model_name,
+        model_path,
+        exists,
+        size_bytes,
+        note,
+    }
+}
+
+pub struct LocalWhisperClient {
+    context: Arc<WhisperContext>,
+    model_path: PathBuf,
+    language: Option<String>,
+    threads: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum JobKind {
+    Partial,
+    Final,
+}
+
+#[derive(Debug)]
+struct LocalJob {
+    utterance_id: u64,
+    kind: JobKind,
+    samples: Vec<i16>,
+}
+
+#[derive(Debug)]
+struct TranscriptionResult {
+    transcript: String,
+    confidence: f64,
+}
+
+impl LocalWhisperClient {
+    pub fn new(model_path: PathBuf) -> Result<Self, SttError> {
+        if !model_path.exists() {
+            return Err(SttError::LocalModelMissing(
+                model_path.to_string_lossy().to_string(),
+            ));
+        }
+
+        let threads = std::thread::available_parallelism()
+            .map(|n| n.get().saturating_sub(1).max(1))
+            .unwrap_or(4);
+
+        let context = WhisperContext::new_with_params(
+            model_path.to_string_lossy().into_owned(),
+            WhisperContextParameters::default(),
+        )
+        .map_err(|e| SttError::LocalModelLoadFailed(e.to_string()))?;
+
+        Ok(Self {
+            context: Arc::new(context),
+            model_path,
+            language: Some("en".to_string()),
+            threads,
+        })
+    }
+
+    pub fn model_status(&self) -> LocalModelStatus {
+        let size_bytes = std::fs::metadata(&self.model_path)
+            .ok()
+            .map(|meta| meta.len());
+
+        LocalModelStatus {
+            model_name: self
+                .model_path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| DEFAULT_MODEL_NAME.to_string()),
+            model_path: Some(self.model_path.clone()),
+            exists: true,
+            size_bytes,
+            note: "Local Whisper.cpp model is ready.".to_string(),
+        }
+    }
+
+    pub async fn connect(
+        &self,
+        audio_rx: Receiver<AudioFrame>,
+        event_tx: mpsc::Sender<TranscriptEvent>,
+    ) -> Result<(), SttError> {
+        let context = self.context.clone();
+        let model_path = self.model_path.clone();
+        let language = self.language.clone();
+        let threads = self.threads;
+
+        tokio::task::spawn_blocking(move || {
+            run_local_session(context, model_path, language, threads, audio_rx, event_tx)
+        })
+        .await
+        .map_err(|e| SttError::ConnectionFailed(format!("Local Whisper worker join failed: {e}")))?
+    }
+}
+
+fn run_local_session(
+    context: Arc<WhisperContext>,
+    _model_path: PathBuf,
+    language: Option<String>,
+    threads: usize,
+    audio_rx: Receiver<AudioFrame>,
+    event_tx: mpsc::Sender<TranscriptEvent>,
+) -> Result<(), SttError> {
+    let job_rx_cancel = Arc::new(AtomicBool::new(false));
+    let worker_failed = Arc::new(AtomicBool::new(false));
+    let worker_error = Arc::new(Mutex::new(None::<String>));
+    let (job_tx, job_rx) = crossbeam_channel::bounded::<LocalJob>(8);
+
+    let worker_failed_thread = worker_failed.clone();
+    let worker_error_thread = worker_error.clone();
+    let worker_cancel = job_rx_cancel.clone();
+    let worker_context = context.clone();
+    let worker_language = language.clone();
+    let worker_event_tx = event_tx.clone();
+
+    let worker = std::thread::Builder::new()
+        .name("whisper-worker".into())
+        .spawn(move || {
+            let mut current_utterance_id = 0_u64;
+            let last_partial = Arc::new(Mutex::new(String::new()));
+
+            while !worker_cancel.load(Ordering::SeqCst) {
+                let job = match job_rx.recv_timeout(Duration::from_millis(100)) {
+                    Ok(job) => job,
+                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
+                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+                };
+
+                if job.utterance_id != current_utterance_id {
+                    current_utterance_id = job.utterance_id;
+                    if let Ok(mut last) = last_partial.lock() {
+                        last.clear();
+                    }
+                }
+
+                match transcribe_chunk(
+                    &worker_context,
+                    worker_language.as_deref(),
+                    threads,
+                    &job.samples,
+                    &worker_event_tx,
+                    &last_partial,
+                ) {
+                    Ok(result) => {
+                        if job.kind == JobKind::Final && !result.transcript.is_empty() {
+                            let _ = worker_event_tx.blocking_send(TranscriptEvent::Final {
+                                transcript: result.transcript,
+                                words: vec![],
+                                confidence: result.confidence,
+                                speech_final: true,
+                            });
+                        }
+                    }
+                    Err(err) => {
+                        worker_failed_thread.store(true, Ordering::SeqCst);
+                        if let Ok(mut slot) = worker_error_thread.lock() {
+                            *slot = Some(err.to_string());
+                        }
+                        let _ =
+                            worker_event_tx.blocking_send(TranscriptEvent::Error(err.to_string()));
+                        break;
+                    }
+                }
+            }
+        })
+        .map_err(|e| SttError::ConnectionFailed(format!("Failed to spawn Whisper worker: {e}")))?;
+
+    let audio_event_tx = event_tx.clone();
+    let audio_cancel = job_rx_cancel.clone();
+    let audio_worker_failed = worker_failed.clone();
+    let audio = std::thread::Builder::new()
+        .name("whisper-audio".into())
+        .spawn(move || {
+            let mut vad = Vad::new(VadConfig::default());
+            let mut current_utterance: Vec<i16> = Vec::new();
+            let mut in_speech = false;
+            let mut utterance_id: u64 = 0;
+            let mut frames_since_partial = 0usize;
+
+            let _ = audio_event_tx.blocking_send(TranscriptEvent::Connected);
+
+            loop {
+                if audio_cancel.load(Ordering::SeqCst) {
+                    break;
+                }
+                if audio_worker_failed.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                let frame = match audio_rx.recv_timeout(Duration::from_millis(100)) {
+                    Ok(frame) => frame,
+                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
+                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+                };
+
+                let vad_result = vad.process(&frame);
+
+                match vad_result.transition {
+                    Some(VadTransition::SpeechStarted) => {
+                        utterance_id = utterance_id.wrapping_add(1);
+                        current_utterance.clear();
+                        in_speech = true;
+                        frames_since_partial = 0;
+                        let _ = audio_event_tx.blocking_send(TranscriptEvent::SpeechStarted);
+                    }
+                    Some(VadTransition::SpeechEnded) => {
+                        if in_speech && !current_utterance.is_empty() {
+                            let samples = std::mem::take(&mut current_utterance);
+                            if job_tx
+                                .send(LocalJob {
+                                    utterance_id,
+                                    kind: JobKind::Final,
+                                    samples,
+                                })
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        in_speech = false;
+                        frames_since_partial = 0;
+                    }
+                    None => {}
+                }
+
+                if !vad_result.frames.is_empty() {
+                    for frame in vad_result.frames {
+                        current_utterance.extend(frame.samples);
+                    }
+
+                    if in_speech {
+                        frames_since_partial += 1;
+                        if frames_since_partial >= PARTIAL_FRAME_INTERVAL
+                            && current_utterance.len() >= MIN_PARTIAL_SAMPLES
+                        {
+                            let _ = job_tx.try_send(LocalJob {
+                                utterance_id,
+                                kind: JobKind::Partial,
+                                samples: current_utterance.clone(),
+                            });
+                            frames_since_partial = 0;
+                        }
+                    }
+                }
+            }
+
+            if in_speech && !current_utterance.is_empty() {
+                let _ = job_tx.send(LocalJob {
+                    utterance_id,
+                    kind: JobKind::Final,
+                    samples: current_utterance,
+                });
+            }
+        })
+        .map_err(|e| {
+            SttError::ConnectionFailed(format!("Failed to spawn Whisper audio thread: {e}"))
+        })?;
+
+    while !audio.is_finished() || !worker.is_finished() {
+        if worker_failed.load(Ordering::SeqCst) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    job_rx_cancel.store(true, Ordering::SeqCst);
+    let _ = audio.join();
+    let _ = worker.join();
+
+    if worker_failed.load(Ordering::SeqCst) {
+        if let Ok(slot) = worker_error.lock() {
+            if let Some(message) = slot.clone() {
+                return Err(SttError::ConnectionFailed(message));
+            }
+        }
+        return Err(SttError::ConnectionFailed(
+            "Local Whisper transcription failed".to_string(),
+        ));
+    }
+
+    let _ = event_tx.blocking_send(TranscriptEvent::Disconnected);
+    Ok(())
+}
+
+fn transcribe_chunk(
+    context: &Arc<WhisperContext>,
+    language: Option<&str>,
+    threads: usize,
+    samples: &[i16],
+    event_tx: &mpsc::Sender<TranscriptEvent>,
+    last_partial: &Arc<Mutex<String>>,
+) -> Result<TranscriptionResult, SttError> {
+    if samples.is_empty() {
+        return Ok(TranscriptionResult {
+            transcript: String::new(),
+            confidence: 0.0,
+        });
+    }
+
+    let mut state = context
+        .create_state()
+        .map_err(|e| SttError::LocalModelLoadFailed(e.to_string()))?;
+
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+    params.set_n_threads(threads as i32);
+    params.set_translate(false);
+    params.set_no_context(true);
+    params.set_single_segment(false);
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+    params.set_initial_prompt(model_prompt());
+    if let Some(language) = language {
+        params.set_language(Some(language));
+    }
+
+    let partial_segments = Arc::new(Mutex::new(Vec::<String>::new()));
+    let partial_segments_cb = partial_segments.clone();
+    let event_tx_cb = event_tx.clone();
+    let last_partial_cb = last_partial.clone();
+
+    let segment_callback: Box<dyn FnMut(SegmentCallbackData)> =
+        Box::new(move |segment: SegmentCallbackData| {
+            let text = segment.text.trim().to_string();
+            if text.is_empty() {
+                return;
+            }
+
+            if let Ok(mut parts) = partial_segments_cb.lock() {
+                parts.push(text);
+                let joined = parts.join(" ");
+
+                if let Ok(mut last) = last_partial_cb.lock() {
+                    if *last != joined {
+                        *last = joined.clone();
+                        let _ = event_tx_cb.try_send(TranscriptEvent::Partial {
+                            transcript: joined,
+                            words: vec![],
+                        });
+                    }
+                }
+            }
+        });
+
+    params.set_segment_callback_safe_lossy::<
+        Option<Box<dyn FnMut(SegmentCallbackData)>>,
+        Box<dyn FnMut(SegmentCallbackData)>,
+    >(Some(segment_callback));
+
+    let audio: Vec<f32> = samples
+        .iter()
+        .map(|sample| *sample as f32 / i16::MAX as f32)
+        .collect();
+
+    state
+        .full(params, &audio)
+        .map_err(|e| SttError::ConnectionFailed(format!("Whisper transcription failed: {e}")))?;
+
+    let mut transcript = String::new();
+    let mut confidences = Vec::new();
+    for segment in state.as_iter() {
+        let text = segment
+            .to_str_lossy()
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if text.is_empty() {
+            continue;
+        }
+
+        if !transcript.is_empty() {
+            transcript.push(' ');
+        }
+        transcript.push_str(&text);
+        confidences.push(1.0 - segment.no_speech_probability().clamp(0.0, 1.0));
+    }
+
+    if transcript.is_empty() {
+        if let Ok(parts) = partial_segments.lock() {
+            transcript = parts.join(" ");
+        }
+    }
+
+    let confidence = if confidences.is_empty() {
+        0.0
+    } else {
+        confidences.iter().copied().sum::<f32>() / confidences.len() as f32
+    } as f64;
+
+    Ok(TranscriptionResult {
+        transcript,
+        confidence,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_whisper_model_name;
+
+    #[test]
+    fn normalize_whisper_model_name_handles_shortcuts_and_prefixes() {
+        assert_eq!(normalize_whisper_model_name("tiny.en"), "ggml-tiny.en.bin");
+        assert_eq!(
+            normalize_whisper_model_name("ggml-small.en.bin"),
+            "ggml-small.en.bin"
+        );
+        assert_eq!(
+            normalize_whisper_model_name("ggml-base.en"),
+            "ggml-base.en.bin"
+        );
+    }
+}

--- a/src-tauri/crates/stt/src/rest.rs
+++ b/src-tauri/crates/stt/src/rest.rs
@@ -75,9 +75,7 @@ impl DeepgramRestClient {
 
         if let Some(channels) = channels {
             for channel in channels {
-                let alternatives = channel
-                    .get("alternatives")
-                    .and_then(|a| a.as_array());
+                let alternatives = channel.get("alternatives").and_then(|a| a.as_array());
 
                 if let Some(alts) = alternatives {
                     if let Some(first) = alts.first() {

--- a/src-tauri/crates/stt/src/types.rs
+++ b/src-tauri/crates/stt/src/types.rs
@@ -9,6 +9,14 @@ pub struct Word {
     pub punctuated_word: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TranscriptionBackend {
+    Auto,
+    Local,
+    Deepgram,
+}
+
 #[derive(Debug, Clone)]
 pub enum TranscriptEvent {
     Partial {
@@ -46,5 +54,49 @@ impl Default for SttConfig {
             encoding: "linear16".to_string(),
             language: None,
         }
+    }
+}
+
+impl TranscriptionBackend {
+    pub fn from_option(value: Option<&str>) -> Self {
+        match value.unwrap_or("auto").to_lowercase().as_str() {
+            "local" => Self::Local,
+            "deepgram" => Self::Deepgram,
+            _ => Self::Auto,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Local => "local",
+            Self::Deepgram => "deepgram",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TranscriptionBackend;
+
+    #[test]
+    fn transcription_backend_from_option_normalizes_case_and_defaults() {
+        assert_eq!(
+            TranscriptionBackend::from_option(None),
+            TranscriptionBackend::Auto
+        );
+        assert_eq!(
+            TranscriptionBackend::from_option(Some("LOCAL")),
+            TranscriptionBackend::Local
+        );
+        assert_eq!(
+            TranscriptionBackend::from_option(Some("deepgram")),
+            TranscriptionBackend::Deepgram
+        );
+        assert_eq!(
+            TranscriptionBackend::from_option(Some("something-else")),
+            TranscriptionBackend::Auto
+        );
+        assert_eq!(TranscriptionBackend::Local.as_str(), "local");
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -7,8 +7,6 @@ use rhema_audio::DeviceInfo;
 
 /// List all available audio input devices.
 #[tauri::command]
-pub fn get_audio_devices(
-    _state: State<'_, Mutex<AppState>>,
-) -> Result<Vec<DeviceInfo>, String> {
+pub fn get_audio_devices(_state: State<'_, Mutex<AppState>>) -> Result<Vec<DeviceInfo>, String> {
     rhema_audio::device::enumerate_devices().map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/bible.rs
+++ b/src-tauri/src/commands/bible.rs
@@ -1,14 +1,12 @@
-use std::sync::Mutex;
 use serde::Serialize;
+use std::sync::Mutex;
 use tauri::State;
 
 use crate::state::AppState;
 use rhema_bible::{Book, CrossReference, Translation, Verse};
 
 #[tauri::command]
-pub fn list_translations(
-    state: State<'_, Mutex<AppState>>,
-) -> Result<Vec<Translation>, String> {
+pub fn list_translations(state: State<'_, Mutex<AppState>>) -> Result<Vec<Translation>, String> {
     let app_state = state.lock().map_err(|e| e.to_string())?;
     let db = app_state
         .bible_db
@@ -97,9 +95,7 @@ pub fn get_cross_references(
 
 /// Get the active translation ID
 #[tauri::command]
-pub fn get_active_translation(
-    state: State<'_, Mutex<AppState>>,
-) -> Result<i64, String> {
+pub fn get_active_translation(state: State<'_, Mutex<AppState>>) -> Result<i64, String> {
     let app_state = state.lock().map_err(|e| e.to_string())?;
     Ok(app_state.active_translation_id)
 }

--- a/src-tauri/src/commands/broadcast.rs
+++ b/src-tauri/src/commands/broadcast.rs
@@ -1,10 +1,10 @@
 use std::sync::Mutex;
 
 use base64::Engine;
+use rhema_broadcast::ndi::{NdiRuntime, NdiSessionInfo, NdiStartRequest};
 use serde::{Deserialize, Serialize};
 use tauri::State;
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
-use rhema_broadcast::ndi::{NdiRuntime, NdiSessionInfo, NdiStartRequest};
 
 /// Map output_id ("main" | "alt") to Tauri window label.
 fn window_label(output_id: &str) -> &'static str {
@@ -58,18 +58,18 @@ pub fn ensure_broadcast_window(app: tauri::AppHandle, output_id: String) -> Resu
     if app.get_webview_window(label).is_some() {
         return Ok(());
     }
-    WebviewWindowBuilder::new(
-        &app,
-        label,
-        WebviewUrl::App(window_url(&output_id).into()),
-    )
-    .title(if output_id == "alt" { "Rhema NDI Alt" } else { "Rhema NDI" })
-    .inner_size(1920.0, 1080.0)
-    .visible(false)
-    .skip_taskbar(true)
-    .focused(false)
-    .build()
-    .map_err(|e| e.to_string())?;
+    WebviewWindowBuilder::new(&app, label, WebviewUrl::App(window_url(&output_id).into()))
+        .title(if output_id == "alt" {
+            "Rhema NDI Alt"
+        } else {
+            "Rhema NDI"
+        })
+        .inner_size(1920.0, 1080.0)
+        .visible(false)
+        .skip_taskbar(true)
+        .focused(false)
+        .build()
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -112,20 +112,16 @@ pub fn open_broadcast_window(
         "Projector - Program"
     };
 
-    WebviewWindowBuilder::new(
-        &app,
-        label,
-        WebviewUrl::App(window_url(&output_id).into()),
-    )
-    .title(title)
-    .position(pos.x as f64, pos.y as f64)
-    .inner_size(size.width as f64, size.height as f64)
-    .decorations(true)
-    .always_on_top(false)
-    .skip_taskbar(false)
-    .focused(true)
-    .build()
-    .map_err(|e| e.to_string())?;
+    WebviewWindowBuilder::new(&app, label, WebviewUrl::App(window_url(&output_id).into()))
+        .title(title)
+        .position(pos.x as f64, pos.y as f64)
+        .inner_size(size.width as f64, size.height as f64)
+        .decorations(true)
+        .always_on_top(false)
+        .skip_taskbar(false)
+        .focused(true)
+        .build()
+        .map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -158,9 +154,7 @@ pub fn start_ndi(
     request: NdiStartRequest,
 ) -> Result<NdiSessionInfo, String> {
     let mut runtime = runtime.lock().map_err(|e| e.to_string())?;
-    runtime
-        .start(output_id, request)
-        .map_err(|e| e.to_string())
+    runtime.start(output_id, request).map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -43,25 +43,58 @@ pub fn to_result(state: &AppState, merged: &MergedDetection) -> DetectionResult 
                 (r, v.text, v.book_name, v.book_number, v.chapter, v.verse)
             } else {
                 let r = format!("{} {}:{}", vr.book_name, vr.chapter, vr.verse_start);
-                (r, String::new(), vr.book_name.clone(), vr.book_number, vr.chapter, vr.verse_start)
+                (
+                    r,
+                    String::new(),
+                    vr.book_name.clone(),
+                    vr.book_number,
+                    vr.chapter,
+                    vr.verse_start,
+                )
             }
         } else if let Some(ref db) = state.bible_db {
             // Direct detection: resolve via book/chapter/verse
             if vr.book_number > 0 && vr.chapter > 0 && vr.verse_start > 0 {
-                if let Ok(Some(v)) = db.get_verse(state.active_translation_id, vr.book_number, vr.chapter, vr.verse_start) {
+                if let Ok(Some(v)) = db.get_verse(
+                    state.active_translation_id,
+                    vr.book_number,
+                    vr.chapter,
+                    vr.verse_start,
+                ) {
                     let r = format!("{} {}:{}", v.book_name, v.chapter, v.verse);
                     (r, v.text, v.book_name, v.book_number, v.chapter, v.verse)
                 } else {
                     let r = format!("{} {}:{}", vr.book_name, vr.chapter, vr.verse_start);
-                    (r, String::new(), vr.book_name.clone(), vr.book_number, vr.chapter, vr.verse_start)
+                    (
+                        r,
+                        String::new(),
+                        vr.book_name.clone(),
+                        vr.book_number,
+                        vr.chapter,
+                        vr.verse_start,
+                    )
                 }
             } else {
                 let r = format!("{} {}:{}", vr.book_name, vr.chapter, vr.verse_start);
-                (r, String::new(), vr.book_name.clone(), vr.book_number, vr.chapter, vr.verse_start)
+                (
+                    r,
+                    String::new(),
+                    vr.book_name.clone(),
+                    vr.book_number,
+                    vr.chapter,
+                    vr.verse_start,
+                )
             }
         } else {
             let r = format!("{} {}:{}", vr.book_name, vr.chapter, vr.verse_start);
-            (r, String::new(), vr.book_name.clone(), vr.book_number, vr.chapter, vr.verse_start)
+            (
+                r,
+                String::new(),
+                vr.book_name.clone(),
+                vr.book_number,
+                vr.chapter,
+                vr.verse_start,
+            )
         };
 
     DetectionResult {
@@ -148,7 +181,10 @@ pub fn semantic_search(
         return Err("Semantic search not available — model or embeddings not loaded".into());
     }
 
-    let hits = app_state.detection_pipeline.semantic.search_query(&query, k);
+    let hits = app_state
+        .detection_pipeline
+        .semantic
+        .search_query(&query, k);
 
     let mut results: Vec<SemanticSearchResult> = hits
         .into_iter()
@@ -171,7 +207,11 @@ pub fn semantic_search(
         .collect();
 
     // Ensure highest similarity is always first
-    results.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| {
+        b.similarity
+            .partial_cmp(&a.similarity)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
     Ok(results)
 }
@@ -259,9 +299,7 @@ pub struct ReadingModeStatus {
 
 /// Stop reading mode
 #[tauri::command]
-pub fn stop_reading_mode(
-    state: State<'_, Mutex<ReadingMode>>,
-) -> Result<(), String> {
+pub fn stop_reading_mode(state: State<'_, Mutex<ReadingMode>>) -> Result<(), String> {
     let mut rm = state.lock().map_err(|e| e.to_string())?;
     rm.deactivate();
     Ok(())

--- a/src-tauri/src/commands/stt.rs
+++ b/src-tauri/src/commands/stt.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 
@@ -9,23 +10,61 @@ use crate::events::{
 };
 use crate::state::AppState;
 use rhema_audio::{AudioConfig, AudioFrame};
-use rhema_stt::{DeepgramClient, SttConfig, TranscriptEvent};
+use rhema_stt::local::{local_model_status, resolve_whisper_model};
+use rhema_stt::{
+    DeepgramClient, LocalWhisperClient, SttConfig, TranscriptEvent, TranscriptionBackend,
+    TranscriptionStatus,
+};
+
+enum SelectedBackend {
+    Local(LocalWhisperClient),
+    Deepgram(DeepgramClient),
+}
+
+fn stt_base_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+#[tauri::command]
+pub fn get_transcription_status() -> Result<TranscriptionStatus, String> {
+    let base_dir = stt_base_dir();
+    let local_model = local_model_status(&base_dir);
+    let deepgram_key_configured = std::env::var("DEEPGRAM_API_KEY")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false);
+
+    let recommended_backend = if local_model.exists {
+        TranscriptionBackend::Local
+    } else if deepgram_key_configured {
+        TranscriptionBackend::Deepgram
+    } else {
+        TranscriptionBackend::Auto
+    };
+
+    Ok(TranscriptionStatus {
+        backend: TranscriptionBackend::Auto,
+        recommended_backend,
+        local_model,
+        deepgram_key_configured,
+    })
+}
 
 /// Start the full audio-capture-to-transcription pipeline.
 ///
 /// 1. Opens the microphone via cpal (on a dedicated thread so the non-Send
 ///    `AudioCapture` never crosses thread boundaries).
-/// 2. Connects to Deepgram via WebSocket.
-/// 3. Fans audio out to both the level meter (emits `audio_level` events) and Deepgram.
+/// 2. Resolves the transcription backend (local whisper.cpp by default, Deepgram fallback).
+/// 3. Fans audio out to the level meter (emits `audio_level` events) and the chosen backend.
 /// 4. Receives transcripts and emits `transcript_partial` / `transcript_final` events.
 /// 5. On final transcripts, runs the detection pipeline and emits `verse_detected` events.
 #[tauri::command]
 pub async fn start_transcription(
     app: AppHandle,
     state: State<'_, Mutex<AppState>>,
-    api_key: String,
+    api_key: Option<String>,
     device_id: Option<String>,
     gain: Option<f32>,
+    backend: Option<String>,
 ) -> Result<(), String> {
     // ── 1. Guard: already running? ──────────────────────────────────────
     let (stt_active, audio_active) = {
@@ -36,26 +75,84 @@ pub async fn start_transcription(
         (app_state.stt_active.clone(), app_state.audio_active.clone())
     };
 
-    // Resolve API key: use provided key, or fall back to DEEPGRAM_API_KEY env var
-    let resolved_api_key = if api_key.is_empty() {
-        std::env::var("DEEPGRAM_API_KEY").unwrap_or_default()
-    } else {
-        api_key
+    let backend_mode = TranscriptionBackend::from_option(backend.as_deref());
+    let resolved_api_key = api_key
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| std::env::var("DEEPGRAM_API_KEY").ok())
+        .unwrap_or_default();
+
+    let base_dir = stt_base_dir();
+    let local_status = local_model_status(&base_dir);
+    let local_model_path = resolve_whisper_model(&base_dir);
+
+    let stt_config = SttConfig {
+        api_key: resolved_api_key,
+        model: "nova-3".to_string(),
+        sample_rate: 16_000,
+        encoding: "linear16".to_string(),
+        language: None,
     };
 
-    if resolved_api_key.is_empty() {
-        return Err("No Deepgram API key provided. Set it in Settings or via DEEPGRAM_API_KEY env var.".into());
-    }
+    let selected_backend = match backend_mode {
+        TranscriptionBackend::Local => {
+            let model_path = local_model_path
+                .clone()
+                .ok_or_else(|| local_status.note.clone())?;
+            let client = LocalWhisperClient::new(model_path)
+                .map_err(|e| format!("Local Whisper setup failed: {e}"))?;
+            SelectedBackend::Local(client)
+        }
+        TranscriptionBackend::Deepgram => {
+            if stt_config.api_key.is_empty() {
+                return Err(
+                    "No Deepgram API key provided. Set it in Settings or via DEEPGRAM_API_KEY env var."
+                        .into(),
+                );
+            }
+            SelectedBackend::Deepgram(DeepgramClient::new(stt_config.clone()))
+        }
+        TranscriptionBackend::Auto => {
+            if let Some(model_path) = local_model_path.clone() {
+                match LocalWhisperClient::new(model_path) {
+                    Ok(client) => SelectedBackend::Local(client),
+                    Err(err) => {
+                        if !stt_config.api_key.is_empty() {
+                            log::warn!(
+                                "Local Whisper unavailable, falling back to Deepgram: {err}"
+                            );
+                            SelectedBackend::Deepgram(DeepgramClient::new(stt_config.clone()))
+                        } else {
+                            return Err(format!(
+                                "Local Whisper is not ready and no Deepgram key is configured: {err}"
+                            ));
+                        }
+                    }
+                }
+            } else if !stt_config.api_key.is_empty() {
+                log::warn!(
+                    "Local Whisper model missing, falling back to Deepgram: {}",
+                    local_status.note
+                );
+                SelectedBackend::Deepgram(DeepgramClient::new(stt_config.clone()))
+            } else {
+                return Err(local_status.note.clone());
+            }
+        }
+    };
 
-    log::info!("Starting transcription: api_key={}..., device_id={:?}, gain={:?}",
-        &resolved_api_key[..8.min(resolved_api_key.len())], device_id, gain);
+    log::info!(
+        "Starting transcription: backend={}, device_id={:?}, gain={:?}",
+        backend_mode.as_str(),
+        device_id,
+        gain
+    );
 
     stt_active.store(true, Ordering::SeqCst);
     audio_active.store(true, Ordering::SeqCst);
 
     // ── 2. Prepare channels ─────────────────────────────────────────────
-    // Deepgram channel carries Vec<i16> (the samples from each AudioFrame).
-    let (deepgram_tx, deepgram_rx) = crossbeam_channel::bounded::<Vec<i16>>(64);
+    let (audio_tx, audio_rx) = crossbeam_channel::bounded::<AudioFrame>(64);
+    let (backend_audio_tx, backend_audio_rx) = crossbeam_channel::bounded::<AudioFrame>(64);
 
     // ── 3. Spawn the audio-capture + fan-out thread ─────────────────────
     // cpal's `Stream` (inside `AudioCapture`) is !Send, so we must create
@@ -63,7 +160,7 @@ pub async fn start_transcription(
     //   a) starts the cpal capture
     //   b) reads AudioFrames
     //   c) computes levels → emits audio_level events
-    //   d) forwards samples to Deepgram via crossbeam
+    //   d) forwards frames to the chosen transcription backend
     let gain_val = gain.unwrap_or(1.0).clamp(0.0, 2.0);
     let fan_active = stt_active.clone();
     let fan_app = app.clone();
@@ -77,9 +174,6 @@ pub async fn start_transcription(
                 gain: gain_val,
             };
 
-            let (audio_tx, audio_rx) = crossbeam_channel::bounded::<AudioFrame>(64);
-
-            // Start capture on THIS thread — AudioCapture stays here.
             let capture = match rhema_audio::capture::start(config, audio_tx) {
                 Ok(c) => c,
                 Err(e) => {
@@ -93,17 +187,11 @@ pub async fn start_transcription(
 
             let mut frame_count: u64 = 0;
 
-            loop {
-                if !fan_active.load(Ordering::SeqCst) {
-                    break;
-                }
-
+            while fan_active.load(Ordering::SeqCst) {
                 match audio_rx.recv_timeout(std::time::Duration::from_millis(100)) {
                     Ok(frame) => {
                         frame_count += 1;
 
-                        // (a) Compute audio levels at ~15 Hz
-                        //     At 16 kHz with ~1024-sample frames, every 4th frame is ~15 Hz.
                         if frame_count % 4 == 0 {
                             let level = rhema_audio::meter::compute_level(&frame.samples);
                             let _ = fan_app.emit(
@@ -115,18 +203,16 @@ pub async fn start_transcription(
                             );
                         }
 
-                        // (b) Forward all audio to Deepgram
-                        // NOTE: VAD module exists (audio/vad.rs) but disabled —
-                        // Deepgram's built-in VAD handles silence detection.
-                        // Re-enable when VAD thresholds are properly tuned.
-                        let _ = deepgram_tx.try_send(frame.samples);
+                        if backend_audio_tx.send(frame).is_err() {
+                            log::warn!("Backend audio channel disconnected; stopping capture");
+                            break;
+                        }
                     }
                     Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
                     Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
                 }
             }
 
-            // Dropping `capture` stops the cpal stream.
             capture.stop();
             log::info!("Audio capture stopped on fanout thread");
         })
@@ -136,94 +222,113 @@ pub async fn start_transcription(
             format!("Failed to spawn audio fanout thread: {e}")
         })?;
 
-    // ── 4. Spawn the Deepgram connection on the tokio runtime ───────────
-    let stt_config = SttConfig {
-        api_key: resolved_api_key,
-        model: "nova-3".to_string(),
-        sample_rate: 16_000,
-        encoding: "linear16".to_string(),
-        language: None,
-    };
-
-    let client = DeepgramClient::new(stt_config.clone());
-
+    // ── 4. Spawn the selected transcription backend on the tokio runtime ─
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TranscriptEvent>(64);
 
     let conn_active = stt_active.clone();
+    let audio_active_task = audio_active.clone();
+    let backend_audio_rx = backend_audio_rx;
 
-    // Task A: run the Deepgram WebSocket connection.
-    // On max reconnect failure, falls back to REST mode (hybrid).
-    let rest_event_tx = event_tx.clone();
-    let rest_config = stt_config.clone();
-    tauri::async_runtime::spawn(async move {
-        let result = client.connect(deepgram_rx.clone(), event_tx).await;
-        if let Err(e) = result {
-            log::error!("Deepgram WebSocket failed: {e}");
+    match selected_backend {
+        SelectedBackend::Local(client) => {
+            let conn_active = conn_active.clone();
+            let audio_active_task = audio_active_task.clone();
+            let task_event_tx = event_tx.clone();
+            let local_audio_rx = backend_audio_rx.clone();
+            tauri::async_runtime::spawn(async move {
+                let result = client.connect(local_audio_rx, task_event_tx.clone()).await;
+                if let Err(e) = result {
+                    log::error!("Local Whisper backend failed: {e}");
+                    let _ = task_event_tx
+                        .send(TranscriptEvent::Error(format!(
+                            "Local Whisper backend failed: {e}"
+                        )))
+                        .await;
+                }
+                conn_active.store(false, Ordering::SeqCst);
+                audio_active_task.store(false, Ordering::SeqCst);
+                log::info!("Local Whisper transcription task exited");
+            });
+        }
+        SelectedBackend::Deepgram(client) => {
+            let deepgram_audio_rx = backend_audio_rx.clone();
+            let rest_audio_rx = backend_audio_rx;
+            let rest_event_tx = event_tx.clone();
+            let rest_config = stt_config.clone();
+            let task_event_tx = event_tx.clone();
+            tauri::async_runtime::spawn(async move {
+                let result = client.connect(deepgram_audio_rx, task_event_tx).await;
+                if let Err(e) = result {
+                    log::error!("Deepgram WebSocket failed: {e}");
 
-            // ── Hybrid mode: fall back to REST transcription ──
-            {
-                log::warn!("[STT] Connection unstable, switching to Hybrid mode (REST fallback)");
-                let _ = rest_event_tx
-                    .send(TranscriptEvent::Error(
-                        "Connection unstable, switching to Hybrid mode".into(),
-                    ))
-                    .await;
+                    log::warn!(
+                        "[STT] Connection unstable, switching to Hybrid mode (REST fallback)"
+                    );
+                    let _ = rest_event_tx
+                        .send(TranscriptEvent::Error(
+                            "Connection unstable, switching to Hybrid mode".into(),
+                        ))
+                        .await;
 
-                let rest_client = rhema_stt::DeepgramRestClient::new(rest_config);
-                let mut audio_buffer: Vec<i16> = Vec::new();
-                let flush_interval = std::time::Duration::from_secs(5);
-                let mut last_flush = std::time::Instant::now();
+                    let rest_client = rhema_stt::DeepgramRestClient::new(rest_config);
+                    let mut audio_buffer: Vec<i16> = Vec::new();
+                    let flush_interval = std::time::Duration::from_secs(5);
+                    let mut last_flush = std::time::Instant::now();
 
-                loop {
-                    if !conn_active.load(Ordering::SeqCst) {
-                        break;
-                    }
+                    loop {
+                        if !conn_active.load(Ordering::SeqCst) {
+                            break;
+                        }
 
-                    match deepgram_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-                        Ok(samples) => {
-                            audio_buffer.extend(samples);
+                        match rest_audio_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                            Ok(frame) => {
+                                audio_buffer.extend(frame.samples);
 
-                            // Flush every 5 seconds of accumulated audio
-                            if last_flush.elapsed() >= flush_interval && !audio_buffer.is_empty() {
-                                match rest_client.transcribe(&audio_buffer).await {
-                                    Ok(events) => {
-                                        for evt in events {
-                                            let _ = rest_event_tx.send(evt).await;
+                                if last_flush.elapsed() >= flush_interval
+                                    && !audio_buffer.is_empty()
+                                {
+                                    match rest_client.transcribe(&audio_buffer).await {
+                                        Ok(events) => {
+                                            for evt in events {
+                                                let _ = rest_event_tx.send(evt).await;
+                                            }
+                                        }
+                                        Err(e) => {
+                                            log::error!("[STT-REST] Transcription failed: {e}");
                                         }
                                     }
-                                    Err(e) => {
-                                        log::error!("[STT-REST] Transcription failed: {e}");
-                                    }
+                                    audio_buffer.clear();
+                                    last_flush = std::time::Instant::now();
                                 }
-                                audio_buffer.clear();
-                                last_flush = std::time::Instant::now();
                             }
-                        }
-                        Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                            // Flush if we have audio and enough time has passed
-                            if last_flush.elapsed() >= flush_interval && !audio_buffer.is_empty() {
-                                match rest_client.transcribe(&audio_buffer).await {
-                                    Ok(events) => {
-                                        for evt in events {
-                                            let _ = rest_event_tx.send(evt).await;
+                            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                                if last_flush.elapsed() >= flush_interval
+                                    && !audio_buffer.is_empty()
+                                {
+                                    match rest_client.transcribe(&audio_buffer).await {
+                                        Ok(events) => {
+                                            for evt in events {
+                                                let _ = rest_event_tx.send(evt).await;
+                                            }
+                                        }
+                                        Err(e) => {
+                                            log::error!("[STT-REST] Transcription failed: {e}");
                                         }
                                     }
-                                    Err(e) => {
-                                        log::error!("[STT-REST] Transcription failed: {e}");
-                                    }
+                                    audio_buffer.clear();
+                                    last_flush = std::time::Instant::now();
                                 }
-                                audio_buffer.clear();
-                                last_flush = std::time::Instant::now();
                             }
+                            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
                         }
-                        Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
                     }
                 }
-            }
+                conn_active.store(false, Ordering::SeqCst);
+                audio_active_task.store(false, Ordering::SeqCst);
+                log::info!("Deepgram connection task exited");
+            });
         }
-        conn_active.store(false, Ordering::SeqCst);
-        log::info!("Deepgram connection task exited");
-    });
+    }
 
     // Task B: consume TranscriptEvents, emit to frontend, run detection
     let evt_active = stt_active.clone();
@@ -367,7 +472,7 @@ pub async fn start_transcription(
 /// never blocks on the semantic worker, and cooldown state persists across calls.
 /// Returns true if high-confidence results were found (>= 0.90).
 fn run_direct_detection(app: &AppHandle, transcript: &str) -> bool {
-    use rhema_detection::{DirectDetector, DetectionMerger};
+    use rhema_detection::{DetectionMerger, DirectDetector};
 
     let detector_state: State<'_, Mutex<DirectDetector>> = app.state();
     let mut detector = match detector_state.lock() {
@@ -428,7 +533,11 @@ fn run_direct_detection(app: &AppHandle, transcript: &str) -> bool {
                 })
                 .collect();
             for r in &results {
-                log::info!("[DET-DIRECT] Found: {} ({:.0}%) (no DB)", r.verse_ref, r.confidence * 100.0);
+                log::info!(
+                    "[DET-DIRECT] Found: {} ({:.0}%) (no DB)",
+                    r.verse_ref,
+                    r.confidence * 100.0
+                );
             }
             let _ = app.emit("verse_detections", &results);
             return has_high_confidence;
@@ -441,15 +550,17 @@ fn run_direct_detection(app: &AppHandle, transcript: &str) -> bool {
 
     // Update sermon context with direct detection results
     for m in &merged {
-        app_state.sermon_context.update(
-            &m.detection.verse_ref,
-            m.detection.confidence,
-            "direct",
-        );
+        app_state
+            .sermon_context
+            .update(&m.detection.verse_ref, m.detection.confidence, "direct");
     }
 
     for r in &results {
-        log::info!("[DET-DIRECT] Found: {} ({:.0}%)", r.verse_ref, r.confidence * 100.0);
+        log::info!(
+            "[DET-DIRECT] Found: {} ({:.0}%)",
+            r.verse_ref,
+            r.confidence * 100.0
+        );
     }
     drop(app_state);
     let _ = app.emit("verse_detections", &results);
@@ -458,7 +569,10 @@ fn run_direct_detection(app: &AppHandle, transcript: &str) -> bool {
 
 /// Run semantic (ONNX embedding) detection. Slow, runs in background worker.
 fn run_semantic_detection(app: &AppHandle, transcript: &str) {
-    log::info!("[DET-SEMANTIC] Running on: {:?}", &transcript[..transcript.len().min(80)]);
+    log::info!(
+        "[DET-SEMANTIC] Running on: {:?}",
+        &transcript[..transcript.len().min(80)]
+    );
     let managed: State<'_, Mutex<AppState>> = app.state();
     let mut app_state = match managed.lock() {
         Ok(s) => s,
@@ -500,7 +614,10 @@ fn run_semantic_detection(app: &AppHandle, transcript: &str) {
     for r in &results {
         log::info!(
             "[DET-SEMANTIC] Found: {} ({:.0}% {}) auto_q={}",
-            r.verse_ref, r.confidence * 100.0, r.source, r.auto_queued
+            r.verse_ref,
+            r.confidence * 100.0,
+            r.source,
+            r.auto_queued
         );
     }
     drop(app_state);
@@ -530,7 +647,9 @@ fn check_reading_mode(app: &AppHandle, transcript: &str, direct_found: bool) {
             // Get the confidence of the detection to distinguish explicit refs from false positives
             let detection_confidence = {
                 let detector_state: State<'_, Mutex<rhema_detection::DirectDetector>> = app.state();
-                detector_state.lock().ok()
+                detector_state
+                    .lock()
+                    .ok()
                     .and_then(|d| d.recent_detections.front().map(|_| 0.95)) // Direct detections are always high confidence
                     .unwrap_or(0.0)
             };
@@ -545,10 +664,12 @@ fn check_reading_mode(app: &AppHandle, transcript: &str, direct_found: bool) {
                             // Paused — restart on any new explicit reference
                             true
                         } else if rm.current_book() == recent.book_number
-                            && rm.current_chapter() == recent.chapter {
+                            && rm.current_chapter() == recent.chapter
+                        {
                             false // Same book+chapter — already tracking this
                         } else if rm.current_book() != recent.book_number
-                            && detection_confidence >= 0.90 {
+                            && detection_confidence >= 0.90
+                        {
                             // Different book with high confidence — explicit new reference
                             // (e.g., "John 1:1" after reading Exodus). Restart.
                             true
@@ -572,7 +693,13 @@ fn check_reading_mode(app: &AppHandle, transcript: &str, direct_found: bool) {
                         Err(_) => return,
                     };
                     match &app_state.bible_db {
-                        Some(db) => db.get_chapter(app_state.active_translation_id, recent.book_number, recent.chapter).ok(),
+                        Some(db) => db
+                            .get_chapter(
+                                app_state.active_translation_id,
+                                recent.book_number,
+                                recent.chapter,
+                            )
+                            .ok(),
                         None => None,
                     }
                 };
@@ -662,10 +789,13 @@ fn check_translation_command(app: &AppHandle, transcript: &str) {
                         abbreviation: String,
                         translation_id: i64,
                     }
-                    let _ = app.emit("translation_command", TranslationSwitch {
-                        abbreviation: abbrev,
-                        translation_id: t.id,
-                    });
+                    let _ = app.emit(
+                        "translation_command",
+                        TranslationSwitch {
+                            abbreviation: abbrev,
+                            translation_id: t.id,
+                        },
+                    );
                 }
             }
         }
@@ -752,9 +882,7 @@ fn run_quotation_matching(app: &AppHandle, transcript: &str) {
 
 /// Stop the transcription pipeline (audio capture + Deepgram).
 #[tauri::command]
-pub fn stop_transcription(
-    state: State<'_, Mutex<AppState>>,
-) -> Result<(), String> {
+pub fn stop_transcription(state: State<'_, Mutex<AppState>>) -> Result<(), String> {
     let app_state = state.lock().map_err(|e| e.to_string())?;
 
     if !app_state.stt_active.load(Ordering::Relaxed) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
             commands::detection::reading_mode_status,
             commands::detection::stop_reading_mode,
             commands::audio::get_audio_devices,
+            commands::stt::get_transcription_status,
             commands::stt::start_transcription,
             commands::stt::stop_transcription,
             commands::broadcast::list_monitors,

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -24,6 +24,7 @@ export function TranscriptPanel() {
   const connectionStatus = useTranscriptStore((s) => s.connectionStatus)
   const audioLevel = useAudioStore((s) => s.level)
   const deepgramApiKey = useSettingsStore((s) => s.deepgramApiKey)
+  const transcriptionBackend = useSettingsStore((s) => s.transcriptionBackend)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   // Listen for Tauri events
@@ -145,6 +146,7 @@ export function TranscriptPanel() {
         apiKey: deepgramApiKey ?? "",
         deviceId: settings.audioDeviceId,
         gain: settings.gain,
+        backend: transcriptionBackend,
       })
       useTranscriptStore.getState().setTranscribing(true)
     } catch (e) {

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -45,7 +45,7 @@ import type { DeviceInfo } from "@/types/audio"
 /*  Nav definition                                                            */
 /* -------------------------------------------------------------------------- */
 
-type NavSection = "audio" | "bible" | "display" | "api-keys"
+type NavSection = "audio" | "bible" | "display" | "transcription"
 
 const navItems: { name: string; id: NavSection; icon: React.ReactNode }[] = [
   {
@@ -64,8 +64,8 @@ const navItems: { name: string; id: NavSection; icon: React.ReactNode }[] = [
     icon: <TvIcon strokeWidth={2} />,
   },
   {
-    name: "API Keys",
-    id: "api-keys",
+    name: "Transcription",
+    id: "transcription",
     icon: <KeyIcon strokeWidth={2} />,
   },
 ]
@@ -256,13 +256,50 @@ function DisplayModeSection() {
 }
 
 /* -------------------------------------------------------------------------- */
-/*  Section: API Keys                                                         */
+/*  Section: Transcription                                                    */
 /* -------------------------------------------------------------------------- */
 
-function ApiKeysSection() {
-  const { deepgramApiKey, setDeepgramApiKey } = useSettingsStore()
+interface LocalModelStatus {
+  model_name: string
+  model_path: string | null
+  exists: boolean
+  size_bytes: number | null
+  note: string
+}
+
+interface TranscriptionStatus {
+  backend: "auto" | "local" | "deepgram"
+  recommended_backend: "auto" | "local" | "deepgram"
+  local_model: LocalModelStatus
+  deepgram_key_configured: boolean
+}
+
+function TranscriptionSection() {
+  const {
+    deepgramApiKey,
+    setDeepgramApiKey,
+    transcriptionBackend,
+    setTranscriptionBackend,
+  } = useSettingsStore()
   const [keyValue, setKeyValue] = useState(deepgramApiKey ?? "")
   const [saved, setSaved] = useState(false)
+  const [status, setStatus] = useState<TranscriptionStatus | null>(null)
+  const [loadingStatus, setLoadingStatus] = useState(true)
+
+  useEffect(() => {
+    async function loadStatus() {
+      try {
+        const result = await invoke<TranscriptionStatus>("get_transcription_status")
+        setStatus(result)
+      } catch (e) {
+        console.error("Failed to load transcription status:", e)
+      } finally {
+        setLoadingStatus(false)
+      }
+    }
+
+    loadStatus()
+  }, [])
 
   const handleSave = () => {
     setDeepgramApiKey(keyValue || null)
@@ -270,12 +307,98 @@ function ApiKeysSection() {
     setTimeout(() => setSaved(false), 2000)
   }
 
+  const modelReady = status?.local_model.exists ?? false
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
           <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            Deepgram API Key
+            Local Whisper.cpp Model
+          </label>
+          {modelReady ? (
+            <Badge variant="outline" className="text-[0.5rem]">
+              Ready
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-[0.5rem]">
+              Missing
+            </Badge>
+          )}
+        </div>
+        <div className="rounded-lg border border-border bg-muted/20 p-3 text-[0.625rem] leading-relaxed text-muted-foreground">
+          {loadingStatus ? (
+            "Checking local model..."
+          ) : status?.local_model.exists ? (
+            <>
+              <div className="text-foreground">
+                {status.local_model.model_name}
+              </div>
+              <div className="mt-1 break-all">
+                {status.local_model.model_path}
+              </div>
+            </>
+          ) : (
+            <div>{status?.local_model.note ?? "Local model not found."}</div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Transcription Source
+        </label>
+
+        <RadioGroup
+          value={transcriptionBackend}
+          onValueChange={(v) => setTranscriptionBackend(v as "auto" | "local" | "deepgram")}
+          className="gap-3"
+        >
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:ring-1 has-data-[state=checked]:ring-primary/20">
+            <RadioGroupItem value="auto" className="mt-0.5" />
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-foreground">Auto</span>
+                <Badge variant="outline" className="text-[0.5rem]">
+                  Recommended
+                </Badge>
+              </div>
+              <p className="text-[0.625rem] leading-relaxed text-muted-foreground">
+                Prefer local Whisper.cpp whenever the model is available, and
+                fall back to Deepgram only if a key is configured and the local
+                setup is missing.
+              </p>
+            </div>
+          </label>
+
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:ring-1 has-data-[state=checked]:ring-primary/20">
+            <RadioGroupItem value="local" className="mt-0.5" />
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-foreground">Local only</span>
+              <p className="text-[0.625rem] leading-relaxed text-muted-foreground">
+                Always use the on-device Whisper.cpp model and never fall back
+                to cloud transcription.
+              </p>
+            </div>
+          </label>
+
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:ring-1 has-data-[state=checked]:ring-primary/20">
+            <RadioGroupItem value="deepgram" className="mt-0.5" />
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-foreground">Deepgram only</span>
+              <p className="text-[0.625rem] leading-relaxed text-muted-foreground">
+                Use the cloud backend explicitly. This requires a configured API
+                key.
+              </p>
+            </div>
+          </label>
+        </RadioGroup>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Deepgram Fallback Key
           </label>
           {deepgramApiKey && (
             <Badge variant="outline" className="text-[0.5rem]">
@@ -303,8 +426,8 @@ function ApiKeysSection() {
           </Button>
         </div>
         <p className="text-[0.625rem] text-muted-foreground">
-          Required for live transcription. Get a key at{" "}
-          <span className="text-primary">deepgram.com</span>
+          Optional fallback when local Whisper.cpp is unavailable, or required
+          if you select Deepgram only.
         </p>
       </div>
     </div>
@@ -318,7 +441,7 @@ function ApiKeysSection() {
 const sectionTitles: Record<NavSection, string> = {
   audio: "Audio",
   display: "Display Mode",
-  "api-keys": "API Keys",
+  transcription: "Transcription",
 }
 
 /* -------------------------------------------------------------------------- */
@@ -425,7 +548,7 @@ const sectionComponents: Record<NavSection, React.FC> = {
   audio: AudioSection,
   bible: BibleSection,
   display: DisplayModeSection,
-  "api-keys": ApiKeysSection,
+  transcription: TranscriptionSection,
 }
 
 /* -------------------------------------------------------------------------- */
@@ -448,7 +571,7 @@ export function SettingsDialog() {
       <DialogContent className="overflow-hidden p-0 md:max-h-[600px] md:max-w-[800px] lg:max-w-[900px]">
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">
-          Configure audio, display mode, and API keys.
+          Configure audio, display mode, Bible translation, and transcription.
         </DialogDescription>
         <SidebarProvider className="items-start">
           <Sidebar collapsible="none" className="hidden md:flex">

--- a/src/hooks/use-transcription.ts
+++ b/src/hooks/use-transcription.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
-import { useTranscriptStore } from "@/stores"
+import { useTranscriptStore, useSettingsStore } from "@/stores"
 import { useTauriEvent } from "./use-tauri-event"
 import type { TranscriptSegment } from "@/types"
 
@@ -12,6 +12,10 @@ interface TranscriptPartialPayload {
 
 export function useTranscription() {
   const store = useTranscriptStore()
+  const transcriptionBackend = useSettingsStore((s) => s.transcriptionBackend)
+  const deepgramApiKey = useSettingsStore((s) => s.deepgramApiKey)
+  const audioDeviceId = useSettingsStore((s) => s.audioDeviceId)
+  const gain = useSettingsStore((s) => s.gain)
 
   // Listen for transcript events from Rust
   useTauriEvent<TranscriptPartialPayload>("transcript_partial", (payload) => {
@@ -31,9 +35,14 @@ export function useTranscription() {
   })
 
   const startTranscription = useCallback(async () => {
-    await invoke("start_transcription")
+    await invoke("start_transcription", {
+      apiKey: deepgramApiKey ?? "",
+      deviceId: audioDeviceId,
+      gain,
+      backend: transcriptionBackend,
+    })
     store.setTranscribing(true)
-  }, [store])
+  }, [audioDeviceId, deepgramApiKey, gain, store, transcriptionBackend])
 
   const stopTranscription = useCallback(async () => {
     await invoke("stop_transcription")

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,9 +1,11 @@
 import { create } from "zustand"
+import type { TranscriptionBackend } from "@/types"
 
 interface SettingsState {
   deepgramApiKey: string | null
   openaiApiKey: string | null
   claudeApiKey: string | null
+  transcriptionBackend: TranscriptionBackend
   activeTranslationId: number
   audioDeviceId: string | null
   gain: number
@@ -15,6 +17,7 @@ interface SettingsState {
   setDeepgramApiKey: (key: string | null) => void
   setOpenaiApiKey: (key: string | null) => void
   setClaudeApiKey: (key: string | null) => void
+  setTranscriptionBackend: (backend: TranscriptionBackend) => void
   setActiveTranslationId: (id: number) => void
   setAudioDeviceId: (id: string | null) => void
   setGain: (gain: number) => void
@@ -28,6 +31,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   deepgramApiKey: null,
   openaiApiKey: null,
   claudeApiKey: null,
+  transcriptionBackend: "auto",
   activeTranslationId: 1,
   audioDeviceId: null,
   gain: 1.0,
@@ -39,6 +43,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   setDeepgramApiKey: (deepgramApiKey) => set({ deepgramApiKey }),
   setOpenaiApiKey: (openaiApiKey) => set({ openaiApiKey }),
   setClaudeApiKey: (claudeApiKey) => set({ claudeApiKey }),
+  setTranscriptionBackend: (transcriptionBackend) => set({ transcriptionBackend }),
   setActiveTranslationId: (activeTranslationId) => set({ activeTranslationId }),
   setAudioDeviceId: (audioDeviceId) => set({ audioDeviceId }),
   setGain: (gain) => set({ gain }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export type { DeviceInfo, AudioLevel, AudioConfig } from "./audio"
 export type {
   Word,
   TranscriptSegment,
+  TranscriptionBackend,
   TranscriptEventPayload,
 } from "./transcript"
 export type { Translation, Book, Verse, CrossReference } from "./bible"

--- a/src/types/transcript.ts
+++ b/src/types/transcript.ts
@@ -15,6 +15,8 @@ export interface TranscriptSegment {
   timestamp: number
 }
 
+export type TranscriptionBackend = "auto" | "local" | "deepgram"
+
 export type TranscriptEventPayload =
   | {
       type: "partial"


### PR DESCRIPTION
This draft PR migrates transcription from Deepgram to a local Whisper.cpp-backed path, while keeping Deepgram as an optional fallback.

What changed:
- Added a local STT backend abstraction in `rhema-stt`.
- Wired `start_transcription` to prefer local Whisper when a model is available.
- Added model status reporting and UI controls for `auto` / `local` / `deepgram`.
- Added setup instructions for Whisper and embedding models.
- Enabled macOS whisper-rs Metal/CoreML support and added tiny/small model support.

Why:
- Keep transcription local and free by default, while preserving the transcript event flow for verse detection and broadcast output.

Validation:
- `cargo check --manifest-path /Users/mac/Documents/GitHub/rhema/src-tauri/Cargo.toml -p app`
- `cargo test --manifest-path /Users/mac/Documents/GitHub/rhema/src-tauri/Cargo.toml -p rhema-audio vad -- --nocapture`
- `cargo test --manifest-path /Users/mac/Documents/GitHub/rhema/src-tauri/Cargo.toml -p rhema-stt --lib -- --nocapture`
- `PATH="$PWD/node_modules/.bin:$PATH" bun run typecheck`

Notes:
- The branch is published to the fork `rob-345/rhema` as `whisper-stt`.
- This is marked draft because latency tuning is still in progress.
