### PR TITLE
feat: improve queue UX with dedup indicators, default verse, and layout fixes

### DIFF
--- a/src/components/panels/queue-panel.tsx
+++ b/src/components/panels/queue-panel.tsx
@@ -51,6 +51,7 @@ function QueueItemRow({
 
   return (
     <div
+      data-queue-idx={index}
       className={cn(
         "group flex h-10 items-center gap-2 rounded-md px-2.5 transition-colors",
         isHighlighted

--- a/src/components/panels/search-panel.tsx
+++ b/src/components/panels/search-panel.tsx
@@ -85,12 +85,25 @@ export function SearchPanel() {
     selectedVerse,
   } = useBible()
 
+  const queueItems = useQueueStore((s) => s.items)
+  const queuedVerseKeys = useMemo(() => {
+    return new Set(
+      queueItems.map((item) => `${item.verse.book_number}:${item.verse.chapter}:${item.verse.verse}`)
+    )
+  }, [queueItems])
+
   const selectedBookNumber = selectedBook?.book_number
 
-  // Load initial data
+  // Load initial data and default to Genesis 1:1
   useEffect(() => {
     bibleActions.loadTranslations().catch(console.error)
-    bibleActions.loadBooks().catch(console.error)
+    bibleActions.loadBooks().then(() => {
+      useBibleStore.getState().setPendingNavigation({
+        bookNumber: 1,
+        chapter: 1,
+        verse: 1,
+      })
+    }).catch(console.error)
   }, [])
 
   // Load chapter when book + chapter are set
@@ -359,7 +372,7 @@ export function SearchPanel() {
     <div
       ref={panelRef}
       data-slot="search-panel"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card outline-none"
       onKeyDown={activeTab === "book" ? handleKeyDown : undefined}
       tabIndex={-1}
     >
@@ -560,7 +573,7 @@ export function SearchPanel() {
                     "group flex cursor-pointer items-center gap-3 rounded-lg p-3 transition-colors",
                     verse.id === effectiveSelectedVerseId
                       ? "border border-lime-500/50 bg-lime-500/10"
-                      : "hover:bg-muted/50"
+                      : "border border-transparent hover:bg-muted/50"
                   )}
                 >
                   <span className="w-6 shrink-0 text-right text-sm font-semibold text-primary">
@@ -569,39 +582,61 @@ export function SearchPanel() {
                   <p className="flex-1 text-sm leading-relaxed text-foreground/80">
                     {verse.text}
                   </p>
-                  {verse.id === effectiveSelectedVerseId && (
-                    <CheckIcon className="size-4 shrink-0 text-ai-direct" />
+                  {queuedVerseKeys.has(`${verse.book_number}:${verse.chapter}:${verse.verse}`) ? (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="flex size-6 shrink-0 cursor-pointer items-center justify-center"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              const store = useQueueStore.getState()
+                              const idx = store.findDuplicate(verse.book_number, verse.chapter, verse.verse)
+                              if (idx !== -1) {
+                                store.flashItem(store.items[idx].id)
+                                document.querySelector(`[data-slot="queue-panel"] [data-queue-idx="${idx}"]`)
+                                  ?.scrollIntoView({ behavior: "smooth", block: "nearest" })
+                              }
+                            }}
+                          >
+                            <CheckIcon className="size-4 text-ai-direct" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="left">Already in queue</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            className={cn(
+                              "shrink-0 opacity-0 group-hover:opacity-100 transition-opacity",
+                              verse.id === effectiveSelectedVerseId
+                                ? "hover:bg-lime-500/20 hover:text-lime-500"
+                                : "bg-primary/40! text-primary-foreground hover:bg-primary!"
+                            )}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              useQueueStore.getState().addItem({
+                                id: crypto.randomUUID(),
+                                verse,
+                                reference: `${verse.book_name} ${verse.chapter}:${verse.verse}`,
+                                confidence: 1,
+                                source: "manual",
+                                added_at: Date.now(),
+                              })
+                            }}
+                          >
+                            <PlusIcon className="size-3" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="left">Add to queue</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                   )}
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon-xs"
-                          className={cn(
-                            "shrink-0 opacity-0 group-hover:opacity-100 transition-opacity",
-                            verse.id === effectiveSelectedVerseId
-                              ? "hover:bg-lime-500/20 hover:text-lime-500"
-                              : "bg-primary/40! text-primary-foreground hover:bg-primary!"
-                          )}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            useQueueStore.getState().addItem({
-                              id: crypto.randomUUID(),
-                              verse,
-                              reference: `${verse.book_name} ${verse.chapter}:${verse.verse}`,
-                              confidence: 1,
-                              source: "manual",
-                              added_at: Date.now(),
-                            })
-                          }}
-                        >
-                          <PlusIcon className="size-3" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="left">Add to queue</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
                 </div>
               ))}
             </div>
