### PR TITLE
feat: lock into book/chapter as soon as it's mentioned

### DIFF
--- a/src-tauri/crates/detection/src/direct/detector.rs
+++ b/src-tauri/crates/detection/src/direct/detector.rs
@@ -138,8 +138,8 @@ fn is_valid_reference(book_number: i32, chapter: i32) -> bool {
 }
 
 /// Confidence assigned to chapter-only references (no verse specified).
-/// Lower than full references (0.90+) since the user likely wants a specific verse.
-const CHAPTER_ONLY_CONFIDENCE: f64 = 0.75;
+/// Set above the auto-queue threshold (0.80) so partial refs reach the queue immediately.
+const CHAPTER_ONLY_CONFIDENCE: f64 = 0.85;
 
 /// Filler phrases commonly found in sermon transcripts that confuse detection.
 /// These are stripped (case-insensitively) before the text reaches the automaton.
@@ -337,26 +337,18 @@ impl DirectDetector {
             return detections;
         }
 
-        // Step 0c: Check if there's a pending incomplete reference
-        // Try to complete it with the current text, or emit it if timed out.
+        // Step 0c: Check if there's a pending incomplete reference.
+        // Try to complete it with a verse continuation, or expire it on timeout.
+        // The chapter-only detection was already emitted when first seen — no
+        // re-emission needed on timeout.
         if let Some(ref incomplete) = self.incomplete.clone() {
             let elapsed = incomplete.timestamp.elapsed().as_millis();
             if elapsed > INCOMPLETE_REF_TIMEOUT_MS {
-                // Timeout: emit the chapter-only reference (verse 1)
-                let mut ref_with_verse = incomplete.verse_ref.clone();
-                ref_with_verse.verse_start = 1;
-                detections.push(self.make_direct_detection(
-                    &ref_with_verse,
-                    CHAPTER_ONLY_CONFIDENCE,
-                    text,
-                    0,
-                    text.len(),
-                ));
-                self.push_recent(&ref_with_verse);
-                self.context.update(&ref_with_verse);
+                // Timeout: chapter-only ref was already emitted immediately.
+                // Just clean up the pending state (EDGE-02).
                 self.incomplete = None;
             } else if let Some(verse) = try_extract_verse_continuation(text) {
-                // Completed! Merge the verse into the incomplete ref.
+                // Verse spoken — refine the chapter-only detection (DET-02).
                 let mut completed = incomplete.verse_ref.clone();
                 completed.verse_start = verse;
                 detections.push(self.make_direct_detection(
@@ -369,7 +361,7 @@ impl DirectDetector {
                 self.push_recent(&completed);
                 self.context.update(&completed);
                 self.incomplete = None;
-                return detections; // The continuation IS the detection
+                return detections;
             }
         }
 
@@ -410,8 +402,39 @@ impl DirectDetector {
                     continue;
                 }
 
-                // Chapter-only: hold as incomplete reference, wait for verse
+                // Chapter-only: emit immediately with verse 1, hold for refinement (DET-01)
                 if resolved.verse_start == 0 {
+                    // Skip re-emission if this exact book+chapter is already pending
+                    let already_pending = self.incomplete.as_ref().is_some_and(|inc| {
+                        inc.verse_ref.book_number == resolved.book_number
+                            && inc.verse_ref.chapter == resolved.chapter
+                    });
+
+                    if !already_pending {
+                        // Emit chapter-only detection immediately (defaults to verse 1)
+                        let mut ref_with_verse = resolved.clone();
+                        ref_with_verse.verse_start = 1;
+
+                        let snippet = extract_snippet(text, book_match.start, book_match.end);
+                        #[expect(clippy::cast_possible_truncation, reason = "timestamp millis won't exceed u64 for centuries")]
+                        let now = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as u64;
+
+                        detections.push(Detection {
+                            verse_ref: ref_with_verse.clone(),
+                            verse_id: None,
+                            confidence: CHAPTER_ONLY_CONFIDENCE,
+                            source: DetectionSource::DirectReference,
+                            transcript_snippet: snippet,
+                            detected_at: now,
+                            is_chapter_only: true,
+                        });
+                        self.push_recent(&ref_with_verse);
+                    }
+
+                    // Store/refresh as incomplete for verse refinement
                     self.incomplete = Some(IncompleteRef {
                         verse_ref: resolved.clone(),
                         timestamp: Instant::now(),
@@ -439,6 +462,7 @@ impl DirectDetector {
                     source: DetectionSource::DirectReference,
                     transcript_snippet: snippet,
                     detected_at: now,
+                    is_chapter_only: false,
                 };
 
                 // Track in recent detections for "previous verse" support
@@ -470,6 +494,7 @@ impl DirectDetector {
                         source: DetectionSource::DirectReference,
                         transcript_snippet: text.to_string(),
                         detected_at: now,
+                        is_chapter_only: false,
                     });
                 }
             }
@@ -517,6 +542,7 @@ impl DirectDetector {
             source: DetectionSource::DirectReference,
             transcript_snippet: snippet,
             detected_at: now,
+            is_chapter_only: false,
         }
     }
 }
@@ -666,30 +692,90 @@ mod tests {
     }
 
     #[test]
-    fn test_chapter_only_held_as_incomplete() {
-        // Chapter-only references are held as incomplete, waiting for verse completion
+    fn test_chapter_only_emitted_immediately() {
+        // Chapter-only references are emitted immediately with verse=1 and is_chapter_only=true
         let mut detector = DirectDetector::new();
         let results = detector.detect("Genesis 3 is about the fall of man");
-        // Not emitted yet — held as incomplete
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_name, "Genesis");
+        assert_eq!(results[0].verse_ref.chapter, 3);
+        assert_eq!(results[0].verse_ref.verse_start, 1);
+        assert!(results[0].is_chapter_only);
+        assert!((results[0].confidence - 0.85).abs() < f64::EPSILON);
+        // Also held as incomplete for verse refinement
+        assert!(detector.incomplete.is_some());
+    }
+
+    #[test]
+    fn test_chapter_only_no_duplicate_on_repeat() {
+        // Same book+chapter in a subsequent call should not re-emit
+        let mut detector = DirectDetector::new();
+        let results = detector.detect("Genesis 3");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_chapter_only);
+
+        // Same text again — already pending, skip re-emission
+        let results = detector.detect("Genesis 3");
         assert!(results.is_empty());
         assert!(detector.incomplete.is_some());
     }
 
     #[test]
     fn test_incomplete_ref_completed_by_verse() {
-        // An incomplete reference can be completed by a subsequent "verse N" text
+        // Chapter-only emitted first, then refined by verse continuation
         let mut detector = DirectDetector::new();
-        // First: chapter-only
+        // First: chapter-only — emitted immediately
         let results = detector.detect("Genesis 3");
-        assert!(results.is_empty());
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_chapter_only);
         assert!(detector.incomplete.is_some());
 
