### PR TITLE
Fix theme designer flow gaps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,8 @@
         "@fontsource/geist-mono": "^5.2.7",
         "@tailwindcss/vite": "^4.2.1",
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-dialog": "^2.7.0",
+        "@tauri-apps/plugin-fs": "^2.5.0",
         "@tauri-apps/plugin-global-shortcut": "~2",
         "@tauri-apps/plugin-log": "~2",
         "@tauri-apps/plugin-opener": "^2.5.3",
@@ -515,6 +517,10 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.10.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
+
+    "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw=="],
+
+    "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.5.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ=="],
 
     "@tauri-apps/plugin-global-shortcut": ["@tauri-apps/plugin-global-shortcut@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-vr40W2N6G63dmBPaha1TsBQLLURXG538RQbH5vAm0G/ovVZyXJrmZR1HF1W+WneNloQvwn4dm8xzwpEXRW560g=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@fontsource/geist-mono": "^5.2.7",
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-dialog": "^2.7.0",
+    "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-global-shortcut": "~2",
     "@tauri-apps/plugin-log": "~2",
     "@tauri-apps/plugin-opener": "^2.5.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -184,6 +184,8 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-store",
@@ -3007,6 +3009,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3973,6 +3976,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5044,6 +5071,48 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,8 @@ rhema-detection = { path = "crates/detection", features = ["onnx", "vector-searc
 crossbeam-channel = "0.5"
 dotenvy = "0.15"
 base64 = "0.22"
+tauri-plugin-dialog = "2.7.0"
+tauri-plugin-fs = "2.5.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-global-shortcut = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,8 @@
   ],
   "permissions": [
     "core:default",
+    "dialog:default",
+    "fs:default",
     "store:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,8 @@ pub fn run() {
                 .level(tauri_plugin_log::log::LevelFilter::Info)
                 .build(),
         )
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
         .manage(Mutex::new(state::AppState::new()))

--- a/src/components/broadcast/background-properties.tsx
+++ b/src/components/broadcast/background-properties.tsx
@@ -345,13 +345,18 @@ function TextBoxSection() {
     <div className="flex flex-col gap-3 border-t pt-3">
       <div className="flex items-center justify-between">
         <h4 className="text-xs font-semibold">Text Box</h4>
-        <input
-          type="checkbox"
-          checked={textBox.enabled}
-          onChange={(e) => update("textBox.enabled", e.target.checked)}
-          className="h-4 w-4 rounded border-input accent-primary"
-        />
-      </div>
+          <input
+            type="checkbox"
+            checked={textBox.enabled}
+            onChange={(e) => {
+              update("textBox.enabled", e.target.checked)
+              if (e.target.checked && textBox.opacity === 0) {
+                update("textBox.opacity", 0.5)
+              }
+            }}
+            className="h-4 w-4 rounded border-input accent-primary"
+          />
+        </div>
 
       {textBox.enabled && (
         <div className="flex flex-col gap-3">

--- a/src/components/broadcast/background-properties.tsx
+++ b/src/components/broadcast/background-properties.tsx
@@ -1,3 +1,4 @@
+import { pickThemeBackgroundImage } from "@/lib/theme-designer-files"
 import { useBroadcastStore } from "@/stores/broadcast-store"
 import { Slider } from "@/components/ui/slider"
 import { Input } from "@/components/ui/input"
@@ -197,17 +198,11 @@ function ImageSection() {
           size="sm"
           className="w-full"
           onClick={() => {
-            const input = document.createElement("input")
-            input.type = "file"
-            input.accept = "image/*"
-            input.onchange = (e) => {
-              const file = (e.target as HTMLInputElement).files?.[0]
-              if (file) {
-                const url = URL.createObjectURL(file)
-                update("background.image.url", url)
-              }
-            }
-            input.click()
+            void (async () => {
+              const imageUrl = await pickThemeBackgroundImage()
+              if (!imageUrl) return
+              update("background.image.url", imageUrl)
+            })()
           }}
         >
           Change Image

--- a/src/components/broadcast/design-canvas.tsx
+++ b/src/components/broadcast/design-canvas.tsx
@@ -27,6 +27,12 @@ export function DesignCanvas() {
   const latestThemeRef = useRef<BroadcastTheme | null>(null)
   const imageCacheRef = useRef<Map<string, HTMLImageElement>>(new Map())
   const imageRequestsRef = useRef<Map<string, Promise<HTMLImageElement>>>(new Map())
+  const dragStateRef = useRef<{
+    startX: number
+    startY: number
+    offsetX: number
+    offsetY: number
+  } | null>(null)
   const objectsRef = useRef<{
     workspace: fabric.Rect | null
     referenceRegion: fabric.Rect | null
@@ -129,6 +135,7 @@ export function DesignCanvas() {
       lockMovementY: true,
       evented: true,
       objectCaching: false,
+      hoverCursor: "move",
     })
     canvas.add(refRegion)
     objectsRef.current.referenceRegion = refRegion
@@ -150,6 +157,7 @@ export function DesignCanvas() {
       lockMovementY: true,
       evented: true,
       objectCaching: false,
+      hoverCursor: "move",
     })
     canvas.add(verseRegion)
     objectsRef.current.verseRegion = verseRegion
@@ -175,6 +183,57 @@ export function DesignCanvas() {
       useBroadcastStore.getState().setSelectedElement(null)
     })
 
+    canvas.on("mouse:down", (event) => {
+      const target = event.target
+      const scenePoint = event.scenePoint
+      const theme = latestThemeRef.current
+      if (!scenePoint || !theme) return
+
+      if (target === objectsRef.current.referenceRegion) {
+        useBroadcastStore.getState().setSelectedElement("reference")
+      } else if (target === objectsRef.current.verseRegion) {
+        useBroadcastStore.getState().setSelectedElement("verse")
+      } else {
+        dragStateRef.current = null
+        return
+      }
+
+      dragStateRef.current = {
+        startX: scenePoint.x,
+        startY: scenePoint.y,
+        offsetX: theme.layout.offsetX,
+        offsetY: theme.layout.offsetY,
+      }
+    })
+
+    canvas.on("mouse:move", (event) => {
+      const dragState = dragStateRef.current
+      const theme = latestThemeRef.current
+      const scenePoint = event.scenePoint
+      if (!dragState || !theme || !scenePoint) return
+
+      const nextOffsetX = Math.round(dragState.offsetX + (scenePoint.x - dragState.startX))
+      const nextOffsetY = Math.round(dragState.offsetY + (scenePoint.y - dragState.startY))
+      if (
+        nextOffsetX === theme.layout.offsetX &&
+        nextOffsetY === theme.layout.offsetY
+      ) {
+        return
+      }
+
+      useBroadcastStore.getState().updateDraft({
+        layout: {
+          ...theme.layout,
+          offsetX: nextOffsetX,
+          offsetY: nextOffsetY,
+        },
+      })
+    })
+
+    canvas.on("mouse:up", () => {
+      dragStateRef.current = null
+    })
+
     fabricRef.current = canvas
 
     // Auto-zoom after a tick (canvas needs to be in DOM)
@@ -187,6 +246,7 @@ export function DesignCanvas() {
     observer.observe(containerRef.current)
 
     return () => {
+      dragStateRef.current = null
       observer.disconnect()
       void canvas.dispose()
       fabricRef.current = null

--- a/src/components/broadcast/design-canvas.tsx
+++ b/src/components/broadcast/design-canvas.tsx
@@ -532,6 +532,10 @@ function ensureImage(
       onReady?.()
       return img
     })
+    .catch((error) => {
+      console.warn("[theme-designer] failed to load background image", { url, error })
+      throw error
+    })
     .finally(() => {
       pending.delete(url)
     })

--- a/src/components/broadcast/properties-panel.tsx
+++ b/src/components/broadcast/properties-panel.tsx
@@ -1,5 +1,6 @@
 import { useBroadcastStore } from "@/stores/broadcast-store"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { TextProperties } from "@/components/broadcast/text-properties"
 import { BackgroundProperties } from "@/components/broadcast/background-properties"
 import { LayoutProperties } from "@/components/broadcast/layout-properties"
@@ -24,7 +25,7 @@ export function PropertiesPanel() {
         : "Select an element or use tabs below"
 
   return (
-    <div className="flex h-full flex-col border-l border-border bg-card">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden border-l border-border bg-card">
       {/* Header */}
       <div className="flex h-14 flex-col gap-0.5 border-b border-border px-4 py-2">
         <h3 className="truncate text-sm font-semibold">{draftTheme.name}</h3>
@@ -32,7 +33,7 @@ export function PropertiesPanel() {
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue="text" className="flex min-h-0 flex-1 flex-col">
+      <Tabs defaultValue="text" className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div className="shrink-0 px-4 pt-3">
           <TabsList variant="default" className="w-full">
             <TabsTrigger value="text">Text</TabsTrigger>
@@ -41,17 +42,17 @@ export function PropertiesPanel() {
           </TabsList>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
-          <TabsContent value="text" className="mt-0">
+        <ScrollArea className="min-h-0 flex-1">
+          <TabsContent value="text" className="mt-0 p-4">
             <TextProperties />
           </TabsContent>
-          <TabsContent value="background" className="mt-0">
+          <TabsContent value="background" className="mt-0 p-4">
             <BackgroundProperties />
           </TabsContent>
-          <TabsContent value="layout" className="mt-0">
+          <TabsContent value="layout" className="mt-0 p-4">
             <LayoutProperties />
           </TabsContent>
-        </div>
+        </ScrollArea>
       </Tabs>
     </div>
   )

--- a/src/components/broadcast/theme-designer.tsx
+++ b/src/components/broadcast/theme-designer.tsx
@@ -42,7 +42,7 @@ export function ThemeDesigner() {
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
 
         <DialogPrimitive.Content
-          className="fixed inset-0 z-50 flex flex-col bg-background text-foreground outline-none"
+          className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-background text-foreground outline-none"
           aria-describedby={undefined}
         >
           <DialogPrimitive.Title className="sr-only">

--- a/src/components/broadcast/theme-library.tsx
+++ b/src/components/broadcast/theme-library.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, type ChangeEvent } from "react"
+import { useMemo, useState } from "react"
 import { useBroadcastStore } from "@/stores"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
 import { Input } from "@/components/ui/input"
@@ -6,7 +6,12 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { parseImportedThemes, serializeThemes } from "@/lib/theme-transfer"
+import { serializeThemes } from "@/lib/theme-transfer"
+import {
+  pickThemeBackgroundImage,
+  saveThemeExportFile,
+  showThemeDesignerMessage,
+} from "@/lib/theme-designer-files"
 import {
   PlusIcon,
   HeartIcon,
@@ -105,7 +110,6 @@ export function ThemeLibrary() {
   const themes = useBroadcastStore((s) => s.themes)
   const activeThemeId = useBroadcastStore((s) => s.activeThemeId)
   const editingThemeId = useBroadcastStore((s) => s.editingThemeId)
-  const importInputRef = useRef<HTMLInputElement>(null)
   const [search, setSearch] = useState("")
   const [filter, setFilter] = useState<FilterTab>("all")
 
@@ -130,52 +134,44 @@ export function ThemeLibrary() {
     }
   }
 
-  const handleImportClick = () => {
-    importInputRef.current?.click()
-  }
-
-  const handleImportThemes = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    event.target.value = ""
-    if (!file) return
-
-    try {
-      const importedThemes = parseImportedThemes(await file.text())
-      const importedCount = useBroadcastStore.getState().importThemes(importedThemes)
-      window.alert(
-        importedCount === 1
-          ? "Imported 1 theme."
-          : `Imported ${importedCount} themes.`,
+  const handleImportClick = async () => {
+    const draftTheme = useBroadcastStore.getState().draftTheme
+    if (!draftTheme) {
+      await showThemeDesignerMessage(
+        "Select a theme first, then import a background image.",
+        "warning",
       )
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Theme import failed."
-      window.alert(message)
+      return
     }
+
+    const imageUrl = await pickThemeBackgroundImage()
+    if (!imageUrl) return
+
+    useBroadcastStore.getState().updateDraft({
+      background: {
+        ...draftTheme.background,
+        type: "image",
+        image: {
+          url: imageUrl,
+          fit: draftTheme.background.image?.fit ?? "cover",
+          blur: draftTheme.background.image?.blur ?? 0,
+          brightness: draftTheme.background.image?.brightness ?? 100,
+          tint: draftTheme.background.image?.tint ?? null,
+        },
+      },
+    })
   }
 
-  const handleExportAll = () => {
+  const handleExportAll = async () => {
     const contents = serializeThemes(themes)
-    const blob = new Blob([contents], { type: "application/json" })
-    const url = URL.createObjectURL(blob)
-    const anchor = document.createElement("a")
     const stamp = new Date().toISOString().slice(0, 10)
-
-    anchor.href = url
-    anchor.download = `rhema-themes-${stamp}.json`
-    anchor.click()
-
-    URL.revokeObjectURL(url)
+    const didSave = await saveThemeExportFile(`rhema-themes-${stamp}.json`, contents)
+    if (!didSave) return
+    await showThemeDesignerMessage("Themes exported successfully.")
   }
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden border-r border-border bg-card">
-      <input
-        ref={importInputRef}
-        type="file"
-        accept="application/json,.json"
-        className="hidden"
-        onChange={handleImportThemes}
-      />
       {/* Header */}
       <div className="flex h-14 items-center justify-between border-b border-border px-3">
         <span className="text-lg font-semibold text-foreground">Themes</span>
@@ -216,7 +212,7 @@ export function ThemeLibrary() {
         <Button
           variant="outline"
           className="flex-1 border-border bg-transparent"
-          onClick={handleImportClick}
+          onClick={() => void handleImportClick()}
         >
           <UploadIcon className="size-2.5" />
           Import
@@ -224,7 +220,7 @@ export function ThemeLibrary() {
         <Button
           variant="outline"
           className="flex-1 border-border bg-transparent"
-          onClick={handleExportAll}
+          onClick={() => void handleExportAll()}
         >
           <DownloadIcon className="size-2.5" />
           Export All

--- a/src/components/broadcast/theme-library.tsx
+++ b/src/components/broadcast/theme-library.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { resolveRenderableTheme } from "@/lib/renderable-theme"
 import { serializeThemes } from "@/lib/theme-transfer"
 import {
   pickThemeBackgroundImage,
@@ -32,13 +33,21 @@ const THUMBNAIL_VERSE: VerseRenderData = {
 
 function ThemeCard({
   theme,
+  canDelete,
   isActive,
   isEditing,
+  onDelete,
+  onMakeActive,
+  onRename,
   onSelect,
 }: {
   theme: BroadcastTheme
+  canDelete: boolean
   isActive: boolean
   isEditing: boolean
+  onDelete: () => void
+  onMakeActive: () => void
+  onRename: () => void
   onSelect: () => void
 }) {
   return (
@@ -97,10 +106,51 @@ function ThemeCard({
           className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
           onClick={(e) => {
             e.stopPropagation()
+            onRename()
           }}
         >
           <MoreHorizontalIcon className="size-3" />
         </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-1 px-0.5 pb-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+        {!isActive && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 px-2 text-[0.625rem]"
+            onClick={(event) => {
+              event.stopPropagation()
+              onMakeActive()
+            }}
+          >
+            Use Live
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 px-2 text-[0.625rem]"
+          onClick={(event) => {
+            event.stopPropagation()
+            onRename()
+          }}
+        >
+          Rename
+        </Button>
+        {canDelete && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 px-2 text-[0.625rem]"
+            onClick={(event) => {
+              event.stopPropagation()
+              onDelete()
+            }}
+          >
+            Delete
+          </Button>
+        )}
       </div>
     </div>
   )
@@ -110,6 +160,7 @@ export function ThemeLibrary() {
   const themes = useBroadcastStore((s) => s.themes)
   const activeThemeId = useBroadcastStore((s) => s.activeThemeId)
   const editingThemeId = useBroadcastStore((s) => s.editingThemeId)
+  const draftTheme = useBroadcastStore((s) => s.draftTheme)
   const [search, setSearch] = useState("")
   const [filter, setFilter] = useState<FilterTab>("all")
 
@@ -132,6 +183,43 @@ export function ThemeLibrary() {
     if (firstTheme) {
       useBroadcastStore.getState().duplicateTheme(firstTheme.id)
     }
+  }
+
+  const handleRenameTheme = (theme: BroadcastTheme) => {
+    const nextName = window.prompt("Enter a new theme name.", theme.name)?.trim()
+    if (!nextName || nextName === theme.name) return
+    useBroadcastStore.getState().renameTheme(theme.id, nextName)
+  }
+
+  const handleDeleteTheme = async (theme: BroadcastTheme) => {
+    const confirmed = window.confirm(`Delete "${theme.name}"?`)
+    if (!confirmed) return
+    useBroadcastStore.getState().deleteTheme(theme.id)
+  }
+
+  const renderThemeCard = (theme: BroadcastTheme) => {
+    const displayTheme = resolveRenderableTheme({
+      themes,
+      themeId: theme.id,
+      draftTheme,
+      editingThemeId,
+    })
+
+    return (
+      <ThemeCard
+        key={theme.id}
+        theme={displayTheme}
+        canDelete={!theme.builtin}
+        isActive={theme.id === activeThemeId}
+        isEditing={theme.id === editingThemeId}
+        onDelete={() => void handleDeleteTheme(theme)}
+        onMakeActive={() => useBroadcastStore.getState().setActiveTheme(theme.id)}
+        onRename={() => handleRenameTheme(theme)}
+        onSelect={() =>
+          useBroadcastStore.getState().startEditing(theme.id)
+        }
+      />
+    )
   }
 
   const handleImportClick = async () => {
@@ -236,17 +324,7 @@ export function ThemeLibrary() {
               <p className="px-1.5 pt-2 pb-1 text-[0.625rem] font-semibold tracking-widest text-muted-foreground uppercase">
                 Built-in
               </p>
-              {builtinThemes.map((theme) => (
-                <ThemeCard
-                  key={theme.id}
-                  theme={theme}
-                  isActive={theme.id === activeThemeId}
-                  isEditing={theme.id === editingThemeId}
-                  onSelect={() =>
-                    useBroadcastStore.getState().startEditing(theme.id)
-                  }
-                />
-              ))}
+              {builtinThemes.map(renderThemeCard)}
             </>
           )}
 
@@ -256,17 +334,7 @@ export function ThemeLibrary() {
               <p className="px-1.5 pt-3 pb-1 text-[0.625rem] font-semibold tracking-widest text-muted-foreground uppercase">
                 Custom
               </p>
-              {customThemes.map((theme) => (
-                <ThemeCard
-                  key={theme.id}
-                  theme={theme}
-                  isActive={theme.id === activeThemeId}
-                  isEditing={theme.id === editingThemeId}
-                  onSelect={() =>
-                    useBroadcastStore.getState().startEditing(theme.id)
-                  }
-                />
-              ))}
+              {customThemes.map(renderThemeCard)}
             </>
           )}
 

--- a/src/components/broadcast/theme-library.tsx
+++ b/src/components/broadcast/theme-library.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react"
+import { useMemo, useRef, useState, type ChangeEvent } from "react"
 import { useBroadcastStore } from "@/stores"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
 import { Input } from "@/components/ui/input"
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { parseImportedThemes, serializeThemes } from "@/lib/theme-transfer"
 import {
   PlusIcon,
   HeartIcon,
@@ -104,6 +105,7 @@ export function ThemeLibrary() {
   const themes = useBroadcastStore((s) => s.themes)
   const activeThemeId = useBroadcastStore((s) => s.activeThemeId)
   const editingThemeId = useBroadcastStore((s) => s.editingThemeId)
+  const importInputRef = useRef<HTMLInputElement>(null)
   const [search, setSearch] = useState("")
   const [filter, setFilter] = useState<FilterTab>("all")
 
@@ -128,8 +130,53 @@ export function ThemeLibrary() {
     }
   }
 
+  const handleImportClick = () => {
+    importInputRef.current?.click()
+  }
+
+  const handleImportThemes = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file) return
+
+    try {
+      const importedThemes = parseImportedThemes(await file.text())
+      const importedCount = useBroadcastStore.getState().importThemes(importedThemes)
+      window.alert(
+        importedCount === 1
+          ? "Imported 1 theme."
+          : `Imported ${importedCount} themes.`,
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Theme import failed."
+      window.alert(message)
+    }
+  }
+
+  const handleExportAll = () => {
+    const contents = serializeThemes(themes)
+    const blob = new Blob([contents], { type: "application/json" })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    const stamp = new Date().toISOString().slice(0, 10)
+
+    anchor.href = url
+    anchor.download = `rhema-themes-${stamp}.json`
+    anchor.click()
+
+    URL.revokeObjectURL(url)
+  }
+
   return (
     <div className="flex h-full flex-col border-r border-border bg-card">
+      <input
+        ref={importInputRef}
+        type="file"
+        accept="application/json,.json"
+        className="hidden"
+        onChange={handleImportThemes}
+      />
+
       {/* Header */}
       <div className="flex h-14 items-center justify-between border-b border-border px-3">
         <span className="text-lg font-semibold text-foreground">Themes</span>
@@ -167,11 +214,19 @@ export function ThemeLibrary() {
 
       {/* Import / Export */}
       <div className="flex gap-1.5 px-3 pb-3">
-        <Button variant="outline" className="flex-1 border-border bg-transparent">
+        <Button
+          variant="outline"
+          className="flex-1 border-border bg-transparent"
+          onClick={handleImportClick}
+        >
           <UploadIcon className="size-2.5" />
           Import
         </Button>
-        <Button variant="outline" className="flex-1 border-border bg-transparent">
+        <Button
+          variant="outline"
+          className="flex-1 border-border bg-transparent"
+          onClick={handleExportAll}
+        >
           <DownloadIcon className="size-2.5" />
           Export All
         </Button>

--- a/src/components/broadcast/theme-library.tsx
+++ b/src/components/broadcast/theme-library.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react"
 import { useBroadcastStore } from "@/stores"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
 import { Input } from "@/components/ui/input"
@@ -47,14 +47,47 @@ function ThemeCard({
   isEditing: boolean
   onDelete: () => void
   onMakeActive: () => void
-  onRename: () => void
+  onRename: (name: string) => void
   onSelect: () => void
 }) {
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [pendingName, setPendingName] = useState(theme.name)
+
+  useEffect(() => {
+    setPendingName(theme.name)
+  }, [theme.name])
+
+  const commitRename = () => {
+    const nextName = pendingName.trim()
+    if (!nextName) {
+      setPendingName(theme.name)
+      setIsRenaming(false)
+      return
+    }
+
+    onRename(nextName)
+    setIsRenaming(false)
+  }
+
+  const handleRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      commitRename()
+      return
+    }
+
+    if (event.key === "Escape") {
+      setPendingName(theme.name)
+      setIsRenaming(false)
+    }
+  }
+
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={onSelect}
+      onClick={() => {
+        if (!isRenaming) onSelect()
+      }}
       className={cn(
         "group relative flex w-full flex-col gap-1.5 rounded-lg p-1.5 text-left transition-colors hover:bg-muted/50",
         isEditing && "ring-2 ring-primary"
@@ -82,9 +115,21 @@ function ThemeCard({
       {/* Info */}
       <div className="flex items-center gap-1.5 px-0.5">
         <div className="min-w-0 flex-1">
-          <p className="truncate text-xs font-medium text-foreground">
-            {theme.name}
-          </p>
+          {isRenaming ? (
+            <Input
+              autoFocus
+              value={pendingName}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) => setPendingName(event.target.value)}
+              onBlur={commitRename}
+              onKeyDown={handleRenameKeyDown}
+              className="h-7"
+            />
+          ) : (
+            <p className="truncate text-xs font-medium text-foreground">
+              {theme.name}
+            </p>
+          )}
           {isActive && (
             <p className="text-[0.5rem] text-muted-foreground">Default</p>
           )}
@@ -106,7 +151,7 @@ function ThemeCard({
           className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
           onClick={(e) => {
             e.stopPropagation()
-            onRename()
+            setIsRenaming(true)
           }}
         >
           <MoreHorizontalIcon className="size-3" />
@@ -133,7 +178,7 @@ function ThemeCard({
           className="h-6 px-2 text-[0.625rem]"
           onClick={(event) => {
             event.stopPropagation()
-            onRename()
+            setIsRenaming(true)
           }}
         >
           Rename
@@ -179,16 +224,7 @@ export function ThemeLibrary() {
   const customThemes = filteredThemes.filter((t) => !t.builtin)
 
   const handleNewTheme = () => {
-    const firstTheme = themes[0]
-    if (firstTheme) {
-      useBroadcastStore.getState().duplicateTheme(firstTheme.id)
-    }
-  }
-
-  const handleRenameTheme = (theme: BroadcastTheme) => {
-    const nextName = window.prompt("Enter a new theme name.", theme.name)?.trim()
-    if (!nextName || nextName === theme.name) return
-    useBroadcastStore.getState().renameTheme(theme.id, nextName)
+    useBroadcastStore.getState().createTheme()
   }
 
   const handleDeleteTheme = async (theme: BroadcastTheme) => {
@@ -214,7 +250,7 @@ export function ThemeLibrary() {
         isEditing={theme.id === editingThemeId}
         onDelete={() => void handleDeleteTheme(theme)}
         onMakeActive={() => useBroadcastStore.getState().setActiveTheme(theme.id)}
-        onRename={() => handleRenameTheme(theme)}
+        onRename={(name) => useBroadcastStore.getState().renameTheme(theme.id, name)}
         onSelect={() =>
           useBroadcastStore.getState().startEditing(theme.id)
         }

--- a/src/components/broadcast/theme-library.tsx
+++ b/src/components/broadcast/theme-library.tsx
@@ -168,7 +168,7 @@ export function ThemeLibrary() {
   }
 
   return (
-    <div className="flex h-full flex-col border-r border-border bg-card">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden border-r border-border bg-card">
       <input
         ref={importInputRef}
         type="file"
@@ -176,7 +176,6 @@ export function ThemeLibrary() {
         className="hidden"
         onChange={handleImportThemes}
       />
-
       {/* Header */}
       <div className="flex h-14 items-center justify-between border-b border-border px-3">
         <span className="text-lg font-semibold text-foreground">Themes</span>
@@ -203,7 +202,7 @@ export function ThemeLibrary() {
       <Tabs
         value={filter}
         onValueChange={(value) => setFilter(value as FilterTab)}
-        className="px-3 pb-4"
+        className="shrink-0 px-3 pb-4"
       >
         <TabsList className="h-7 w-full">
           <TabsTrigger value="all" className="capitalize">all</TabsTrigger>

--- a/src/components/panels/live-output-panel.tsx
+++ b/src/components/panels/live-output-panel.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
 import { cn } from "@/lib/utils"
+import { resolveRenderableTheme } from "@/lib/renderable-theme"
 import { useBroadcastStore, useBibleStore } from "@/stores"
 import { deriveLiveVerse } from "@/hooks/use-broadcast"
 
@@ -9,13 +10,20 @@ export function LiveOutputPanel() {
   const isLive = useBroadcastStore((s) => s.isLive)
   const themes = useBroadcastStore((s) => s.themes)
   const activeThemeId = useBroadcastStore((s) => s.activeThemeId)
+  const draftTheme = useBroadcastStore((s) => s.draftTheme)
+  const editingThemeId = useBroadcastStore((s) => s.editingThemeId)
 
   // Read the same data source as the preview panel
   const selectedVerse = useBibleStore((s) => s.selectedVerse)
   const translations = useBibleStore((s) => s.translations)
   const activeTranslationId = useBibleStore((s) => s.activeTranslationId)
 
-  const activeTheme = themes.find((t) => t.id === activeThemeId) ?? themes[0]
+  const activeTheme = resolveRenderableTheme({
+    themes,
+    themeId: activeThemeId,
+    draftTheme,
+    editingThemeId,
+  })
   const translation =
     translations.find((t) => t.id === activeTranslationId)?.abbreviation ?? "KJV"
 

--- a/src/components/panels/preview-panel.tsx
+++ b/src/components/panels/preview-panel.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
+import { resolveRenderableTheme } from "@/lib/renderable-theme"
 import { useBibleStore, useBroadcastStore } from "@/stores"
 import { bibleActions } from "@/hooks/use-bible"
 import { toVerseRenderData } from "@/hooks/use-broadcast"
@@ -24,8 +25,15 @@ export function PreviewPanel() {
   }, [activeTranslationId])
   const themes = useBroadcastStore((s) => s.themes)
   const activeThemeId = useBroadcastStore((s) => s.activeThemeId)
+  const draftTheme = useBroadcastStore((s) => s.draftTheme)
+  const editingThemeId = useBroadcastStore((s) => s.editingThemeId)
 
-  const activeTheme = themes.find((t) => t.id === activeThemeId) ?? themes[0]
+  const activeTheme = resolveRenderableTheme({
+    themes,
+    themeId: activeThemeId,
+    draftTheme,
+    editingThemeId,
+  })
   const translation = translations.find((t) => t.id === activeTranslationId)?.abbreviation ?? "KJV"
 
   const verseData = selectedVerse ? toVerseRenderData(selectedVerse, translation) : null

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -58,25 +58,6 @@ function disableTransitionsTemporarily() {
   }
 }
 
-function isEditableTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) {
-    return false
-  }
-
-  if (target.isContentEditable) {
-    return true
-  }
-
-  const editableParent = target.closest(
-    "input, textarea, select, [contenteditable='true']"
-  )
-  if (editableParent) {
-    return true
-  }
-
-  return false
-}
-
 export function ThemeProvider({
   children,
   defaultTheme = "system",
@@ -138,46 +119,6 @@ export function ThemeProvider({
       mediaQuery.removeEventListener("change", handleChange)
     }
   }, [theme, applyTheme])
-
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.repeat) {
-        return
-      }
-
-      if (event.metaKey || event.ctrlKey || event.altKey) {
-        return
-      }
-
-      if (isEditableTarget(event.target)) {
-        return
-      }
-
-      if (event.key.toLowerCase() !== "d") {
-        return
-      }
-
-      setThemeState((currentTheme) => {
-        const nextTheme =
-          currentTheme === "dark"
-            ? "light"
-            : currentTheme === "light"
-              ? "dark"
-              : getSystemTheme() === "dark"
-                ? "light"
-                : "dark"
-
-        localStorage.setItem(storageKey, nextTheme)
-        return nextTheme
-      })
-    }
-
-    window.addEventListener("keydown", handleKeyDown)
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown)
-    }
-  }, [storageKey])
 
   React.useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {

--- a/src/components/ui/canvas-verse.tsx
+++ b/src/components/ui/canvas-verse.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState, memo } from "react"
 import { renderVerse } from "@/lib/verse-renderer"
+import { useThemeImageCache } from "@/lib/theme-image-cache"
 import type { BroadcastTheme, VerseRenderData } from "@/types"
 import { cn } from "@/lib/utils"
 
@@ -17,6 +18,7 @@ export const CanvasVerse = memo(function CanvasVerse({
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [containerWidth, setContainerWidth] = useState(0)
+  const { imageCache, imageVersion } = useThemeImageCache(theme)
 
   // Measure container width with ResizeObserver
   useEffect(() => {
@@ -50,8 +52,8 @@ export const CanvasVerse = memo(function CanvasVerse({
 
     ctx.scale(dpr, dpr)
     const scale = displayW / theme.resolution.width
-    renderVerse(ctx, theme, verse, { scale })
-  }, [theme, verse, containerWidth])
+    renderVerse(ctx, theme, verse, { scale, imageCache })
+  }, [theme, verse, containerWidth, imageCache, imageVersion])
 
   return (
     <div ref={containerRef} className={cn("w-full", className)}>

--- a/src/lib/renderable-theme.ts
+++ b/src/lib/renderable-theme.ts
@@ -1,0 +1,21 @@
+import type { BroadcastTheme } from "@/types"
+
+interface ResolveRenderableThemeOptions {
+  themes: BroadcastTheme[]
+  themeId: string
+  draftTheme: BroadcastTheme | null
+  editingThemeId: string | null
+}
+
+export function resolveRenderableTheme({
+  themes,
+  themeId,
+  draftTheme,
+  editingThemeId,
+}: ResolveRenderableThemeOptions) {
+  if (draftTheme && editingThemeId === themeId) {
+    return draftTheme
+  }
+
+  return themes.find((theme) => theme.id === themeId) ?? themes[0]
+}

--- a/src/lib/theme-designer-files.ts
+++ b/src/lib/theme-designer-files.ts
@@ -1,0 +1,51 @@
+import { convertFileSrc } from "@tauri-apps/api/core"
+import { message, open, save } from "@tauri-apps/plugin-dialog"
+import { writeTextFile } from "@tauri-apps/plugin-fs"
+
+const IMAGE_FILTER = {
+  name: "Images",
+  extensions: ["png", "jpg", "jpeg", "webp", "gif", "bmp"],
+}
+
+function normalizeDialogPath(path: string | string[] | null) {
+  if (!path) return null
+  return Array.isArray(path) ? path[0] ?? null : path
+}
+
+export async function pickThemeBackgroundImage() {
+  const filePath = normalizeDialogPath(
+    await open({
+      title: "Choose Background Image",
+      filters: [IMAGE_FILTER],
+      multiple: false,
+      directory: false,
+      pickerMode: "image",
+      fileAccessMode: "copy",
+    }),
+  )
+
+  if (!filePath) return null
+  return convertFileSrc(filePath)
+}
+
+export async function saveThemeExportFile(fileName: string, contents: string) {
+  const filePath = await save({
+    title: "Export Themes",
+    defaultPath: fileName,
+    filters: [{ name: "JSON", extensions: ["json"] }],
+  })
+
+  if (!filePath) return false
+  await writeTextFile(filePath, contents)
+  return true
+}
+
+export async function showThemeDesignerMessage(
+  body: string,
+  kind: "info" | "warning" | "error" = "info",
+) {
+  await message(body, {
+    title: "Theme Designer",
+    kind,
+  })
+}

--- a/src/lib/theme-designer-files.ts
+++ b/src/lib/theme-designer-files.ts
@@ -1,15 +1,40 @@
-import { convertFileSrc } from "@tauri-apps/api/core"
 import { message, open, save } from "@tauri-apps/plugin-dialog"
-import { writeTextFile } from "@tauri-apps/plugin-fs"
+import { readFile, writeTextFile } from "@tauri-apps/plugin-fs"
 
 const IMAGE_FILTER = {
   name: "Images",
   extensions: ["png", "jpg", "jpeg", "webp", "gif", "bmp"],
 }
 
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  gif: "image/gif",
+  bmp: "image/bmp",
+}
+
 function normalizeDialogPath(path: string | string[] | null) {
   if (!path) return null
   return Array.isArray(path) ? path[0] ?? null : path
+}
+
+function inferImageMimeType(path: string) {
+  const extension = path.split(".").pop()?.toLowerCase() ?? ""
+  return IMAGE_MIME_BY_EXTENSION[extension] ?? "application/octet-stream"
+}
+
+function bytesToBase64(bytes: Uint8Array) {
+  const chunkSize = 0x8000
+  let output = ""
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize)
+    output += String.fromCharCode(...chunk)
+  }
+
+  return btoa(output)
 }
 
 export async function pickThemeBackgroundImage() {
@@ -25,7 +50,9 @@ export async function pickThemeBackgroundImage() {
   )
 
   if (!filePath) return null
-  return convertFileSrc(filePath)
+  const bytes = await readFile(filePath)
+  const mimeType = inferImageMimeType(filePath)
+  return `data:${mimeType};base64,${bytesToBase64(bytes)}`
 }
 
 export async function saveThemeExportFile(fileName: string, contents: string) {

--- a/src/lib/theme-image-cache.ts
+++ b/src/lib/theme-image-cache.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from "react"
+import type { BroadcastTheme } from "@/types"
+
+export function useThemeImageCache(theme: BroadcastTheme) {
+  const cacheRef = useRef<Map<string, HTMLImageElement>>(new Map())
+  const [imageVersion, setImageVersion] = useState(0)
+
+  useEffect(() => {
+    const imageUrl = theme.background.type === "image" ? theme.background.image?.url : null
+    if (!imageUrl) return
+
+    if (cacheRef.current.has(imageUrl)) return
+
+    let cancelled = false
+    const image = new Image()
+    image.onload = () => {
+      if (cancelled) return
+      cacheRef.current.set(imageUrl, image)
+      setImageVersion((version) => version + 1)
+    }
+    image.onerror = () => {
+      if (cancelled) return
+      console.warn("[canvas-verse] failed to load background image", { url: imageUrl })
+    }
+    image.src = imageUrl
+
+    return () => {
+      cancelled = true
+    }
+  }, [theme.background])
+
+  return {
+    imageCache: cacheRef.current,
+    imageVersion,
+  }
+}

--- a/src/lib/theme-transfer.test.ts
+++ b/src/lib/theme-transfer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest"
+import { BUILTIN_THEMES } from "@/lib/builtin-themes"
+import {
+  parseImportedThemes,
+  sanitizeImportedThemes,
+  serializeThemes,
+} from "@/lib/theme-transfer"
+
+describe("theme transfer", () => {
+  it("serializes themes into a portable payload", () => {
+    const serialized = serializeThemes([BUILTIN_THEMES[0]])
+    const parsed = JSON.parse(serialized) as { app: string; version: number; themes: unknown[] }
+
+    expect(parsed.app).toBe("rhema")
+    expect(parsed.version).toBe(1)
+    expect(parsed.themes).toHaveLength(1)
+  })
+
+  it("parses both wrapped payloads and raw arrays", () => {
+    const wrapped = parseImportedThemes(
+      JSON.stringify({
+        app: "rhema",
+        version: 1,
+        themes: [BUILTIN_THEMES[0]],
+      }),
+    )
+    const rawArray = parseImportedThemes(JSON.stringify([BUILTIN_THEMES[1]]))
+
+    expect(wrapped[0]?.id).toBe(BUILTIN_THEMES[0].id)
+    expect(rawArray[0]?.id).toBe(BUILTIN_THEMES[1].id)
+  })
+
+  it("rejects files without themes", () => {
+    expect(() => parseImportedThemes(JSON.stringify({ nope: true }))).toThrow(
+      "That file does not contain any importable themes.",
+    )
+  })
+
+  it("sanitizes imported themes into custom themes with unique ids", () => {
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("imported-theme-id")
+
+    const imported = sanitizeImportedThemes([BUILTIN_THEMES[0]], [BUILTIN_THEMES[0]])
+
+    expect(imported[0]).toMatchObject({
+      id: "imported-theme-id",
+      builtin: false,
+    })
+  })
+})

--- a/src/lib/theme-transfer.ts
+++ b/src/lib/theme-transfer.ts
@@ -1,0 +1,67 @@
+import type { BroadcastTheme } from "@/types"
+
+const THEME_EXPORT_VERSION = 1
+
+interface ThemeExportPayload {
+  app: "rhema"
+  version: number
+  exportedAt: string
+  themes: BroadcastTheme[]
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function isThemeArray(value: unknown): value is BroadcastTheme[] {
+  return Array.isArray(value) && value.every((item) => isObject(item))
+}
+
+function ensureUniqueThemeId(existingIds: Set<string>, preferredId: string) {
+  let nextId = preferredId
+  while (existingIds.has(nextId)) {
+    nextId = crypto.randomUUID()
+  }
+  existingIds.add(nextId)
+  return nextId
+}
+
+export function serializeThemes(themes: BroadcastTheme[]) {
+  const payload: ThemeExportPayload = {
+    app: "rhema",
+    version: THEME_EXPORT_VERSION,
+    exportedAt: new Date().toISOString(),
+    themes,
+  }
+
+  return JSON.stringify(payload, null, 2)
+}
+
+export function parseImportedThemes(fileContents: string) {
+  const parsed = JSON.parse(fileContents) as unknown
+
+  if (isThemeArray(parsed)) {
+    return parsed
+  }
+
+  if (isObject(parsed) && isThemeArray(parsed.themes)) {
+    return parsed.themes
+  }
+
+  throw new Error("That file does not contain any importable themes.")
+}
+
+export function sanitizeImportedThemes(
+  importedThemes: BroadcastTheme[],
+  existingThemes: BroadcastTheme[],
+) {
+  const existingIds = new Set(existingThemes.map((theme) => theme.id))
+
+  return importedThemes.map((theme) => ({
+    ...theme,
+    id: ensureUniqueThemeId(existingIds, theme.id),
+    builtin: false,
+    createdAt: typeof theme.createdAt === "number" ? theme.createdAt : Date.now(),
+    updatedAt: Date.now(),
+  }))
+}

--- a/src/lib/verse-renderer.ts
+++ b/src/lib/verse-renderer.ts
@@ -283,10 +283,12 @@ function drawBackground(
 
       ctx.save()
 
+      const brightnessMultiplier = Math.max(0, bg.image.brightness) / 100
+
       if (bg.image.blur > 0) {
-        ctx.filter = `blur(${bg.image.blur}px) brightness(${bg.image.brightness})`
-      } else if (bg.image.brightness !== 1) {
-        ctx.filter = `brightness(${bg.image.brightness})`
+        ctx.filter = `blur(${bg.image.blur}px) brightness(${brightnessMultiplier})`
+      } else if (brightnessMultiplier !== 1) {
+        ctx.filter = `brightness(${brightnessMultiplier})`
       }
 
       let drawX = 0

--- a/src/lib/verse-renderer.ts
+++ b/src/lib/verse-renderer.ts
@@ -595,6 +595,44 @@ function rectForAlignedText(
   }
 }
 
+function clampToBounds(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function unionRects(rects: VerseLayoutRect[]) {
+  if (rects.length === 0) return null
+
+  const minX = Math.min(...rects.map((rect) => rect.x))
+  const minY = Math.min(...rects.map((rect) => rect.y))
+  const maxX = Math.max(...rects.map((rect) => rect.x + rect.width))
+  const maxY = Math.max(...rects.map((rect) => rect.y + rect.height))
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}
+
+function paddedRect(
+  rect: VerseLayoutRect,
+  padding: number,
+  bounds: { width: number; height: number },
+): VerseLayoutRect {
+  const x = clampToBounds(rect.x - padding, 0, bounds.width)
+  const y = clampToBounds(rect.y - padding, 0, bounds.height)
+  const maxX = clampToBounds(rect.x + rect.width + padding, 0, bounds.width)
+  const maxY = clampToBounds(rect.y + rect.height + padding, 0, bounds.height)
+
+  return {
+    x,
+    y,
+    width: Math.max(0, maxX - x),
+    height: Math.max(0, maxY - y),
+  }
+}
+
 export function computeVerseLayoutMetrics(
   ctx: CanvasRenderingContext2D,
   theme: BroadcastTheme,
@@ -775,15 +813,24 @@ function renderVerseImpl(
 
   // Draw text box if enabled
   if (scaledTheme.textBox.enabled) {
+    const textContentRect = unionRects(
+      [metrics.referenceRect, metrics.verseRect].filter(
+        (rect): rect is VerseLayoutRect => rect !== null,
+      ),
+    )
+    const textBoxRect = textContentRect
+      ? paddedRect(textContentRect, scaledTheme.textBox.padding, scaledTheme.resolution)
+      : metrics.textAreaRect
+
     ctx.save()
     ctx.globalAlpha = (options?.opacity ?? 1) * scaledTheme.textBox.opacity
     ctx.fillStyle = scaledTheme.textBox.color
     roundRect(
       ctx,
-      metrics.textAreaRect.x,
-      metrics.textAreaRect.y,
-      metrics.textAreaRect.width,
-      metrics.textAreaRect.height,
+      textBoxRect.x,
+      textBoxRect.y,
+      textBoxRect.width,
+      textBoxRect.height,
       scaledTheme.textBox.borderRadius,
     )
     ctx.fill()

--- a/src/stores/broadcast-store.test.ts
+++ b/src/stores/broadcast-store.test.ts
@@ -126,6 +126,20 @@ describe("broadcast store sync", () => {
     expect(state.draftTheme?.name).toBe("New Theme Name")
   })
 
+  it("creates a new untitled custom theme and starts editing it", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+
+    useBroadcastStore.getState().createTheme()
+
+    const state = useBroadcastStore.getState()
+    const createdTheme = state.themes.find((theme) => theme.id === state.editingThemeId)
+
+    expect(createdTheme).toBeTruthy()
+    expect(createdTheme?.builtin).toBe(false)
+    expect(createdTheme?.name).toBe("Untitled")
+    expect(state.draftTheme?.id).toBe(createdTheme?.id)
+  })
+
   it("falls back to the first remaining theme when deleting the active theme", async () => {
     const { useBroadcastStore } = await import("./broadcast-store")
     const [firstTheme] = useBroadcastStore.getState().themes

--- a/src/stores/broadcast-store.test.ts
+++ b/src/stores/broadcast-store.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const emitToMock = vi.fn()
+const { emitToMock } = vi.hoisted(() => ({
+  emitToMock: vi.fn(),
+}))
 
 vi.mock("@tauri-apps/api/event", () => ({
   emitTo: emitToMock,
@@ -27,13 +29,83 @@ describe("broadcast store sync", () => {
     emitToMock.mockClear()
     useBroadcastStore.getState().syncBroadcastOutput()
 
-    expect(emitToMock).toHaveBeenCalledTimes(1)
+    expect(emitToMock).toHaveBeenCalledTimes(2)
     expect(emitToMock).toHaveBeenCalledWith(
       "broadcast",
       "broadcast:verse-update",
       expect.objectContaining({
         theme: expect.objectContaining({ id: theme.id }),
         verse: expect.objectContaining({ reference: "John 3:16" }),
+      }),
+    )
+  })
+
+  it("uses the draft theme for broadcast output while editing the active theme", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    const theme = useBroadcastStore.getState().themes[0]
+    const draftTheme = {
+      ...theme,
+      layout: {
+        ...theme.layout,
+        offsetX: 140,
+        offsetY: -60,
+      },
+    }
+
+    useBroadcastStore.setState({
+      activeThemeId: theme.id,
+      editingThemeId: theme.id,
+      draftTheme,
+      liveVerse: {
+        reference: "John 3:16",
+        segments: [{ text: "For God so loved the world", verseNumber: 16 }],
+      },
+    })
+
+    emitToMock.mockClear()
+    useBroadcastStore.getState().syncBroadcastOutput()
+
+    expect(emitToMock).toHaveBeenCalledWith(
+      "broadcast",
+      "broadcast:verse-update",
+      expect.objectContaining({
+        theme: expect.objectContaining({
+          id: theme.id,
+          layout: expect.objectContaining({
+            offsetX: 140,
+            offsetY: -60,
+          }),
+        }),
+      }),
+    )
+  })
+
+  it("re-syncs broadcast output when an active theme draft changes", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    const theme = useBroadcastStore.getState().themes[0]
+
+    useBroadcastStore.setState({
+      activeThemeId: theme.id,
+      editingThemeId: theme.id,
+      draftTheme: theme,
+      liveVerse: {
+        reference: "John 3:16",
+        segments: [{ text: "For God so loved the world", verseNumber: 16 }],
+      },
+    })
+
+    emitToMock.mockClear()
+    useBroadcastStore.getState().updateDraftNested("layout.offsetX", 220)
+
+    expect(emitToMock).toHaveBeenCalledWith(
+      "broadcast",
+      "broadcast:verse-update",
+      expect.objectContaining({
+        theme: expect.objectContaining({
+          layout: expect.objectContaining({
+            offsetX: 220,
+          }),
+        }),
       }),
     )
   })

--- a/src/stores/broadcast-store.test.ts
+++ b/src/stores/broadcast-store.test.ts
@@ -109,4 +109,42 @@ describe("broadcast store sync", () => {
       }),
     )
   })
+
+  it("renames both the saved theme and the current draft", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    const theme = useBroadcastStore.getState().themes[0]
+
+    useBroadcastStore.setState({
+      editingThemeId: theme.id,
+      draftTheme: theme,
+    })
+
+    useBroadcastStore.getState().renameTheme(theme.id, "New Theme Name")
+
+    const state = useBroadcastStore.getState()
+    expect(state.themes.find((entry) => entry.id === theme.id)?.name).toBe("New Theme Name")
+    expect(state.draftTheme?.name).toBe("New Theme Name")
+  })
+
+  it("falls back to the first remaining theme when deleting the active theme", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    const [firstTheme] = useBroadcastStore.getState().themes
+    useBroadcastStore.getState().duplicateTheme(firstTheme.id)
+    const customTheme = useBroadcastStore.getState().themes.find((theme) => !theme.builtin)
+
+    expect(customTheme).toBeTruthy()
+
+    useBroadcastStore.setState({
+      activeThemeId: customTheme!.id,
+      editingThemeId: customTheme!.id,
+      draftTheme: customTheme!,
+    })
+
+    useBroadcastStore.getState().deleteTheme(customTheme!.id)
+
+    const state = useBroadcastStore.getState()
+    expect(state.activeThemeId).toBe(firstTheme.id)
+    expect(state.editingThemeId).toBeNull()
+    expect(state.draftTheme).toBeNull()
+  })
 })

--- a/src/stores/broadcast-store.ts
+++ b/src/stores/broadcast-store.ts
@@ -23,6 +23,7 @@ interface BroadcastState {
   // Theme management
   loadThemes: () => void
   saveTheme: (theme: BroadcastTheme) => void
+  renameTheme: (id: string, name: string) => void
   importThemes: (themes: BroadcastTheme[]) => number
   deleteTheme: (id: string) => void
   duplicateTheme: (id: string) => void
@@ -103,6 +104,22 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
     }))
     get().syncBroadcastOutput()
   },
+  renameTheme: (id, name) => {
+    const nextName = name.trim()
+    if (!nextName) return
+
+    set((state) => ({
+      themes: state.themes.map((theme) =>
+        theme.id === id
+          ? { ...theme, name: nextName, updatedAt: Date.now() }
+          : theme,
+      ),
+      draftTheme:
+        state.draftTheme?.id === id
+          ? { ...state.draftTheme, name: nextName, updatedAt: Date.now() }
+          : state.draftTheme,
+    }))
+  },
   importThemes: (themes) => {
     const importedThemes = sanitizeImportedThemes(themes, get().themes)
     if (importedThemes.length === 0) return 0
@@ -112,8 +129,27 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
     }))
     return importedThemes.length
   },
-  deleteTheme: (id) =>
-    set((s) => ({ themes: s.themes.filter((t) => t.id !== id || t.builtin) })),
+  deleteTheme: (id) => {
+    set((state) => {
+      const themeToDelete = state.themes.find((theme) => theme.id === id)
+      if (!themeToDelete || themeToDelete.builtin) {
+        return state
+      }
+
+      const remainingThemes = state.themes.filter((theme) => theme.id !== id)
+      const fallbackThemeId = remainingThemes[0]?.id ?? BUILTIN_THEMES[0].id
+
+      return {
+        themes: remainingThemes,
+        activeThemeId: state.activeThemeId === id ? fallbackThemeId : state.activeThemeId,
+        altActiveThemeId: state.altActiveThemeId === id ? fallbackThemeId : state.altActiveThemeId,
+        editingThemeId: state.editingThemeId === id ? null : state.editingThemeId,
+        draftTheme: state.draftTheme?.id === id ? null : state.draftTheme,
+        selectedElement: state.draftTheme?.id === id ? null : state.selectedElement,
+      }
+    })
+    get().syncBroadcastOutput()
+  },
   duplicateTheme: (id) => {
     const s = get()
     const source = s.themes.find((t) => t.id === id)

--- a/src/stores/broadcast-store.ts
+++ b/src/stores/broadcast-store.ts
@@ -22,6 +22,7 @@ interface BroadcastState {
 
   // Theme management
   loadThemes: () => void
+  createTheme: () => void
   saveTheme: (theme: BroadcastTheme) => void
   renameTheme: (id: string, name: string) => void
   importThemes: (themes: BroadcastTheme[]) => number
@@ -82,6 +83,20 @@ function shouldSyncDraftForOutput(
   return Boolean(state.draftTheme && state.editingThemeId === themeId)
 }
 
+function uniqueThemeName(themes: BroadcastTheme[], baseName: string) {
+  const existingNames = new Set(themes.map((theme) => theme.name))
+  if (!existingNames.has(baseName)) {
+    return baseName
+  }
+
+  let suffix = 2
+  while (existingNames.has(`${baseName} ${suffix}`)) {
+    suffix += 1
+  }
+
+  return `${baseName} ${suffix}`
+}
+
 export const useBroadcastStore = create<BroadcastState>((set, get) => ({
   themes: [...BUILTIN_THEMES],
   activeThemeId: BUILTIN_THEMES[0].id,
@@ -95,6 +110,29 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
 
   loadThemes: () => {
     set({ themes: [...BUILTIN_THEMES] })
+  },
+  createTheme: () => {
+    const state = get()
+    const sourceThemeId = state.editingThemeId ?? state.activeThemeId
+    const sourceTheme = state.themes.find((theme) => theme.id === sourceThemeId) ?? state.themes[0]
+    if (!sourceTheme) return
+
+    const newTheme: BroadcastTheme = {
+      ...sourceTheme,
+      id: crypto.randomUUID(),
+      name: uniqueThemeName(state.themes, "Untitled"),
+      builtin: false,
+      pinned: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+
+    set((currentState) => ({
+      themes: [...currentState.themes, newTheme],
+      editingThemeId: newTheme.id,
+      draftTheme: newTheme,
+      selectedElement: null,
+    }))
   },
   saveTheme: (theme) => {
     set((s) => ({

--- a/src/stores/broadcast-store.ts
+++ b/src/stores/broadcast-store.ts
@@ -2,6 +2,8 @@ import { create } from "zustand"
 import { emitTo } from "@tauri-apps/api/event"
 import type { BroadcastTheme, VerseRenderData } from "@/types"
 import { BUILTIN_THEMES } from "@/lib/builtin-themes"
+import { resolveRenderableTheme } from "@/lib/renderable-theme"
+import { sanitizeImportedThemes } from "@/lib/theme-transfer"
 
 type SelectedElement = "verse" | "reference" | null
 
@@ -21,6 +23,7 @@ interface BroadcastState {
   // Theme management
   loadThemes: () => void
   saveTheme: (theme: BroadcastTheme) => void
+  importThemes: (themes: BroadcastTheme[]) => number
   deleteTheme: (id: string) => void
   duplicateTheme: (id: string) => void
   setActiveTheme: (id: string) => void
@@ -70,6 +73,14 @@ function setNestedValue(obj: Record<string, unknown>, path: string, value: unkno
   return result
 }
 
+function shouldSyncDraftForOutput(
+  outputId: "main" | "alt",
+  state: Pick<BroadcastState, "activeThemeId" | "altActiveThemeId" | "editingThemeId" | "draftTheme">,
+) {
+  const themeId = outputId === "alt" ? state.altActiveThemeId : state.activeThemeId
+  return Boolean(state.draftTheme && state.editingThemeId === themeId)
+}
+
 export const useBroadcastStore = create<BroadcastState>((set, get) => ({
   themes: [...BUILTIN_THEMES],
   activeThemeId: BUILTIN_THEMES[0].id,
@@ -84,12 +95,23 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
   loadThemes: () => {
     set({ themes: [...BUILTIN_THEMES] })
   },
-  saveTheme: (theme) =>
+  saveTheme: (theme) => {
     set((s) => ({
       themes: s.themes.some((t) => t.id === theme.id)
         ? s.themes.map((t) => (t.id === theme.id ? theme : t))
         : [...s.themes, theme],
-    })),
+    }))
+    get().syncBroadcastOutput()
+  },
+  importThemes: (themes) => {
+    const importedThemes = sanitizeImportedThemes(themes, get().themes)
+    if (importedThemes.length === 0) return 0
+
+    set((state) => ({
+      themes: [...state.themes, ...importedThemes],
+    }))
+    return importedThemes.length
+  },
   deleteTheme: (id) =>
     set((s) => ({ themes: s.themes.filter((t) => t.id !== id || t.builtin) })),
   duplicateTheme: (id) => {
@@ -111,7 +133,12 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
     const s = get()
     const themeId = outputId === "alt" ? s.altActiveThemeId : s.activeThemeId
     const label = outputId === "alt" ? "broadcast-alt" : "broadcast"
-    const theme = s.themes.find((t) => t.id === themeId) ?? s.themes[0]
+    const theme = resolveRenderableTheme({
+      themes: s.themes,
+      themeId,
+      draftTheme: shouldSyncDraftForOutput(outputId as "main" | "alt", s) ? s.draftTheme : null,
+      editingThemeId: s.editingThemeId,
+    })
     if (!theme) return
 
     void emitTo(label, "broadcast:verse-update", {
@@ -139,8 +166,14 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
 
   // Designer
   setDesignerOpen: (isDesignerOpen) => {
+    const wasEditingActiveTheme =
+      get().editingThemeId === get().activeThemeId ||
+      get().editingThemeId === get().altActiveThemeId
     if (!isDesignerOpen) {
       set({ isDesignerOpen, editingThemeId: null, draftTheme: null, selectedElement: null })
+      if (wasEditingActiveTheme) {
+        get().syncBroadcastOutput()
+      }
     } else {
       set({ isDesignerOpen })
     }
@@ -153,17 +186,39 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
       draftTheme: { ...theme, updatedAt: Date.now() },
       selectedElement: null,
     })
+    if (themeId === get().activeThemeId) {
+      get().syncBroadcastOutputFor("main")
+    }
+    if (themeId === get().altActiveThemeId) {
+      get().syncBroadcastOutputFor("alt")
+    }
   },
-  updateDraft: (updates) =>
+  updateDraft: (updates) => {
     set((s) => ({
       draftTheme: s.draftTheme ? { ...s.draftTheme, ...updates, updatedAt: Date.now() } : null,
-    })),
-  updateDraftNested: (path, value) =>
+    }))
+    const state = get()
+    if (state.editingThemeId === state.activeThemeId) {
+      state.syncBroadcastOutputFor("main")
+    }
+    if (state.editingThemeId === state.altActiveThemeId) {
+      state.syncBroadcastOutputFor("alt")
+    }
+  },
+  updateDraftNested: (path, value) => {
     set((s) => ({
       draftTheme: s.draftTheme
         ? (setNestedValue(s.draftTheme as unknown as Record<string, unknown>, path, value) as unknown as BroadcastTheme)
         : null,
-    })),
+    }))
+    const state = get()
+    if (state.editingThemeId === state.activeThemeId) {
+      state.syncBroadcastOutputFor("main")
+    }
+    if (state.editingThemeId === state.altActiveThemeId) {
+      state.syncBroadcastOutputFor("alt")
+    }
+  },
   saveDraft: () => {
     const { draftTheme } = get()
     if (!draftTheme) return
@@ -183,6 +238,7 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
         editingThemeId: customTheme.id,
         draftTheme: customTheme,
       }))
+      get().syncBroadcastOutput()
     } else {
       get().saveTheme(draftTheme)
     }


### PR DESCRIPTION
This PR addresses the parts of the theme designer that were showing up in the UI but were not fully wired up on `main`.

The goal is to make the flow work end to end: creating themes, renaming them, deleting them safely, using draft edits in the live preview, and moving theme data in and out reliably.

**What was not working before**
- Creating a new theme was effectively duplicating an existing one instead of starting a fresh custom theme.
- Rename and delete actions were not behaving like a normal theme management flow.
- Draft edits were not consistently feeding into the live broadcast output while the active theme was being edited.
- Theme import/export and preview rendering had reliability gaps.

**What this PR fixes**
- Creates a new untitled custom theme and starts editing it.
- Makes rename, delete, and use-live actions operate on the real theme state.
- Syncs draft theme changes into the broadcast preview when the edited theme is the active one.
- Improves theme transfer, background rendering, and theme preview behavior so the designer is dependable again.
