### PR TITLE
feat: add local Whisper speech-to-text as alternative to Deepgram

### DIFF
--- a/data/download-whisper-model.ts
+++ b/data/download-whisper-model.ts
@@ -1,0 +1,75 @@
+/**
+ * Downloads the Whisper large-v3-turbo Q8_0 GGML model for local speech-to-text.
+ *
+ * Model: ggml-large-v3-turbo-q8_0.bin (~394MB)
+ * Source: https://huggingface.co/ggerganov/whisper.cpp
+ *
+ * Run: bun run download:whisper
+ */
+
+import { join } from "node:path"
+import { existsSync, mkdirSync, createWriteStream } from "node:fs"
+
+const PROJECT_ROOT = join(import.meta.dir, "..")
+const MODELS_DIR = join(PROJECT_ROOT, "models", "whisper")
+const MODEL_FILE = "ggml-large-v3-turbo-q8_0.bin"
+const MODEL_PATH = join(MODELS_DIR, MODEL_FILE)
+const MODEL_URL = `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/${MODEL_FILE}`
+
+async function main() {
+  if (existsSync(MODEL_PATH)) {
+    console.log(`Whisper model already exists: ${MODEL_PATH}`)
+    return
+  }
+
+  mkdirSync(MODELS_DIR, { recursive: true })
+
+  console.log(`Downloading Whisper model from ${MODEL_URL}`)
+  console.log(`Destination: ${MODEL_PATH}`)
+
+  const response = await fetch(MODEL_URL, { redirect: "follow" })
+  if (!response.ok) {
+    throw new Error(`Download failed: ${response.status} ${response.statusText}`)
+  }
+
+  const totalBytes = Number(response.headers.get("content-length") ?? 0)
+  const totalMB = (totalBytes / 1_000_000).toFixed(0)
+  console.log(`Size: ${totalMB} MB`)
+
+  const writer = createWriteStream(MODEL_PATH + ".tmp")
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error("No response body")
+
+  let downloaded = 0
+  let lastPercent = -1
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    writer.write(Buffer.from(value))
+    downloaded += value.byteLength
+
+    const percent = totalBytes > 0 ? Math.floor((downloaded / totalBytes) * 100) : 0
+    if (percent !== lastPercent && percent % 5 === 0) {
+      process.stdout.write(`\r  ${percent}% (${(downloaded / 1_000_000).toFixed(0)}/${totalMB} MB)`)
+      lastPercent = percent
+    }
+  }
+
+  writer.end()
+  await new Promise<void>((resolve, reject) => {
+    writer.on("finish", resolve)
+    writer.on("error", reject)
+  })
+
+  // Atomic rename
+  const { renameSync } = await import("node:fs")
+  renameSync(MODEL_PATH + ".tmp", MODEL_PATH)
+
+  console.log(`\nWhisper model downloaded: ${MODEL_PATH}`)
+}
+
+main().catch((e) => {
+  console.error("Failed to download Whisper model:", e)
+  process.exit(1)
+})