-        // Second: verse continuation
+        // Second: verse continuation — refines the detection
         let results = detector.detect("verse 15");
-        assert!(!results.is_empty());
+        assert_eq!(results.len(), 1);
         assert_eq!(results[0].verse_ref.book_name, "Genesis");
         assert_eq!(results[0].verse_ref.chapter, 3);
         assert_eq!(results[0].verse_ref.verse_start, 15);
+        assert!(!results[0].is_chapter_only);
+        assert!(detector.incomplete.is_none());
+    }
+
+    #[test]
+    fn test_new_book_supersedes_incomplete() {
+        // EDGE-01: a new book/chapter replaces the pending incomplete cleanly
+        let mut detector = DirectDetector::new();
+        let results = detector.detect("Genesis 3");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_name, "Genesis");
+
+        // Different book — supersedes Genesis 3
+        let results = detector.detect("let's look at John 1");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_name, "John");
+        assert_eq!(results[0].verse_ref.chapter, 1);
+        assert!(results[0].is_chapter_only);
+        // Incomplete now tracks John 1, not Genesis 3
+        let inc = detector.incomplete.as_ref().unwrap();
+        assert_eq!(inc.verse_ref.book_name, "John");
+    }
+
+    #[test]
+    fn test_abandoned_partial_no_stale_state() {
+        // EDGE-02: after timeout, incomplete is cleaned up without re-emission
+        let mut detector = DirectDetector::new();
+        let results = detector.detect("Genesis 3");
+        assert_eq!(results.len(), 1);
+        assert!(detector.incomplete.is_some());
+
+        // Simulate timeout by replacing with an expired timestamp
+        detector.incomplete = Some(IncompleteRef {
+            verse_ref: detector.incomplete.as_ref().unwrap().verse_ref.clone(),
+            timestamp: Instant::now() - std::time::Duration::from_secs(10),
+        });
+
+        // Next detect call should clean up without emitting
+        let results = detector.detect("something unrelated");
+        assert!(results.is_empty());
         assert!(detector.incomplete.is_none());
     }
 

