### PR TITLE
Show a helpful modal when Start listening is clicked without an API key

### DIFF
--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -1,9 +1,11 @@
-import { useRef, useEffect } from "react"
+import { useEffect, useRef, useState } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { LevelMeter } from "@/components/ui/level-meter"
 import { Button } from "@/components/ui/button"
+import { ApiKeyPrompt } from "@/components/ui/api-key-prompt"
 import { MicIcon, MicOffIcon } from "lucide-react"
 import { invoke } from "@tauri-apps/api/core"
+import { hasConfiguredApiKey } from "@/lib/api-key"
 import {
   useTranscriptStore,
   useAudioStore,
@@ -25,6 +27,7 @@ export function TranscriptPanel() {
   const audioLevel = useAudioStore((s) => s.level)
   const deepgramApiKey = useSettingsStore((s) => s.deepgramApiKey)
   const scrollRef = useRef<HTMLDivElement>(null)
+  const [showKeyPrompt, setShowKeyPrompt] = useState(false)
 
   // Listen for Tauri events
   useTauriEvent<{ rms: number; peak: number }>("audio_level", (payload) => {
@@ -136,6 +139,11 @@ export function TranscriptPanel() {
   }, [segments, currentPartial])
 
   const handleStart = async () => {
+    if (!hasConfiguredApiKey(deepgramApiKey)) {
+      setShowKeyPrompt(true)
+      return
+    }
+
     try {
       useTranscriptStore.getState().setConnectionStatus("connecting")
       const { useSettingsStore } = await import("@/stores")
@@ -254,6 +262,13 @@ export function TranscriptPanel() {
           </Button>
         )}
       </div>
+
+      <ApiKeyPrompt
+        open={showKeyPrompt}
+        onOpenChange={setShowKeyPrompt}
+        service="Deepgram"
+        description="Live transcription needs a Deepgram API key. Add it in settings so the app can start listening."
+      />
     </div>
   )
 }

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -39,6 +39,7 @@ import {
   BookOpenIcon,
 } from "lucide-react"
 import { useSettingsStore } from "@/stores"
+import { useSettingsDialogStore } from "@/lib/settings-dialog"
 import type { DeviceInfo } from "@/types/audio"
 
 /* -------------------------------------------------------------------------- */
@@ -428,18 +429,26 @@ const sectionComponents: Record<NavSection, React.FC> = {
   "api-keys": ApiKeysSection,
 }
 
-/* -------------------------------------------------------------------------- */
 /*  Main dialog                                                               */
 /* -------------------------------------------------------------------------- */
 
 export function SettingsDialog() {
-  const [open, setOpen] = useState(false)
-  const [activeSection, setActiveSection] = useState<NavSection>("audio")
+  const open = useSettingsDialogStore((s) => s.isOpen)
+  const activeSection = useSettingsDialogStore((s) => s.activeSection)
+  const setActiveSection = useSettingsDialogStore((s) => s.setActiveSection)
+  const closeSettings = useSettingsDialogStore((s) => s.closeSettings)
 
   const ActiveContent = sectionComponents[activeSection]
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          closeSettings()
+        }
+      }}
+    >
       <DialogTrigger asChild>
         <Button variant="ghost" size="icon-sm">
           <SettingsIcon className="size-3.5" />

