### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: "\U0001F41B Bug report"
+description: Report a bug in Rhema
+labels: [bug, pending triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this bug! Please fill out the form below so we can investigate.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Rhema is affected?
+      options:
+        - Frontend UI
+        - Broadcast / NDI output
+        - Theme Designer
+        - Bible search / data
+        - Audio / speech-to-text
+        - Verse detection
+        - Remote control (OSC)
+        - Remote control (HTTP API)
+        - Queue management
+        - Settings / preferences
+        - Build / installation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description.
+      placeholder: |
+        What I was doing: ...
+        What I expected: ...
+        What actually happened: ...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Detailed steps to reproduce the behavior.
+      placeholder: |
+        1. Open Rhema
+        2. Navigate to ...
+        3. Click on ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide the following information. You can find the Rhema and Tauri versions in the app's About screen.
+      value: |
+        - **OS**: [e.g., macOS 15.2, Windows 11, Ubuntu 24.04]
+        - **Rhema version**: [e.g., 0.1.0]
+        - **Installation method**: [e.g., .dmg, .msi, built from source]
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If applicable, include relevant log output. For frontend issues, open browser dev tools (Cmd+Option+I / Ctrl+Shift+I) and copy console output. For backend issues, check the Tauri log file.
+      render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or recordings
+      description: If applicable, add screenshots or screen recordings to help explain the problem.
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't [already an issue](https://github.com/openbezal/rhema/issues) that reports the same bug to avoid creating a duplicate.
+          required: true
+        - label: This is a concrete bug, not a question. For questions, use [GitHub Discussions](https://github.com/openbezal/rhema/discussions).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/openbezal/rhema/discussions
+    about: Use GitHub Discussions for questions, ideas, and general conversation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: "\U0001F680 Feature request"
+description: Propose a new feature or enhancement for Rhema
+labels: [enhancement, pending triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea in detail so we can evaluate it.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature area
+      description: Which part of Rhema does this feature relate to?
+      options:
+        - Frontend UI
+        - Broadcast / NDI output
+        - Theme Designer
+        - Bible search / data
+        - Audio / speech-to-text
+        - Verse detection
+        - Remote control (OSC)
+        - Remote control (HTTP API)
+        - Queue management
+        - Settings / preferences
+        - New integration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clear and concise description of the feature. What problem does it solve? If you intend to submit a PR for this, tell us here.
+      placeholder: As a broadcast operator, I want [goal] so that [benefit].
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-solution
+    attributes:
+      label: Suggested solution
+      description: How do you think this could be implemented or how should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other solutions or workarounds have you considered?
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, mockups, or references. If this relates to external hardware or software (stream decks, lighting consoles, TouchOSC, ProPresenter, etc.), mention the specific product.
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't [already an issue](https://github.com/openbezal/rhema/issues) requesting the same feature to avoid creating a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+## Description
+
+<!-- What does this PR do? Reference any related issues (e.g., `fixes #123`). -->
+
+## Type of change
+
+<!-- Check the one that applies: -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring (no functional changes)
+- [ ] Documentation
+- [ ] Build / CI
+- [ ] Performance improvement
+
+## Areas affected
+
+<!-- Check all that apply: -->
+
+- [ ] Frontend (React / TypeScript)
+- [ ] Backend (Rust / Tauri commands)
+- [ ] Rust crate: <!-- specify which crate(s) -->
+- [ ] Remote control (OSC / HTTP)
+- [ ] Broadcast / NDI
+- [ ] Theme Designer
+- [ ] Bible data / search
+- [ ] Audio / STT
+
+## Checklist
+
+- [ ] I have tested this change locally
+- [ ] `bun run typecheck` passes
+- [ ] `cargo clippy` passes without warnings
+- [ ] `bun run test` passes (if applicable)
+- [ ] I have added tests for new functionality (if applicable)
+- [ ] UI changes include a screenshot or recording below
+
+## Tested on
+
+<!-- Check the platforms you tested on: -->
+
+- [ ] macOS
+- [ ] Windows
+- [ ] Linux
+
+## Screenshots / recordings
+
+<!-- If this PR includes UI changes, add screenshots or recordings here. -->


### PR DESCRIPTION
Add structured YAML issue forms for bug reports and feature requests, an issue chooser config that disables blank issues, and a PR template with dual-stack (TypeScript + Rust) checklist and platform testing.