@@ -653,40 +688,65 @@ export function SearchPanel() {
                 <p className="flex-1 text-xs leading-relaxed text-muted-foreground">
                   <HighlightedText text={result.verse_text} query={contextQuery} />
                 </p>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        className="absolute right-2 top-1/2 -translate-y-1/2 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity bg-primary text-primary-foreground hover:bg-primary/80"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          useQueueStore.getState().addItem({
-                            id: crypto.randomUUID(),
-                            verse: {
-                              id: 0,
-                              translation_id: activeTranslationId,
-                              book_number: result.book_number,
-                              book_name: result.book_name,
-                              book_abbreviation: "",
-                              chapter: result.chapter,
-                              verse: result.verse,
-                              text: result.verse_text,
-                            },
-                            reference: `${result.book_name} ${result.chapter}:${result.verse}`,
-                            confidence: result.similarity,
-                            source: "manual",
-                            added_at: Date.now(),
-                          })
-                        }}
-                      >
-                        <PlusIcon className="size-3" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="left">Add to queue</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                {queuedVerseKeys.has(`${result.book_number}:${result.chapter}:${result.verse}`) ? (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className="flex size-6 absolute right-2 top-1/2 -translate-y-1/2 shrink-0 cursor-pointer items-center justify-center"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            const store = useQueueStore.getState()
+                            const idx = store.findDuplicate(result.book_number, result.chapter, result.verse)
+                            if (idx !== -1) {
+                              store.flashItem(store.items[idx].id)
+                              document.querySelector(`[data-slot="queue-panel"] [data-queue-idx="${idx}"]`)
+                                ?.scrollIntoView({ behavior: "smooth", block: "nearest" })
+                            }
+                          }}
+                        >
+                          <CheckIcon className="size-4 text-ai-direct" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="left">Already in queue</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ) : (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity bg-primary text-primary-foreground hover:bg-primary/80"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            useQueueStore.getState().addItem({
+                              id: crypto.randomUUID(),
+                              verse: {
+                                id: 0,
+                                translation_id: activeTranslationId,
+                                book_number: result.book_number,
+                                book_name: result.book_name,
+                                book_abbreviation: "",
+                                chapter: result.chapter,
+                                verse: result.verse,
+                                text: result.verse_text,
+                              },
+                              reference: `${result.book_name} ${result.chapter}:${result.verse}`,
+                              confidence: result.similarity,
+                              source: "manual",
+                              added_at: Date.now(),
+                            })
+                          }}
+                        >
+                          <PlusIcon className="size-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left">Add to queue</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
When a detected verse already exists in the queue, the existing item gets a brief amber pulse highlight instead of being re-added as a duplicate. Complete references are also auto-selected as the active queue item.

- **Before:** the same verse could appear multiple times in the queue — especially during the chapter-only → refinement → repeat cycle (e.g., "Mark ch 1" → "verse 2" → "Mark ch 1" again → "verse 2" = two Mark 1:2 entries).
- **After:** duplicates are caught at two levels. The caller checks before adding and flashes the existing item, and `addItem` itself rejects exact duplicates as a safety net.

## What changed

### Queue store (`queue-store.ts`)

- **`addItem` dedup safety net:** rejects items where the same book+chapter+verse already exists in the queue, regardless of caller
- **`flashItem(id)`:** sets `highlightedId` for 1.5 seconds, triggering an amber pulse animation on the matching queue row
- **`findDuplicate(book, chapter, verse)`:** returns the index of an existing item matching the exact reference, or -1

### Transcript panel (`transcript-panel.tsx`)

- **Chapter-only broad match:** when a chapter-only detection arrives, matches by book+chapter (any verse) — prevents the cycle where "Mark ch 1" refined to Mark 1:2 then "Mark ch 1" again would slip past the exact-verse check
- **Flash + select on duplicate:** instead of silently skipping, flashes the existing queue item and (for complete references) sets it as the active item

### Queue panel (`queue-panel.tsx`)

- **Flash highlight rendering:** `QueueItemRow` accepts `isHighlighted` prop — shows `animate-pulse` with amber border/background when active
- **`highlightedId` subscription:** `QueuePanel` reads `highlightedId` from the store and passes it down
- **`data-queue-idx` attribute:** added to queue rows for scroll-into-view targeting from the search panel

### Search panel (`search-panel.tsx`)

- **Default Genesis 1:1 on startup:** app loads Genesis chapter 1 and selects verse 1 on launch, rendering it in the program preview instead of showing a blank state
- **Queue-aware verse icons:** verses already in the queue show a green checkmark instead of the `+` add button — prevents duplicate manual queue entries. Applied to both Book search and Context search tabs
- **Checkmark click flashes queue item:** clicking the checkmark finds the matching queue item, triggers the amber flash highlight, and scrolls the queue panel to it
- **"Already in queue" tooltip:** hovering the checkmark shows an "Already in queue" tooltip
- **Layout shift fix:** added `border border-transparent` to unselected verse items so they match the selected state's border width, eliminating the 2px shift on selection
- **Removed default focus outline:** suppressed the browser's default focus ring on the search panel container

## Files changed (2 files, +131 / -70)

| File | Change |
|------|--------|
| `src/components/panels/search-panel.tsx` | Default Gen 1:1, queue-aware icons, checkmark flash+scroll, layout shift fix, focus outline removal |
| `src/components/panels/queue-panel.tsx` | `data-queue-idx` attr for scroll-into-view targeting |

## Test plan

- [x] TypeScript compiles with zero errors
- [x] Manual: app opens with Genesis 1:1 loaded in search panel and program preview
- [x] Manual: detect "John 3:16" twice — second time flashes existing item, no duplicate added
- [x] Manual: "Mark ch 1" → "verse 2" → "Mark ch 1" again — flashes existing Mark 1:2, no new entry
- [x] Manual: "Mark ch 1" → "verse 2" → "Mark ch 1" → "verse 5" — Mark 1:2 stays, Mark 1:5 is NOT added (same book+chapter already in queue)
- [x] Manual: flash highlight disappears after ~1.5 seconds
- [x] Manual: complete reference duplicate also auto-selects the existing item (green active border)
- [x] Manual: add verse to queue — checkmark replaces `+` icon, `+` icon disappears
- [x] Manual: hover checkmark — "Already in queue" tooltip appears
- [x] Manual: click checkmark — queue item flashes amber and scrolls into view
- [x] Manual: click checkmark — verse in search panel does NOT get selected/focused
- [x] Manual: selecting/deselecting verses causes no layout shift
- [x] Manual: search panel has no visible focus outline ring

## Demo

https://github.com/user-attachments/assets/b2fea129-85cf-4a2c-9fa3-bd54fe7e4770


