### PR TITLE
fix: Unicode crash when downloading Bible translations on Windows

### DIFF
--- a/data/download-biblegateway.py
+++ b/data/download-biblegateway.py
@@ -125,7 +125,7 @@ def load_cached_book(book_file):
     if not book_file.exists() or book_file.stat().st_size < 10:
         return None
     try:
-        with open(book_file) as f:
+        with open(book_file, encoding='utf-8') as f:
             data = json.load(f)
         if "Info" in data:
             del data["Info"]
@@ -174,7 +174,7 @@ def download_translation(abbrev):
 
                 download_book(book, book_file, abbrev)
 
-                with open(book_file) as f:
+                with open(book_file, encoding='utf-8') as f:
                     data = json.load(f)
                     if "Info" in data:
                         del data["Info"]
@@ -204,7 +204,7 @@ def download_translation(abbrev):
     # Convert to scrollmapper format and write
     scrollmapper = convert_to_scrollmapper(combined, abbrev)
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding='utf-8') as f:
         json.dump(scrollmapper, f, indent=2)
 
     size_mb = output_file.stat().st_size / 1024 / 1024

--- a/data/prepare-embeddings.ts
+++ b/data/prepare-embeddings.ts
@@ -54,11 +54,16 @@ function shouldSkip(label: string, ...artifacts: string[]): boolean {
   return allExist
 }
 
-async function run(cmd: string[], cwd?: string): Promise<void> {
+async function run(
+  cmd: string[],
+  cwd?: string,
+  extraEnv?: Record<string, string>
+): Promise<void> {
   const proc = Bun.spawn(cmd, {
     stdout: "inherit",
     stderr: "inherit",
     cwd: cwd ?? PROJECT_ROOT,
+    env: { ...process.env, ...extraEnv },
   })
   const exitCode = await proc.exited
   if (exitCode !== 0) {
@@ -98,10 +103,11 @@ async function main() {
     const venvPython = getVenvBin(
       process.platform === "win32" ? "python" : "python3"
     )
-    await run([
-      venvPython,
-      join(DATA_DIR, "download-biblegateway.py"),
-    ])
+    await run(
+      [venvPython, join(DATA_DIR, "download-biblegateway.py")],
+      undefined,
+      { PYTHONUTF8: "1" }
+    )
   }
 
   // ── Phase 4: Build Bible database ──────────────────────────────
@@ -176,10 +182,11 @@ async function main() {
       process.platform === "win32" ? "python" : "python3"
     )
     // Use sentence-transformers + MPS GPU (much faster than ONNX CPU)
-    await run([
-      venvPython,
-      join(DATA_DIR, "precompute-embeddings.py"),
-    ])
+    await run(
+      [venvPython, join(DATA_DIR, "precompute-embeddings.py")],
+      undefined,
+      { PYTHONUTF8: "1" }
+    )
   }
 
   // ── Done ───────────────────────────────────────────────────────


### PR DESCRIPTION
On Windows, Python defaults to the system's legacy encoding (cp1252) instead of UTF-8. Bible text from BibleGateway contains characters that cp1252 can't handle, causing the download to crash with:

  'charmap' codec can't decode byte 0x9d in position 295

Two changes to fix this:

1. prepare-embeddings.ts — pass PYTHONUTF8=1 to the Python process when running the BibleGateway download (Phase 3) and the embeddings precompute (Phase 7). This forces Python and all libraries it uses to treat everything as UTF-8, which is the correct fix for third-party code we can't modify.

2. download-biblegateway.py — add encoding='utf-8' to all file open() calls as a safety net when the script is run directly, outside of the pipeline.

before
<img width="1139" height="768" alt="Screenshot 2026-04-11 133145" src="https://github.com/user-attachments/assets/607091d0-7e02-4dc8-acfd-2ff2054190c7" />

after
<img width="978" height="767" alt="image" src="https://github.com/user-attachments/assets/9eb7d423-08b1-4a73-85c1-6cab5b876491" />