--- a/src-tauri/crates/detection/src/merger.rs
+++ b/src-tauri/crates/detection/src/merger.rs
@@ -161,6 +161,7 @@ mod tests {
             source,
             transcript_snippet: format!("{book_name} {chapter}:{verse_start}"),
             detected_at: 0,
+            is_chapter_only: false,
         }
     }
 

--- a/src-tauri/crates/detection/src/pipeline.rs
+++ b/src-tauri/crates/detection/src/pipeline.rs
@@ -156,6 +156,7 @@ impl DetectionPipeline {
                 source: DetectionSource::Semantic { similarity: confidence },
                 transcript_snippet: snippet.clone(),
                 detected_at: now,
+                is_chapter_only: false,
             });
         }
 

--- a/src-tauri/crates/detection/src/semantic/detector.rs
+++ b/src-tauri/crates/detection/src/semantic/detector.rs
@@ -196,6 +196,7 @@ impl SemanticDetector {
             },
             transcript_snippet: snippet.to_string(),
             detected_at,
+            is_chapter_only: false,
         }
     }
 }

--- a/src-tauri/crates/detection/src/types.rs
+++ b/src-tauri/crates/detection/src/types.rs
@@ -28,4 +28,8 @@ pub struct Detection {
     pub source: DetectionSource,
     pub transcript_snippet: String,
     pub detected_at: u64,
+    /// True when the detection was emitted from a chapter-only reference (no verse spoken yet).
+    /// The verse defaults to 1 and may be refined later when the speaker says the verse number.
+    #[serde(default)]
+    pub is_chapter_only: bool,
 }

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -32,6 +32,8 @@ pub struct DetectionResult {
     pub source: String,
     pub auto_queued: bool,
     pub transcript_snippet: String,
+    /// True when detected from a chapter-only reference (verse defaults to 1, may be refined).
+    pub is_chapter_only: bool,
 }
 
 fn source_to_string(source: &rhema_detection::DetectionSource) -> String {
@@ -89,6 +91,7 @@ pub fn to_result(state: &AppState, merged: &MergedDetection) -> DetectionResult 
         source: source_to_string(&merged.detection.source),
         auto_queued: merged.auto_queued,
         transcript_snippet: merged.detection.transcript_snippet.clone(),
+        is_chapter_only: merged.detection.is_chapter_only,
     }
 }
 

--- a/src-tauri/src/commands/stt.rs
+++ b/src-tauri/src/commands/stt.rs
@@ -408,6 +408,7 @@ fn run_direct_detection(app: &AppHandle, transcript: &str) -> bool {
                     source: "direct".to_string(),
                     auto_queued: m.auto_queued,
                     transcript_snippet: m.detection.transcript_snippet.clone(),
+                    is_chapter_only: m.detection.is_chapter_only,
                 }
             })
             .collect();
@@ -628,6 +629,7 @@ fn check_reading_mode(app: &AppHandle, transcript: &str, direct_found: bool) -> 
                         source: "contextual".to_string(),
                         auto_queued: true,
                         transcript_snippet: String::new(),
+                        is_chapter_only: false,
                     };
                     let _ = app.emit("verse_detections", &vec![result]);
 
@@ -662,6 +664,7 @@ fn check_reading_mode(app: &AppHandle, transcript: &str, direct_found: bool) -> 
             source: "contextual".to_string(),
             auto_queued: true,
             transcript_snippet: String::new(),
+            is_chapter_only: false,
         };
         let _ = app.emit("verse_detections", &vec![result]);
         return true;

--- a/src/components/panels/queue-panel.tsx
+++ b/src/components/panels/queue-panel.tsx
@@ -6,6 +6,7 @@ import {
   PlayIcon,
   XIcon,
   GripVerticalIcon,
+  BookOpenIcon,
 } from "lucide-react"
 import { useQueueStore, useBroadcastStore, useBibleStore } from "@/stores"
 import { toVerseRenderData } from "@/hooks/use-broadcast"