--- a/src/components/ui/api-key-prompt.tsx
+++ b/src/components/ui/api-key-prompt.tsx
@@ -1,0 +1,99 @@
+import { openSettings } from "@/lib/settings-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface ApiKeyPromptProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  service: string
+  description?: string
+}
+
+export function ApiKeyPrompt({
+  open,
+  onOpenChange,
+  service,
+  description,
+}: ApiKeyPromptProps) {
+  const serviceLabel =
+    service === "Deepgram" ? (
+      <>
+        <span className="text-chart-1">D</span>
+        <span className="text-chart-2">eep</span>
+        <span className="text-chart-3">gram</span>
+      </>
+    ) : (
+      service
+    )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="border-white/12 bg-linear-to-b from-card to-card/95 sm:max-w-[420px]"
+        showCloseButton={false}
+      >
+        <DialogHeader>
+          <div className="mx-auto mb-3 flex size-14 items-center justify-center rounded-full bg-linear-to-br from-chart-1 via-chart-2 to-chart-3 p-px shadow-[0_0_30px_color-mix(in_oklab,var(--color-chart-2)_28%,transparent)]">
+            <div className="flex size-full items-center justify-center rounded-full bg-card">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="url(#api-key-gradient)"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="size-6"
+            >
+              <defs>
+                <linearGradient id="api-key-gradient" x1="0" y1="0" x2="24" y2="24">
+                  <stop offset="0%" stopColor="var(--color-chart-1)" />
+                  <stop offset="55%" stopColor="var(--color-chart-2)" />
+                  <stop offset="100%" stopColor="var(--color-chart-3)" />
+                </linearGradient>
+              </defs>
+              <path d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z" />
+            </svg>
+          </div>
+          </div>
+          <DialogTitle className="text-center">
+            <span className="font-semibold">{serviceLabel}</span>{" "}
+            <span className="text-foreground">API key required</span>
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            {description ??
+              `To use this feature, add your ${service} API key in settings.`}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex-col gap-2 sm:flex-col">
+          <Button
+            className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={() => {
+              onOpenChange(false)
+              // Give the current dialog one frame to close before opening the
+              // settings dialog on the API key section.
+              window.setTimeout(() => {
+                openSettings("api-keys")
+              }, 120)
+            }}
+          >
+            Open settings
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full text-muted-foreground"
+            onClick={() => onOpenChange(false)}
+          >
+            Not now
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/lib/api-key.test.ts
+++ b/src/lib/api-key.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { hasConfiguredApiKey } from "./api-key"
+
+describe("hasConfiguredApiKey", () => {
+  it("returns false when the key is missing", () => {
+    expect(hasConfiguredApiKey(null)).toBe(false)
+    expect(hasConfiguredApiKey(undefined)).toBe(false)
+    expect(hasConfiguredApiKey("")).toBe(false)
+  })
+
+  it("treats whitespace-only values as missing", () => {
+    expect(hasConfiguredApiKey("   ")).toBe(false)
+  })
+
+  it("returns true when a non-empty key is present", () => {
+    expect(hasConfiguredApiKey("dg_test_123")).toBe(true)
+    expect(hasConfiguredApiKey("  dg_test_123  ")).toBe(true)
+  })
+})

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -1,0 +1,3 @@
+export function hasConfiguredApiKey(apiKey: string | null | undefined) {
+  return Boolean(apiKey?.trim())
+}

--- a/src/lib/settings-dialog.ts
+++ b/src/lib/settings-dialog.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand"
+
+type SettingsSection = "audio" | "bible" | "display" | "api-keys"
+
+interface SettingsDialogState {
+  isOpen: boolean
+  activeSection: SettingsSection
+  openSettings: (section?: SettingsSection) => void
+  closeSettings: () => void
+  setActiveSection: (section: SettingsSection) => void
+}
+
+const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
+  isOpen: false,
+  activeSection: "audio",
+  openSettings: (section) =>
+    set((state) => ({
+      isOpen: true,
+      activeSection: section ?? state.activeSection,
+    })),
+  closeSettings: () => set({ isOpen: false }),
+  setActiveSection: (activeSection) => set({ activeSection }),
+}))
+
+export function openSettings(section?: SettingsSection) {
+  useSettingsDialogStore.getState().openSettings(section)
+}
+
+export { useSettingsDialogStore }
+export type { SettingsSection }


### PR DESCRIPTION
## Problem

Right now, if someone clicks `Start listening` without a Deepgram API key set, nothing happens.

That is confusing because it makes the app feel broken, and the user does not know what is missing.

## Fix

This PR adds a reusable API key modal and uses it for the transcription flow.

Now when `Start listening` is clicked without a key:
- the app explains what is wrong
- the user sees a clear `Open settings` action
- settings opens to the API Keys section

## Reusable modal

The reusable modal lives in `src/components/ui/api-key-prompt.tsx`.

## Screenshot
<img width="1264" height="711" alt="image" src="https://github.com/user-attachments/assets/17176265-5646-4afd-8f97-41108cce5e76" />


## Checks

- `bun run typecheck`
- `bun x eslint src/components/panels/transcript-panel.tsx src/components/ui/api-key-prompt.tsx src/components/settings-dialog.tsx src/lib/api-key.ts src/lib/api-key.test.ts src/lib/settings-dialog.ts`
