### PR TITLE
Fix Theme Designer sidebar scrolling

### DIFF
--- a/src/components/broadcast/properties-panel.tsx
+++ b/src/components/broadcast/properties-panel.tsx
@@ -1,5 +1,6 @@
 import { useBroadcastStore } from "@/stores/broadcast-store"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { TextProperties } from "@/components/broadcast/text-properties"
 import { BackgroundProperties } from "@/components/broadcast/background-properties"
 import { LayoutProperties } from "@/components/broadcast/layout-properties"
@@ -24,7 +25,7 @@ export function PropertiesPanel() {
         : "Select an element or use tabs below"
 
   return (
-    <div className="flex h-full flex-col border-l border-border bg-card">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden border-l border-border bg-card">
       {/* Header */}
       <div className="flex h-14 flex-col gap-0.5 border-b border-border px-4 py-2">
         <h3 className="truncate text-sm font-semibold">{draftTheme.name}</h3>
@@ -32,7 +33,7 @@ export function PropertiesPanel() {
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue="text" className="flex min-h-0 flex-1 flex-col">
+      <Tabs defaultValue="text" className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div className="shrink-0 px-4 pt-3">
           <TabsList variant="default" className="w-full">
             <TabsTrigger value="text">Text</TabsTrigger>
@@ -41,17 +42,17 @@ export function PropertiesPanel() {
           </TabsList>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
-          <TabsContent value="text" className="mt-0">
+        <ScrollArea className="min-h-0 flex-1">
+          <TabsContent value="text" className="mt-0 p-4">
             <TextProperties />
           </TabsContent>
-          <TabsContent value="background" className="mt-0">
+          <TabsContent value="background" className="mt-0 p-4">
             <BackgroundProperties />
           </TabsContent>
-          <TabsContent value="layout" className="mt-0">
+          <TabsContent value="layout" className="mt-0 p-4">
             <LayoutProperties />
           </TabsContent>
-        </div>
+        </ScrollArea>
       </Tabs>
     </div>
   )

--- a/src/components/broadcast/theme-designer.tsx
+++ b/src/components/broadcast/theme-designer.tsx
@@ -42,7 +42,7 @@ export function ThemeDesigner() {
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
 
         <DialogPrimitive.Content
-          className="fixed inset-0 z-50 flex flex-col bg-background text-foreground outline-none"
+          className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-background text-foreground outline-none"
           aria-describedby={undefined}
         >
           <DialogPrimitive.Title className="sr-only">

--- a/src/components/broadcast/theme-library.tsx
+++ b/src/components/broadcast/theme-library.tsx
@@ -129,7 +129,7 @@ export function ThemeLibrary() {
   }
 
   return (
-    <div className="flex h-full flex-col border-r border-border bg-card">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden border-r border-border bg-card">
       {/* Header */}
       <div className="flex h-14 items-center justify-between border-b border-border px-3">
         <span className="text-lg font-semibold text-foreground">Themes</span>
@@ -156,7 +156,7 @@ export function ThemeLibrary() {
       <Tabs
         value={filter}
         onValueChange={(value) => setFilter(value as FilterTab)}
-        className="px-3 pb-4"
+        className="shrink-0 px-3 pb-4"
       >
         <TabsList className="h-7 w-full">
           <TabsTrigger value="all" className="capitalize">all</TabsTrigger>


### PR DESCRIPTION
## Problem

In the Theme Designer, the left and right side panels do not scroll reliably with the trackpad.

That makes it hard to reach controls lower down in the panel, especially in the properties sidebar.

## Fix

This PR makes both side panels use isolated scrolling containers so each sidebar can handle its own scrolling correctly inside the full-screen designer modal.

## What changed

- fixed the right properties panel scrolling
- tightened the left themes panel scrolling behavior
- clipped overflow at the modal/layout level so the sidebars own their scroll area

## Checks

- `bun run typecheck`
- `bun x eslint src/components/broadcast/theme-library.tsx src/components/broadcast/properties-panel.tsx src/components/broadcast/theme-designer.tsx`