--- a/data/lib/python-env.ts
+++ b/data/lib/python-env.ts
@@ -21,7 +21,13 @@ export function getVenvBin(name: string): string {
 }
 
 export async function findPython(): Promise<string> {
-  for (const candidate of ["python3", "python"]) {
+  for (const candidate of [
+    "python3.12",
+    "python3.11",
+    "python3.10",
+    "python3",
+    "python",
+  ]) {
     try {
       const proc = Bun.spawn([candidate, "--version"], {
         stdout: "pipe",

--- a/data/prepare-embeddings.ts
+++ b/data/prepare-embeddings.ts
@@ -8,6 +8,7 @@
  *   Phase 5 – Download & export ONNX model + INT8 quantization
  *   Phase 6 – Export KJV verses to JSON
  *   Phase 7 – Pre-compute verse embeddings
+ *   Phase 8 – Download Whisper model for local STT
  *
  * Every phase is idempotent: if its output artifacts already exist it is
  * skipped. Pass --force to re-run everything regardless.
@@ -39,6 +40,7 @@ const DB_PATH = join(DATA_DIR, "rhema.db")
 const VERSES_JSON = join(DATA_DIR, "verses-for-embedding.json")
 const EMB_BIN = join(PROJECT_ROOT, "embeddings", "kjv-qwen3-0.6b.bin")
 const IDS_BIN = join(PROJECT_ROOT, "embeddings", "kjv-qwen3-0.6b-ids.bin")
+const WHISPER_MODEL = join(PROJECT_ROOT, "models", "whisper", "ggml-large-v3-turbo-q8_0.bin")
 const MODEL_ONNX = join(MODELS_DIR, "model.onnx")
 const MODEL_INT8 = join(MODELS_DIR_INT8, "model_quantized.onnx")
 
@@ -79,12 +81,11 @@ async function main() {
   if (force) console.log("  (--force: re-running all phases)\n")
 
   // ── Phase 1: Python environment ────────────────────────────────
-  console.log("\n━━━ Phase 1/7: Python environment ━━━")
+  console.log("\n━━━ Phase 1/8: Python environment ━━━")
   await ensurePythonEnv([
     "optimum-onnx[onnxruntime]",
     "sentence-transformers",
     "accelerate",
-    "onnxruntime",
     "tokenizers",
     "numpy",
     "torch",
@@ -92,13 +93,13 @@ async function main() {
   ])
 
   // ── Phase 2: Open-source Bible data ────────────────────────────
-  console.log("\n━━━ Phase 2/7: Download open-source Bible data ━━━")
+  console.log("\n━━━ Phase 2/8: Download open-source Bible data ━━━")
   if (!shouldSkip("open-source Bible data", KJV_SOURCE)) {
     await run(["bun", "run", join(DATA_DIR, "download-sources.ts")])
   }
 
   // ── Phase 3: BibleGateway copyrighted translations ─────────────
-  console.log("\n━━━ Phase 3/7: Download BibleGateway translations ━━━")
+  console.log("\n━━━ Phase 3/8: Download BibleGateway translations ━━━")
   if (!shouldSkip("BibleGateway translations", NIV_SOURCE)) {
     const venvPython = getVenvBin(
       process.platform === "win32" ? "python" : "python3"
@@ -111,13 +112,13 @@ async function main() {
   }
 
   // ── Phase 4: Build Bible database ──────────────────────────────
-  console.log("\n━━━ Phase 4/7: Build Bible database ━━━")
+  console.log("\n━━━ Phase 4/8: Build Bible database ━━━")
   if (!shouldSkip("Bible database", DB_PATH)) {
     await run(["bun", "run", join(DATA_DIR, "build-bible-db.ts")])
   }
 
   // ── Phase 5: ONNX model download + quantize ────────────────────
-  console.log("\n━━━ Phase 5/7: ONNX model download & quantize ━━━")
+  console.log("\n━━━ Phase 5/8: ONNX model download & quantize ━━━")
   if (!shouldSkip("ONNX models", MODEL_ONNX, MODEL_INT8)) {
     const optimumCli = getVenvBin("optimum-cli")
 
@@ -164,7 +165,7 @@ async function main() {
   }
 
   // ── Phase 6: Export verses to JSON ─────────────────────────────
-  console.log("\n━━━ Phase 6/7: Export verses to JSON ━━━")
+  console.log("\n━━━ Phase 6/8: Export verses to JSON ━━━")
   if (!shouldSkip("verses JSON", VERSES_JSON)) {
     if (!existsSync(DB_PATH)) {
       console.error(
@@ -176,7 +177,7 @@ async function main() {
   }
 
   // ── Phase 7: Pre-compute embeddings ────────────────────────────
-  console.log("\n━━━ Phase 7/7: Pre-compute verse embeddings ━━━")
+  console.log("\n━━━ Phase 7/8: Pre-compute verse embeddings ━━━")
   if (!shouldSkip("precomputed embeddings", EMB_BIN, IDS_BIN)) {
     const venvPython = getVenvBin(
       process.platform === "win32" ? "python" : "python3"
@@ -187,6 +188,12 @@ async function main() {
       undefined,
       { PYTHONUTF8: "1" }
     )
+  }
+
+  // ── Phase 8: Whisper model ────────────────────────────────────
+  console.log("\n━━━ Phase 8/8: Download Whisper model ━━━")
+  if (!shouldSkip("Whisper model", WHISPER_MODEL)) {
+    await run(["bun", "run", join(DATA_DIR, "download-whisper-model.ts")])
   }
 
   // ── Done ───────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "precompute:embeddings-onnx": "python3 data/precompute-embeddings-onnx.py",
     "precompute:embeddings-py": "python3 data/precompute-embeddings.py",
     "precompute:embeddings": "cd src-tauri && cargo run -p rhema-detection --features precompute-bin --release --bin precompute -- --model ../models/qwen3-embedding-0.6b/model.onnx --tokenizer ../models/qwen3-embedding-0.6b/tokenizer.json --verses ../data/verses-for-embedding.json --output-embeddings ../embeddings/kjv-qwen3-0.6b.bin --output-ids ../embeddings/kjv-qwen3-0.6b-ids.bin",
+    "download:whisper": "bun run data/download-whisper-model.ts",
     "download:ndi-sdk": "bun run data/download-ndi-sdk.ts",
     "setup:all": "bun run data/prepare-embeddings.ts"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -198,6 +198,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +321,29 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -321,7 +355,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
@@ -666,6 +700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,7 +834,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
 ]
 
 [[package]]
@@ -1480,6 +1523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,7 +1739,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -1984,6 +2033,15 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html5ever"
@@ -2349,6 +2407,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2506,6 +2573,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2659,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3977,6 +4062,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3998,12 +4084,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
 ]
 
@@ -4037,7 +4125,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4122,16 +4210,19 @@ dependencies = [
 name = "rhema-stt"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "crossbeam-channel",
  "futures-util",
  "log",
  "reqwest 0.12.28",
+ "rhema-audio",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "url",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -4220,6 +4311,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4235,6 +4332,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4242,7 +4352,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4427,7 +4537,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -5301,7 +5411,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6139,6 +6249,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -6281,6 +6404,39 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6fc553156b521663bfa8e713e7ad58c7ca262d46de9998cd7f2e4de5ba0d9"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bab42b2c319e3a1e0280137c59368072348d3277873c7588b6466a127dca58"
+dependencies = [
+ "bindgen 0.69.5",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
 ]
 
 [[package]]
@@ -6966,7 +7122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,10 @@ crossbeam-channel = "0.5"
 dotenvy = "0.15"
 base64 = "0.22"
 
+[features]
+default = ["whisper"]
+whisper = ["rhema-stt/whisper"]
+
 [lints]
 workspace = true
 

--- a/src-tauri/crates/stt/Cargo.toml
+++ b/src-tauri/crates/stt/Cargo.toml
@@ -13,11 +13,22 @@ log.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true }
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { version = "0.12", features = ["json", "stream"], optional = true }
 url = "2"
 futures-util = "0.3"
 crossbeam-channel = "0.5"
+async-trait = "0.1"
+
+# Whisper local STT (optional)
+rhema-audio = { path = "../audio", optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+whisper-rs = { version = "0.13", features = ["metal"], optional = true }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+whisper-rs = { version = "0.13", optional = true }
 
 [features]
 default = ["rest-fallback"]
 rest-fallback = ["reqwest"]
+whisper = ["dep:whisper-rs", "rhema-audio"]

--- a/src-tauri/crates/stt/src/deepgram.rs
+++ b/src-tauri/crates/stt/src/deepgram.rs
@@ -12,6 +12,7 @@ use url::Url;
 
 use crate::error::SttError;
 use crate::keyterms::bible_keyterms;
+use crate::provider::SttProvider;
 use crate::types::{SttConfig, TranscriptEvent, Word};
 
 const MAX_RECONNECT_ATTEMPTS: u32 = 5;
@@ -444,4 +445,89 @@ async fn parse_and_send(
         .map_err(|e| SttError::SendError(e.to_string()))?;
 
     Ok(())
+}
+
+// ── SttProvider implementation ───────────────────────────────────────────────
+
+#[async_trait::async_trait]
+impl SttProvider for DeepgramClient {
+    async fn start(
+        &self,
+        audio_rx: Receiver<Vec<i16>>,
+        event_tx: mpsc::Sender<TranscriptEvent>,
+    ) -> Result<(), SttError> {
+        let result = self.connect(audio_rx.clone(), event_tx.clone()).await;
+
+        // On max reconnect failure, fall back to REST mode (hybrid).
+        if let Err(ref e) = result {
+            log::warn!(
+                "[STT-Deepgram] WebSocket failed after retries: {e}, switching to REST fallback"
+            );
+            let _ = event_tx
+                .send(TranscriptEvent::Error(
+                    "Connection unstable, switching to Hybrid mode".into(),
+                ))
+                .await;
+
+            let rest_client = crate::rest::DeepgramRestClient::new(self.config.clone());
+            let mut audio_buffer: Vec<i16> = Vec::new();
+            let flush_interval = std::time::Duration::from_secs(5);
+            let mut last_flush = std::time::Instant::now();
+            let cancelled = self.cancelled.clone();
+
+            loop {
+                if cancelled.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                match audio_rx.recv_timeout(Duration::from_millis(100)) {
+                    Ok(samples) => {
+                        audio_buffer.extend(samples);
+
+                        if last_flush.elapsed() >= flush_interval && !audio_buffer.is_empty() {
+                            match rest_client.transcribe(&audio_buffer).await {
+                                Ok(events) => {
+                                    for evt in events {
+                                        let _ = event_tx.send(evt).await;
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!("[STT-REST] Transcription failed: {e}");
+                                }
+                            }
+                            audio_buffer.clear();
+                            last_flush = std::time::Instant::now();
+                        }
+                    }
+                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                        if last_flush.elapsed() >= flush_interval && !audio_buffer.is_empty() {
+                            match rest_client.transcribe(&audio_buffer).await {
+                                Ok(events) => {
+                                    for evt in events {
+                                        let _ = event_tx.send(evt).await;
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!("[STT-REST] Transcription failed: {e}");
+                                }
+                            }
+                            audio_buffer.clear();
+                            last_flush = std::time::Instant::now();
+                        }
+                    }
+                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn stop(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+    }
+
+    fn name(&self) -> &'static str {
+        "deepgram"
+    }
 }

--- a/src-tauri/crates/stt/src/error.rs
+++ b/src-tauri/crates/stt/src/error.rs
@@ -17,4 +17,7 @@ pub enum SttError {
 
     #[error("parse error: {0}")]
     ParseError(String),
+
+    #[error("model not found: {0}")]
+    ModelNotFound(String),
 }

--- a/src-tauri/crates/stt/src/lib.rs
+++ b/src-tauri/crates/stt/src/lib.rs
@@ -1,12 +1,13 @@
 //! Speech-to-text integration for the Rhema application.
 //!
-//! Provides real-time transcription via the Deepgram WebSocket API,
-//! with support for keyword boosting (Bible terms), reconnection
-//! logic, and configurable models.
+//! Provides real-time transcription via multiple providers:
+//! - **Deepgram** (cloud) — WebSocket streaming with keyword boosting
+//! - **Whisper** (local) — offline inference via whisper.cpp
 //!
 //! # Key types
 //!
-//! - [`DeepgramClient`] — WebSocket client for live transcription
+//! - [`SttProvider`] — trait for swappable STT backends
+//! - [`DeepgramClient`] — Deepgram WebSocket/REST provider
 //! - [`TranscriptEvent`] — streaming transcript events (partial, final, etc.)
 //! - [`SttConfig`] — API configuration
 //! - [`SttError`] — error type for STT operations
@@ -14,16 +15,23 @@
 //! # Feature flags
 //!
 //! - `rest-fallback` — enables REST API fallback client
+//! - `whisper` — enables local Whisper STT provider
 
 pub mod deepgram;
 pub mod error;
 pub mod keyterms;
+pub mod provider;
 pub mod rest;
 pub mod types;
+
+#[cfg(feature = "whisper")]
+pub mod whisper;
 
 pub use deepgram::DeepgramClient;
 pub use error::SttError;
 pub use keyterms::bible_keyterms;
+pub use provider::SttProvider;
 pub use types::{SttConfig, TranscriptEvent, Word};
 
-pub use rest::DeepgramRestClient;
+#[cfg(feature = "whisper")]
+pub use whisper::WhisperProvider;

--- a/src-tauri/crates/stt/src/provider.rs
+++ b/src-tauri/crates/stt/src/provider.rs
@@ -1,0 +1,34 @@
+//! STT provider trait abstraction.
+//!
+//! Allows swapping between Deepgram (cloud) and Whisper (local) backends
+//! while keeping the same `TranscriptEvent` interface for the detection pipeline.
+
+use crossbeam_channel::Receiver;
+use tokio::sync::mpsc;
+
+use crate::error::SttError;
+use crate::types::TranscriptEvent;
+
+/// A speech-to-text provider that consumes audio and emits transcript events.
+///
+/// Both Deepgram (cloud) and Whisper (local) implement this trait so the
+/// command layer can select a provider at runtime without changing the
+/// downstream detection pipeline.
+#[async_trait::async_trait]
+pub trait SttProvider: Send + Sync {
+    /// Start the provider, consuming raw 16 kHz mono i16 audio from `audio_rx`
+    /// and emitting [`TranscriptEvent`]s to `event_tx`.
+    ///
+    /// Runs until cancelled, audio source disconnects, or an unrecoverable error.
+    async fn start(
+        &self,
+        audio_rx: Receiver<Vec<i16>>,
+        event_tx: mpsc::Sender<TranscriptEvent>,
+    ) -> Result<(), SttError>;
+
+    /// Signal the provider to stop.
+    fn stop(&self);
+
+    /// Human-readable provider name for logging.
+    fn name(&self) -> &'static str;
+}

--- a/src-tauri/crates/stt/src/whisper.rs
+++ b/src-tauri/crates/stt/src/whisper.rs
@@ -1,0 +1,300 @@
+//! Local Whisper STT provider using whisper.cpp via whisper-rs.
+//!
+//! Processes audio through the app's VAD to detect speech boundaries,
+//! then runs Whisper inference on each speech segment. Emits the same
+//! [`TranscriptEvent`] types as the Deepgram provider.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossbeam_channel::Receiver;
+use tokio::sync::mpsc;
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState};
+
+use crate::error::SttError;
+use crate::provider::SttProvider;
+use crate::types::{TranscriptEvent, Word};
+
+/// Maximum audio buffer before force-flushing to inference (10 seconds at 16 kHz).
+const MAX_BUFFER_SAMPLES: usize = 16_000 * 10;
+
+/// Minimum audio buffer for inference (1.0 seconds).
+/// Whisper warns "input is too short" below 1s.
+const MIN_BUFFER_SAMPLES: usize = 16_000;
+
+/// Convert i16 PCM samples to f32 in [-1.0, 1.0] range.
+fn i16_to_f32(samples: &[i16]) -> Vec<f32> {
+    samples.iter().map(|&s| f32::from(s) / 32768.0).collect()
+}
+
+/// Extract transcript text, words, and average confidence from Whisper state.
+#[expect(clippy::cast_precision_loss, reason = "timestamps and word counts are small enough")]
+fn extract_segments(state: &WhisperState) -> (String, Vec<Word>, f64) {
+    let n_segments = state.full_n_segments().unwrap_or(0);
+    let mut full_text = String::new();
+    let mut words = Vec::new();
+    let mut total_confidence: f64 = 0.0;
+
+    for i in 0..n_segments {
+        let text = state.full_get_segment_text(i).unwrap_or_default();
+        let start_ts = state.full_get_segment_t0(i).unwrap_or(0);
+        let end_ts = state.full_get_segment_t1(i).unwrap_or(0);
+
+        let start_sec = start_ts as f64 / 100.0;
+        let end_sec = end_ts as f64 / 100.0;
+        let confidence = 0.9;
+
+        let n_words = text.split_whitespace().count();
+        if n_words > 0 {
+            let duration_per_word = (end_sec - start_sec) / n_words as f64;
+            for (j, word_text) in text.split_whitespace().enumerate() {
+                let w_start = start_sec + (j as f64 * duration_per_word);
+                let w_end = w_start + duration_per_word;
+                words.push(Word {
+                    text: word_text.to_lowercase(),
+                    start: w_start,
+                    end: w_end,
+                    confidence,
+                    punctuated_word: Some(word_text.to_string()),
+                });
+            }
+        }
+
+        full_text.push_str(&text);
+        total_confidence += confidence;
+    }
+
+    let avg_confidence = if n_segments > 0 {
+        total_confidence / f64::from(n_segments)
+    } else {
+        0.0
+    };
+
+    (full_text.trim().to_string(), words, avg_confidence)
+}
+
+/// Local Whisper STT provider.
+pub struct WhisperProvider {
+    model_path: PathBuf,
+    language: Option<String>,
+    n_threads: i32,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl WhisperProvider {
+    /// Create a new Whisper provider.
+    ///
+    /// - `model_path`: path to a GGML model file
+    /// - `language`: ISO language code (e.g. "en") or `None` for auto-detect
+    /// - `n_threads`: number of CPU threads for inference
+    pub fn new(model_path: PathBuf, language: Option<String>, n_threads: i32) -> Self {
+        Self {
+            model_path,
+            language,
+            n_threads: n_threads.max(1),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl std::fmt::Debug for WhisperProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WhisperProvider")
+            .field("model_path", &self.model_path)
+            .field("language", &self.language)
+            .field("n_threads", &self.n_threads)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl SttProvider for WhisperProvider {
+    #[expect(clippy::too_many_lines, reason = "spawns two blocking tasks with setup; splitting would obscure the pipeline flow")]
+    async fn start(
+        &self,
+        audio_rx: Receiver<Vec<i16>>,
+        event_tx: mpsc::Sender<TranscriptEvent>,
+    ) -> Result<(), SttError> {
+        if !self.model_path.exists() {
+            return Err(SttError::ModelNotFound(format!(
+                "Whisper model not found: {}",
+                self.model_path.display()
+            )));
+        }
+
+        let _ = event_tx.send(TranscriptEvent::Connected).await;
+
+        let model_path = self.model_path.clone();
+        let language = self.language.clone();
+        let n_threads = self.n_threads;
+        let cancelled = self.cancelled.clone();
+
+        let (inference_tx, mut inference_rx) = mpsc::channel::<Vec<i16>>(4);
+
+        // ── Task 1: VAD + audio accumulation ─────────────────────────────
+        let vad_cancelled = cancelled.clone();
+        let vad_event_tx = event_tx.clone();
+        let vad_handle = tokio::task::spawn_blocking(move || {
+            use rhema_audio::{AudioFrame, Vad, VadConfig, VadTransition};
+
+            // Higher thresholds than default to avoid sending near-silence
+            // to Whisper (which causes hallucinations).
+            let vad_config = VadConfig {
+                silence_threshold: 0.01,
+                frame_threshold: 0.005,
+                min_voice_frames: 6,
+                ..VadConfig::default()
+            };
+            let mut vad = Vad::new(vad_config);
+            let mut audio_buffer: Vec<i16> = Vec::new();
+
+            loop {
+                if vad_cancelled.load(Ordering::SeqCst) {
+                    if audio_buffer.len() >= MIN_BUFFER_SAMPLES {
+                        let _ = inference_tx.blocking_send(std::mem::take(&mut audio_buffer));
+                    }
+                    break;
+                }
+
+                match audio_rx.recv_timeout(Duration::from_millis(50)) {
+                    Ok(samples) => {
+                        let frame = AudioFrame { samples, timestamp_ms: 0 };
+                        let result = vad.process(&frame);
+
+                        if let Some(transition) = result.transition {
+                            match transition {
+                                VadTransition::SpeechStarted => {
+                                    let _ = vad_event_tx
+                                        .blocking_send(TranscriptEvent::SpeechStarted);
+                                }
+                                VadTransition::SpeechEnded => {
+                                    if audio_buffer.len() >= MIN_BUFFER_SAMPLES {
+                                        let _ = inference_tx
+                                            .blocking_send(std::mem::take(&mut audio_buffer));
+                                    } else {
+                                        audio_buffer.clear();
+                                    }
+                                }
+                            }
+                        }
+
+                        for frame in result.frames {
+                            audio_buffer.extend_from_slice(&frame.samples);
+                        }
+
+                        if audio_buffer.len() >= MAX_BUFFER_SAMPLES {
+                            let _ = inference_tx.blocking_send(std::mem::take(&mut audio_buffer));
+                        }
+                    }
+                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
+                        if audio_buffer.len() >= MIN_BUFFER_SAMPLES {
+                            let _ = inference_tx.blocking_send(std::mem::take(&mut audio_buffer));
+                        }
+                        break;
+                    }
+                }
+            }
+        });
+
+        // ── Task 2: Whisper inference ────────────────────────────────────
+        let inf_cancelled = cancelled.clone();
+        let inf_event_tx = event_tx.clone();
+        let inf_handle = tokio::task::spawn_blocking(move || {
+            let ctx = match WhisperContext::new_with_params(
+                &model_path.to_string_lossy(),
+                WhisperContextParameters::default(),
+            ) {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    log::error!("[Whisper] Failed to load model: {e}");
+                    let _ = inf_event_tx.blocking_send(TranscriptEvent::Error(
+                        format!("Failed to load Whisper model: {e}"),
+                    ));
+                    return;
+                }
+            };
+
+            let mut state = match ctx.create_state() {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("[Whisper] Failed to create state: {e}");
+                    let _ = inf_event_tx.blocking_send(TranscriptEvent::Error(
+                        format!("Failed to create Whisper state: {e}"),
+                    ));
+                    return;
+                }
+            };
+
+            log::info!("[Whisper] Model loaded, ready for inference");
+
+            while let Some(audio_i16) = inference_rx.blocking_recv() {
+                if inf_cancelled.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                let audio_f32 = i16_to_f32(&audio_i16);
+
+                let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+                params.set_language(Some(
+                    language.as_deref().unwrap_or("en"),
+                ));
+                params.set_n_threads(n_threads);
+                params.set_print_progress(false);
+                params.set_print_special(false);
+                params.set_print_realtime(false);
+                params.set_single_segment(false);
+                params.set_token_timestamps(true);
+                params.set_no_speech_thold(0.6);
+                params.set_suppress_blank(true);
+                params.set_suppress_non_speech_tokens(true);
+
+                let start = std::time::Instant::now();
+                if let Err(e) = state.full(params, &audio_f32) {
+                    log::error!("[Whisper] Inference error: {e}");
+                    let _ = inf_event_tx.blocking_send(TranscriptEvent::Error(
+                        format!("Whisper inference error: {e}"),
+                    ));
+                    continue;
+                }
+                let elapsed = start.elapsed();
+
+                let (text, words, confidence) = extract_segments(&state);
+
+                #[expect(clippy::cast_precision_loss, reason = "audio sample count fits in f64")]
+                let audio_duration_s = audio_i16.len() as f64 / 16_000.0;
+                log::info!(
+                    "[Whisper] Transcribed {audio_duration_s:.1}s audio in {elapsed:.1?}: \"{text}\""
+                );
+
+                if !text.is_empty() {
+                    let _ = inf_event_tx.blocking_send(TranscriptEvent::Final {
+                        transcript: text,
+                        words,
+                        confidence,
+                        speech_final: true,
+                    });
+                }
+
+                let _ = inf_event_tx.blocking_send(TranscriptEvent::UtteranceEnd);
+            }
+
+            log::info!("[Whisper] Inference task exiting");
+        });
+
+        let _ = tokio::join!(vad_handle, inf_handle);
+        let _ = event_tx.send(TranscriptEvent::Disconnected).await;
+
+        Ok(())
+    }
+
+    fn stop(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+    }
+
+    fn name(&self) -> &'static str {
+        "whisper"
+    }
+}

--- a/src-tauri/src/commands/stt.rs
+++ b/src-tauri/src/commands/stt.rs
@@ -11,14 +11,14 @@ use crate::events::{
 };
 use crate::state::AppState;
 use rhema_audio::{AudioConfig, AudioFrame};
-use rhema_stt::{DeepgramClient, SttConfig, TranscriptEvent};
+use rhema_stt::{DeepgramClient, SttConfig, SttProvider, TranscriptEvent};
 
 /// Start the full audio-capture-to-transcription pipeline.
 ///
 /// 1. Opens the microphone via cpal (on a dedicated thread so the non-Send
 ///    `AudioCapture` never crosses thread boundaries).
-/// 2. Connects to Deepgram via WebSocket.
-/// 3. Fans audio out to both the level meter (emits `audio_level` events) and Deepgram.
+/// 2. Connects to the selected STT provider (Deepgram cloud or Whisper local).
+/// 3. Fans audio out to both the level meter (emits `audio_level` events) and STT.
 /// 4. Receives transcripts and emits `transcript_partial` / `transcript_final` events.
 /// 5. On final transcripts, runs the detection pipeline and emits `verse_detected` events.
 #[expect(clippy::too_many_lines, reason = "pipeline setup is inherently complex")]
@@ -29,6 +29,7 @@ pub async fn start_transcription(
     api_key: String,
     device_id: Option<String>,
     gain: Option<f32>,
+    provider: Option<String>,
 ) -> Result<(), String> {
     // ── 1. Guard: already running? ──────────────────────────────────────
     let (stt_active, audio_active) = {
@@ -39,34 +40,108 @@ pub async fn start_transcription(
         (app_state.stt_active.clone(), app_state.audio_active.clone())
     };
 
-    // Resolve API key: use provided key, or fall back to DEEPGRAM_API_KEY env var
-    let resolved_api_key = if api_key.is_empty() {
-        std::env::var("DEEPGRAM_API_KEY").unwrap_or_default()
-    } else {
-        api_key
+    let provider_name = provider.as_deref().unwrap_or("deepgram");
+
+    // ── 2. Build the STT provider ───────────────────────────────────────
+    let stt_provider: Box<dyn SttProvider> = match provider_name {
+        #[cfg(feature = "whisper")]
+        "whisper" => {
+            // Resolve bundled Whisper model path.
+            // Dev: {CARGO_MANIFEST_DIR}/../models/whisper/ggml-large-v3-turbo-q8_0.bin
+            // Prod: resource_dir()/models/whisper/ggml-large-v3-turbo-q8_0.bin
+            let model_filename = "ggml-large-v3-turbo-q8_0.bin";
+            let model_path = {
+                let base_dir =
+                    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+                let dev_path = base_dir
+                    .join("models")
+                    .join("whisper")
+                    .join(model_filename);
+                if dev_path.exists() {
+                    dev_path
+                } else {
+                    app.path()
+                        .resource_dir()
+                        .map(|p| {
+                            p.join("models")
+                                .join("whisper")
+                                .join(model_filename)
+                        })
+                        .ok()
+                        .filter(|p| p.exists())
+                        .ok_or_else(|| {
+                            "Whisper model not found. Run: bun run download:whisper"
+                                .to_string()
+                        })?
+                }
+            };
+
+            let parallelism = std::thread::available_parallelism()
+                .map_or(4, usize::from);
+            let n_threads = i32::try_from(parallelism / 2).unwrap_or(2).max(1);
+
+            log::info!(
+                "Starting Whisper transcription: model={}, threads={n_threads}, device_id={device_id:?}",
+                model_path.display()
+            );
+
+            Box::new(rhema_stt::WhisperProvider::new(
+                model_path,
+                None,
+                n_threads,
+            ))
+        }
+        #[cfg(not(feature = "whisper"))]
+        "whisper" => {
+            return Err(
+                "Whisper support not compiled. Rebuild with --features whisper".into(),
+            );
+        }
+        _ => {
+            // Deepgram (default)
+            let resolved_api_key = if api_key.is_empty() {
+                std::env::var("DEEPGRAM_API_KEY").unwrap_or_default()
+            } else {
+                api_key
+            };
+
+            if resolved_api_key.is_empty() {
+                return Err(
+                    "No Deepgram API key provided. Set it in Settings or via DEEPGRAM_API_KEY env var."
+                        .into(),
+                );
+            }
+
+            log::info!(
+                "Starting Deepgram transcription: api_key={}..., device_id={device_id:?}, gain={gain:?}",
+                &resolved_api_key[..8.min(resolved_api_key.len())]
+            );
+
+            let stt_config = SttConfig {
+                api_key: resolved_api_key,
+                model: "nova-3".to_string(),
+                sample_rate: 16_000,
+                encoding: "linear16".to_string(),
+                language: None,
+            };
+
+            Box::new(DeepgramClient::new(stt_config))
+        }
     };
-
-    if resolved_api_key.is_empty() {
-        return Err("No Deepgram API key provided. Set it in Settings or via DEEPGRAM_API_KEY env var.".into());
-    }
-
-    log::info!("Starting transcription: api_key={}..., device_id={device_id:?}, gain={gain:?}",
-        &resolved_api_key[..8.min(resolved_api_key.len())]);
 
     stt_active.store(true, Ordering::SeqCst);
     audio_active.store(true, Ordering::SeqCst);
 
-    // ── 2. Prepare channels ─────────────────────────────────────────────
-    // Deepgram channel carries Vec<i16> (the samples from each AudioFrame).
-    let (deepgram_tx, deepgram_rx) = crossbeam_channel::bounded::<Vec<i16>>(64);
+    // ── 3. Prepare channels ─────────────────────────────────────────────
+    let (audio_send_tx, audio_send_rx) = crossbeam_channel::bounded::<Vec<i16>>(64);
 
-    // ── 3. Spawn the audio-capture + fan-out thread ─────────────────────
+    // ── 4. Spawn the audio-capture + fan-out thread ─────────────────────
     // cpal's `Stream` (inside `AudioCapture`) is !Send, so we must create
     // and drop it on the same thread. This thread:
     //   a) starts the cpal capture
     //   b) reads AudioFrames
     //   c) computes levels → emits audio_level events
-    //   d) forwards samples to Deepgram via crossbeam
+    //   d) forwards samples to STT provider via crossbeam
     let gain_val = gain.unwrap_or(1.0).clamp(0.0, 2.0);
     let fan_active = stt_active.clone();
     let fan_app = app.clone();
@@ -118,11 +193,8 @@ pub async fn start_transcription(
                             );
                         }
 
-                        // (b) Forward all audio to Deepgram
-                        // NOTE: VAD module exists (audio/vad.rs) but disabled —
-                        // Deepgram's built-in VAD handles silence detection.
-                        // Re-enable when VAD thresholds are properly tuned.
-                        let _ = deepgram_tx.try_send(frame.samples);
+                        // (b) Forward all audio to STT provider
+                        let _ = audio_send_tx.try_send(frame.samples);
                     }
                     Err(crossbeam_channel::RecvTimeoutError::Timeout) => {},
                     Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
@@ -139,93 +211,20 @@ pub async fn start_transcription(
             format!("Failed to spawn audio fanout thread: {e}")
         })?;
 
-    // ── 4. Spawn the Deepgram connection on the tokio runtime ───────────
-    let stt_config = SttConfig {
-        api_key: resolved_api_key,
-        model: "nova-3".to_string(),
-        sample_rate: 16_000,
-        encoding: "linear16".to_string(),
-        language: None,
-    };
-
-    let client = DeepgramClient::new(stt_config.clone());
-
+    // ── 5. Spawn the STT provider on the tokio runtime ──────────────────
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TranscriptEvent>(64);
 
     let conn_active = stt_active.clone();
+    let provider_log_name = stt_provider.name().to_string();
 
-    // Task A: run the Deepgram WebSocket connection.
-    // On max reconnect failure, falls back to REST mode (hybrid).
-    let rest_event_tx = event_tx.clone();
-    let rest_config = stt_config.clone();
+    // Task A: run the STT provider (Deepgram WS+REST or Whisper local).
     tauri::async_runtime::spawn(async move {
-        let result = client.connect(deepgram_rx.clone(), event_tx).await;
+        let result = stt_provider.start(audio_send_rx, event_tx).await;
         if let Err(e) = result {
-            log::error!("Deepgram WebSocket failed: {e}");
-
-            // ── Hybrid mode: fall back to REST transcription ──
-            {
-                log::warn!("[STT] Connection unstable, switching to Hybrid mode (REST fallback)");
-                let _ = rest_event_tx
-                    .send(TranscriptEvent::Error(
-                        "Connection unstable, switching to Hybrid mode".into(),
-                    ))
-                    .await;
-
-                let rest_client = rhema_stt::DeepgramRestClient::new(rest_config);
-                let mut audio_buffer: Vec<i16> = Vec::new();
-                let flush_interval = std::time::Duration::from_secs(5);
-                let mut last_flush = std::time::Instant::now();
-
-                loop {
-                    if !conn_active.load(Ordering::SeqCst) {
-                        break;
-                    }
-
-                    match deepgram_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-                        Ok(samples) => {
-                            audio_buffer.extend(samples);
-
-                            // Flush every 5 seconds of accumulated audio
-                            if last_flush.elapsed() >= flush_interval && !audio_buffer.is_empty() {
-                                match rest_client.transcribe(&audio_buffer).await {
-                                    Ok(events) => {
-                                        for evt in events {
-                                            let _ = rest_event_tx.send(evt).await;
-                                        }
-                                    }
-                                    Err(e) => {
-                                        log::error!("[STT-REST] Transcription failed: {e}");
-                                    }
-                                }
-                                audio_buffer.clear();
-                                last_flush = std::time::Instant::now();
-                            }
-                        }
-                        Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                            // Flush if we have audio and enough time has passed
-                            if last_flush.elapsed() >= flush_interval && !audio_buffer.is_empty() {
-                                match rest_client.transcribe(&audio_buffer).await {
-                                    Ok(events) => {
-                                        for evt in events {
-                                            let _ = rest_event_tx.send(evt).await;
-                                        }
-                                    }
-                                    Err(e) => {
-                                        log::error!("[STT-REST] Transcription failed: {e}");
-                                    }
-                                }
-                                audio_buffer.clear();
-                                last_flush = std::time::Instant::now();
-                            }
-                        }
-                        Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
-                    }
-                }
-            }
+            log::error!("[STT-{provider_log_name}] Provider failed: {e}");
         }
         conn_active.store(false, Ordering::SeqCst);
-        log::info!("Deepgram connection task exited");
+        log::info!("[STT-{provider_log_name}] Provider task exited");
     });
 
     // Task B: consume TranscriptEvents, emit to frontend, run detection
@@ -814,7 +813,7 @@ fn run_quotation_matching(app: &AppHandle, transcript: &str) {
     let _ = app.emit("verse_detections", &results);
 }
 
-/// Stop the transcription pipeline (audio capture + Deepgram).
+/// Stop the transcription pipeline (audio capture + STT provider).
 #[tauri::command]
 pub fn stop_transcription(
     state: State<'_, Mutex<AppState>>,
@@ -832,3 +831,4 @@ pub fn stop_transcription(
     log::info!("Transcription stop requested");
     Ok(())
 }
+

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -142,16 +142,19 @@ export function TranscriptPanel() {
       useTranscriptStore.getState().setConnectionStatus("connecting")
       const { useSettingsStore } = await import("@/stores")
       const settings = useSettingsStore.getState()
-      console.log("[AUDIO] Starting with deviceId:", settings.audioDeviceId, "gain:", settings.gain)
-      await invoke("start_transcription", {
-        apiKey: deepgramApiKey ?? "",
+      const params = {
+        apiKey: settings.sttProvider === "deepgram" ? (deepgramApiKey ?? "") : "",
         deviceId: settings.audioDeviceId,
         gain: settings.gain,
-      })
+        provider: settings.sttProvider,
+      }
+      console.log("[AUDIO] Starting transcription:", params)
+      await invoke("start_transcription", params)
+      console.log("[AUDIO] Transcription started successfully")
       useTranscriptStore.getState().setTranscribing(true)
     } catch (e) {
       const errorMsg = String(e)
-      console.error("Failed to start transcription:", errorMsg)
+      console.error("[AUDIO] Failed to start transcription:", errorMsg)
       useTranscriptStore.getState().setConnectionStatus("error")
 
       if (errorMsg.includes("No Deepgram API key")) {

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -40,6 +40,7 @@ import {
   RadioIcon,
   HelpCircleIcon,
   GraduationCapIcon,
+  BrainCircuitIcon,
 } from "lucide-react"
 import { useSettingsStore } from "@/stores"
 import { useTutorialStore } from "@/stores/tutorial-store"
@@ -50,13 +51,18 @@ import type { DeviceInfo } from "@/types/audio"
 /*  Nav definition                                                            */
 /* -------------------------------------------------------------------------- */
 
-type NavSection = "audio" | "bible" | "display" | "api-keys" | "remote" | "help"
+type NavSection = "audio" | "speech" | "bible" | "display" | "api-keys" | "remote" | "help"
 
 const navItems: { name: string; id: NavSection; icon: React.ReactNode }[] = [
   {
     name: "Audio",
     id: "audio",
     icon: <MicIcon strokeWidth={2} />,
+  },
+  {
+    name: "Speech Recognition",
+    id: "speech",
+    icon: <BrainCircuitIcon strokeWidth={2} />,
   },
   {
     name: "Bible",
@@ -180,6 +186,121 @@ function AudioSection() {
 }
 
 /* -------------------------------------------------------------------------- */
+/*  Section: Speech Recognition                                               */
+/* -------------------------------------------------------------------------- */
+
+function SpeechSection() {
+  const {
+    sttProvider,
+    setSttProvider,
+    deepgramApiKey,
+    setDeepgramApiKey,
+  } = useSettingsStore()
+
+  const [keyValue, setKeyValue] = useState(deepgramApiKey ?? "")
+  const [saved, setSaved] = useState(false)
+
+  const handleSaveKey = () => {
+    setDeepgramApiKey(keyValue || null)
+    setSaved(true)
+    setTimeout(() => setSaved(false), 2000)
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Provider selector */}
+      <div className="flex flex-col gap-3">
+        <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Provider
+        </label>
+
+        <RadioGroup
+          value={sttProvider}
+          onValueChange={(v) => setSttProvider(v as "deepgram" | "whisper")}
+          className="gap-3"
+        >
+          {/* Deepgram (cloud) */}
+          <label
+            className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:ring-1 has-data-[state=checked]:ring-primary/20 ${
+              sttProvider !== "deepgram" ? "hover:border-muted-foreground/25" : ""
+            }`}
+          >
+            <RadioGroupItem value="deepgram" className="mt-0.5" />
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-foreground">
+                Cloud (Deepgram)
+              </span>
+              <p className="text-[0.625rem] leading-relaxed text-muted-foreground">
+                Uses Deepgram Nova-3 for real-time streaming transcription.
+                Requires an API key and internet connection. Best accuracy with
+                keyword boosting for Bible terms.
+              </p>
+            </div>
+          </label>
+
+          {/* Whisper (local) */}
+          <label
+            className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:ring-1 has-data-[state=checked]:ring-primary/20 ${
+              sttProvider !== "whisper" ? "hover:border-muted-foreground/25" : ""
+            }`}
+          >
+            <RadioGroupItem value="whisper" className="mt-0.5" />
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-foreground">
+                Local (Whisper)
+              </span>
+              <p className="text-[0.625rem] leading-relaxed text-muted-foreground">
+                Runs Whisper large-v3-turbo locally on your device. Fully
+                offline, no API key needed. Audio never leaves your machine.
+              </p>
+            </div>
+          </label>
+        </RadioGroup>
+      </div>
+
+      {/* Deepgram settings — show when deepgram is selected */}
+      {sttProvider === "deepgram" && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Deepgram API Key
+            </label>
+            {deepgramApiKey && (
+              <Badge variant="outline" className="text-[0.5rem]">
+                Key configured
+              </Badge>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              type="password"
+              placeholder="Enter your Deepgram API key..."
+              value={keyValue}
+              onChange={(e) => setKeyValue(e.target.value)}
+              className="flex-1 text-xs"
+            />
+            <Button size="sm" onClick={handleSaveKey}>
+              {saved ? (
+                <>
+                  <CheckIcon className="size-3" />
+                  Saved
+                </>
+              ) : (
+                "Save"
+              )}
+            </Button>
+          </div>
+          <p className="text-[0.625rem] text-muted-foreground">
+            Required for live transcription. Get a key at{" "}
+            <span className="text-primary">deepgram.com</span>
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
 /*  Section: Display Mode                                                     */
 /* -------------------------------------------------------------------------- */
 
@@ -275,51 +396,31 @@ function DisplayModeSection() {
 /* -------------------------------------------------------------------------- */
 
 function ApiKeysSection() {
-  const { deepgramApiKey, setDeepgramApiKey } = useSettingsStore()
-  const [keyValue, setKeyValue] = useState(deepgramApiKey ?? "")
-  const [saved, setSaved] = useState(false)
-
-  const handleSave = () => {
-    setDeepgramApiKey(keyValue || null)
-    setSaved(true)
-    setTimeout(() => setSaved(false), 2000)
-  }
+  const { deepgramApiKey, sttProvider } = useSettingsStore()
 
   return (
     <div className="flex flex-col gap-6">
+      {/* Deepgram key status (configured in Speech Recognition section) */}
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
           <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Deepgram API Key
           </label>
-          {deepgramApiKey && (
+          {deepgramApiKey ? (
             <Badge variant="outline" className="text-[0.5rem]">
               Key configured
             </Badge>
+          ) : (
+            <Badge variant="outline" className="text-[0.5rem] text-muted-foreground">
+              Not set
+            </Badge>
           )}
         </div>
-        <div className="flex gap-2">
-          <Input
-            type="password"
-            placeholder="Enter your Deepgram API key..."
-            value={keyValue}
-            onChange={(e) => setKeyValue(e.target.value)}
-            className="flex-1 text-xs"
-          />
-          <Button size="sm" onClick={handleSave}>
-            {saved ? (
-              <>
-                <CheckIcon className="size-3" />
-                Saved
-              </>
-            ) : (
-              "Save"
-            )}
-          </Button>
-        </div>
         <p className="text-[0.625rem] text-muted-foreground">
-          Required for live transcription. Get a key at{" "}
-          <span className="text-primary">deepgram.com</span>
+          {sttProvider === "whisper"
+            ? "Not required when using local Whisper. "
+            : "Required for cloud transcription. "}
+          Configure in the Speech Recognition section.
         </p>
       </div>
     </div>
@@ -332,6 +433,7 @@ function ApiKeysSection() {
 
 const sectionTitles: Record<NavSection, string> = {
   audio: "Audio",
+  speech: "Speech Recognition",
   bible: "Bible Translation",
   display: "Display Mode",
   remote: "Remote Control",
@@ -768,6 +870,7 @@ function StatusDot({ running }: { running: boolean }) {
 
 const sectionComponents: Record<NavSection, React.FC> = {
   audio: AudioSection,
+  speech: SpeechSection,
   bible: BibleSection,
   display: DisplayModeSection,
   remote: RemoteControlSection,

--- a/src/hooks/use-transcription.ts
+++ b/src/hooks/use-transcription.ts
@@ -31,7 +31,12 @@ export function useTranscription() {
   })
 
   const startTranscription = useCallback(async () => {
-    await invoke("start_transcription")
+    const { useSettingsStore } = await import("@/stores")
+    const settings = useSettingsStore.getState()
+    await invoke("start_transcription", {
+      apiKey: settings.sttProvider === "deepgram" ? (settings.deepgramApiKey ?? "") : "",
+      provider: settings.sttProvider,
+    })
     store.setTranscribing(true)
   }, [store])
 

--- a/src/lib/settings-dialog.ts
+++ b/src/lib/settings-dialog.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
 
-type SettingsSection = "audio" | "bible" | "display" | "api-keys" | "help"
+type SettingsSection = "audio" | "speech" | "bible" | "display" | "api-keys" | "help"
 
 interface SettingsDialogState {
   isOpen: boolean

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand"
 
+type SttProvider = "deepgram" | "whisper"
+
 interface SettingsState {
   deepgramApiKey: string | null
   openaiApiKey: string | null
@@ -11,6 +13,7 @@ interface SettingsState {
   confidenceThreshold: number
   cooldownMs: number
   onboardingComplete: boolean
+  sttProvider: SttProvider
 
   setDeepgramApiKey: (key: string | null) => void
   setOpenaiApiKey: (key: string | null) => void
@@ -22,6 +25,7 @@ interface SettingsState {
   setConfidenceThreshold: (threshold: number) => void
   setCooldownMs: (ms: number) => void
   setOnboardingComplete: (complete: boolean) => void
+  setSttProvider: (provider: SttProvider) => void
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
@@ -35,6 +39,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   confidenceThreshold: 0.8,
   cooldownMs: 2500,
   onboardingComplete: false,
+  sttProvider: "deepgram",
 
   setDeepgramApiKey: (deepgramApiKey) => set({ deepgramApiKey }),
   setOpenaiApiKey: (openaiApiKey) => set({ openaiApiKey }),
@@ -46,4 +51,5 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   setConfidenceThreshold: (confidenceThreshold) => set({ confidenceThreshold }),
   setCooldownMs: (cooldownMs) => set({ cooldownMs }),
   setOnboardingComplete: (onboardingComplete) => set({ onboardingComplete }),
+  setSttProvider: (sttProvider) => set({ sttProvider }),
 }))


### PR DESCRIPTION
Adds offline transcription using whisper.cpp (large-v3-turbo) via
  whisper-rs, so the app can transcribe sermons without an API key or
  internet connection. Deepgram remains available as the cloud option.

  - SttProvider trait abstraction for swappable STT backends
  - WhisperProvider with VAD-gated audio buffering + Metal GPU inference
  - Bundled ggml-large-v3-turbo-q8_0 model (downloaded at build time)
  - Speech Recognition settings section with provider toggle
  - Anti-hallucination: no_speech_thold, suppress_blank, tuned VAD

  ## Summary
  - Adds local Whisper STT as an alternative to Deepgram cloud transcription
  - Users can switch between Cloud (Deepgram) and Local (Whisper) in Settings → Speech Recognition
  - Whisper model is bundled at build time via `bun run download:whisper` (included in `setup:all`)
  - No API key or internet required for local mode

  ## Test plan
  - [x] `bun run setup:all` downloads Whisper model as Phase 8
  - [x] Settings → Speech Recognition → toggle between Deepgram and Whisper
  - [x] Start transcription with Whisper → speak → transcript appears
  - [x] Start transcription with Deepgram → still works as before
  - [x] Silence produces no hallucinated text with Whisper

## Description

<!-- What does this PR do? Reference any related issues (e.g., `fixes #123`). -->

## Type of change

<!-- Check the one that applies: -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

<!-- Check all that apply: -->

- [x] Frontend (React / TypeScript)
- [x] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [x] Audio / STT

## Checklist

- [x] I have tested this change locally
- [x] `bun run typecheck` passes
- [x] `cargo clippy` passes without warnings
- [x] `bun run test` passes (if applicable)
- [x] I have added tests for new functionality (if applicable)
- [x] UI changes include a screenshot or recording below

## Tested on

<!-- Check the platforms you tested on: -->

- [x] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

<!-- If this PR includes UI changes, add screenshots or recordings here. -->