@@ -47,6 +48,16 @@ function QueueItemRow({
       </Badge>
     )
 
+  const chapterOnlyBadge = item.is_chapter_only ? (
+    <Badge
+      variant="outline"
+      className="shrink-0 gap-0.5 border-amber-500/30 bg-amber-500/10 text-[0.5rem] text-amber-600 dark:text-amber-400"
+    >
+      <BookOpenIcon className="size-2" />
+      Ch.
+    </Badge>
+  ) : null
+
   return (
     <div
       className={cn(
@@ -64,6 +75,7 @@ function QueueItemRow({
         {item.reference}
       </span>
 
+      {chapterOnlyBadge}
       {sourceBadge}
 
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">

--- a/src/components/panels/queue-panel.tsx
+++ b/src/components/panels/queue-panel.tsx
@@ -6,7 +6,6 @@ import {
   PlayIcon,
   XIcon,
   GripVerticalIcon,
-  BookOpenIcon,
 } from "lucide-react"
 import { useQueueStore, useBroadcastStore, useBibleStore } from "@/stores"
 import { toVerseRenderData } from "@/hooks/use-broadcast"
@@ -48,16 +47,6 @@ function QueueItemRow({
       </Badge>
     )
 
-  const chapterOnlyBadge = item.is_chapter_only ? (
-    <Badge
-      variant="outline"
-      className="shrink-0 gap-0.5 border-amber-500/30 bg-amber-500/10 text-[0.5rem] text-amber-600 dark:text-amber-400"
-    >
-      <BookOpenIcon className="size-2" />
-      Ch.
-    </Badge>
-  ) : null
-
   return (
     <div
       className={cn(
@@ -75,7 +64,6 @@ function QueueItemRow({
         {item.reference}
       </span>
 
-      {chapterOnlyBadge}
       {sourceBadge}
 
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -82,7 +82,7 @@ export function TranscriptPanel() {
     // Auto-navigate book search + select verse for preview/live
     // Auto-navigate on direct detection hits
     const directHit = detections.find(
-      (d) => d.source === "direct"
+      (d) => d.source === "direct" && !d.is_chapter_only
     )
     if (directHit && directHit.book_number > 0) {
       // Select verse immediately so preview/live panels update

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -108,6 +108,23 @@ export function TranscriptPanel() {
 
     // Auto-queue high-confidence detections
     for (const d of detections) {
+      // Check if this detection refines an existing chapter-only queue item
+      if (
+        !d.is_chapter_only &&
+        d.source === "direct" &&
+        useQueueStore
+          .getState()
+          .updateEarlyRef(
+            d.book_number,
+            d.chapter,
+            d.verse,
+            d.verse_ref,
+            d.verse_text,
+          )
+      ) {
+        continue
+      }
+
       if (d.auto_queued) {
         useQueueStore.getState().addItem({
           id: crypto.randomUUID(),
@@ -125,6 +142,7 @@ export function TranscriptPanel() {
           confidence: d.confidence,
           source: d.source === "direct" ? "ai-direct" : "ai-semantic",
           added_at: Date.now(),
+          is_chapter_only: d.is_chapter_only,
         })
       }
     }

--- a/src/stores/queue-store.ts
+++ b/src/stores/queue-store.ts
@@ -19,7 +19,7 @@ export const useQueueStore = create<QueueState>((set) => ({
   activeIndex: null,
 
   addItem: (item) =>
-    set((state) => ({ items: [...state.items, item] })),
+    set((state) => ({ items: [item, ...state.items] })),
   removeItem: (id) =>
     set((state) => ({
       items: state.items.filter((i) => i.id !== id),

--- a/src/stores/queue-store.ts
+++ b/src/stores/queue-store.ts
@@ -10,6 +10,8 @@ interface QueueState {
   reorderItems: (fromIndex: number, toIndex: number) => void
   setActive: (index: number | null) => void
   clearQueue: () => void
+  /** Update a chapter-only queue item in place when the verse is refined. */
+  updateEarlyRef: (bookNumber: number, chapter: number, verse: number, reference: string, verseText: string) => boolean
 }
 
 export const useQueueStore = create<QueueState>((set) => ({
@@ -31,4 +33,25 @@ export const useQueueStore = create<QueueState>((set) => ({
     }),
   setActive: (activeIndex) => set({ activeIndex }),
   clearQueue: () => set({ items: [], activeIndex: null }),
+  updateEarlyRef: (bookNumber, chapter, verse, reference, verseText) => {
+    let found = false
+    set((state) => {
+      const idx = state.items.findIndex(
+        (i) =>
+          i.is_chapter_only &&
+          i.verse.book_number === bookNumber &&
+          i.verse.chapter === chapter,
+      )
+      if (idx === -1) return state
+      found = true
+      const items = [...state.items]
+      const item = { ...items[idx] }
+      item.verse = { ...item.verse, verse, text: verseText }
+      item.reference = reference
+      item.is_chapter_only = false
+      items[idx] = item
+      return { items }
+    })
+    return found
+  },
 }))

--- a/src/types/detection.ts
+++ b/src/types/detection.ts
@@ -9,6 +9,8 @@ export interface DetectionResult {
   source: "direct" | "semantic"
   auto_queued: boolean
   transcript_snippet: string
+  /** True when detected from a chapter-only reference (verse defaults to 1, may be refined). */
+  is_chapter_only: boolean
 }
 
 export interface DetectionStatus {

--- a/src/types/queue.ts
+++ b/src/types/queue.ts
@@ -7,4 +7,6 @@ export interface QueueItem {
   confidence: number
   source: "manual" | "ai-direct" | "ai-semantic" | "ai-cloud"
   added_at: number
+  /** True when queued from a chapter-only detection (verse defaults to 1, may be refined). */
+  is_chapter_only?: boolean
 }


### PR DESCRIPTION
Closes #12

When a preacher says "Exodus chapter 3" and continues speaking, the app now immediately queues **Exo 3:1** instead of waiting 5 seconds for a verse number. When the verse is spoken later (e.g., "verse 14"), the queue item updates in place to **Exo 3:14** — no duplicates.

- **Before:** chapter-only references were held silently for 5 seconds, then emitted with verse defaulting to 1. Confidence (0.75) was below the auto-queue threshold so they never reached the queue automatically.
- **After:** chapter-only references emit immediately, confidence raised to 0.85 (above auto-queue threshold), and the queue item refines in place when the verse arrives.

## What changed

### Backend (Rust — detection crate)

- **Immediate emission:** chapter-only refs emit right away with `is_chapter_only: true` and `verse_start: 1` instead of being held as incomplete
- **Verse refinement:** when a verse continuation is spoken, a follow-up detection is emitted (not a duplicate — it updates the original)
- **Timeout cleanup:** the 5-second timeout now only clears internal state — no re-emission since we already emitted on detection
- **Dedup guard:** same book+chapter repeated in partial/final transcripts doesn't produce duplicate emissions
- **Edge cases:** new book/chapter cleanly supersedes any pending incomplete; abandoned partials leave no stale state
- **`is_chapter_only` field** added to `Detection` and `DetectionResult` types across the pipeline

### Frontend (React — queue + transcript)

- **Auto-queue:** chapter-only detections are added to the queue automatically (confidence 0.85 >= 0.80 threshold)
- **In-place update:** `updateEarlyRef()` in queue store matches chapter-only items by book+chapter and refines the verse
- **No book search navigation:** chapter-only detections skip the auto-navigate/selectVerse logic — only the queue is affected
- **Newest first:** queue items are prepended so the most recent detection appears at the top

## Files changed (11 files, +173 / -29)

| File | Change |
|------|--------|
| `src-tauri/crates/detection/src/types.rs` | `is_chapter_only` field on `Detection` |
| `src-tauri/crates/detection/src/direct/detector.rs` | Core logic: immediate emit, refinement, edge cases, 4 new tests |
| `src-tauri/crates/detection/src/merger.rs` | `is_chapter_only` passthrough in test helper |
| `src-tauri/crates/detection/src/pipeline.rs` | `is_chapter_only` on FTS5 detections |
| `src-tauri/crates/detection/src/semantic/detector.rs` | `is_chapter_only` on semantic detections |
| `src-tauri/src/commands/detection.rs` | `is_chapter_only` on `DetectionResult` |
| `src-tauri/src/commands/stt.rs` | `is_chapter_only` on inline `DetectionResult` constructors |
| `src/types/detection.ts` | `is_chapter_only` on frontend `DetectionResult` |
| `src/types/queue.ts` | `is_chapter_only` on `QueueItem` |
| `src/stores/queue-store.ts` | `updateEarlyRef()`, prepend new items |
| `src/components/panels/transcript-panel.tsx` | Refinement handling, skip nav for chapter-only |

## Test plan

- [x] 120 detection crate tests pass (including 4 new edge case tests)
- [x] 208 total Rust tests pass across all crates
- [x] TypeScript compiles with zero errors
- [x] ESLint passes on all changed files
- [x] Manual: say "Exodus chapter 3" — queue shows Exo 3:1 immediately, book search does not navigate
- [x] Manual: then say "verse 14" — queue item updates to Exo 3:14 in place
- [x] Manual: say "Genesis 5" then "John 1" — Genesis superseded, John 1:1 in queue, no duplicates
- [x] Manual: say "Matthew 5" and wait 5+ seconds — queue item stays as Matthew 5:1, no stale state

## Demo

https://github.com/user-attachments/assets/8a3df2f4-573b-4621-856b-5144a89424b8


