### PR TITLE
feat: replace go-live button with switch toggle

### DIFF
--- a/src/components/panels/live-output-panel.tsx
+++ b/src/components/panels/live-output-panel.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
+import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
 import { useBroadcastStore, useBibleStore } from "@/stores"
 import { deriveLiveVerse } from "@/hooks/use-broadcast"
@@ -38,25 +39,23 @@ export function LiveOutputPanel() {
       )}
     >
       <PanelHeader title="Live display">
-        <button
-          onClick={() => useBroadcastStore.getState().setLive(!isLive)}
-          className={cn(
-            "flex items-center gap-2 rounded-full px-2.5 py-1 text-[0.625rem] font-medium uppercase tracking-wider transition-all",
-            isLive
-              ? "bg-emerald-500/15 text-emerald-400"
-              : "bg-muted text-muted-foreground"
-          )}
-        >
+        <label className="flex items-center gap-2">
           <span
             className={cn(
-              "size-1.5 rounded-full",
-              isLive
-                ? "animate-pulse bg-emerald-400 shadow-[0_0_6px_rgba(16,185,129,0.5)]"
-                : "bg-muted-foreground/50"
+              "text-[0.625rem] font-medium uppercase tracking-wider transition-colors",
+              isLive ? "text-emerald-400" : "text-muted-foreground"
             )}
+          >
+            {isLive ? "Live" : "Go live"}
+          </span>
+          <Switch
+            checked={isLive}
+            onCheckedChange={(checked) =>
+              useBroadcastStore.getState().setLive(checked)
+            }
+            className="data-[state=checked]:bg-emerald-500"
           />
-          {isLive ? "Live" : "Go live"}
-        </button>
+        </label>
       </PanelHeader>
 
       <div


### PR DESCRIPTION
Replace the custom pill-shaped "Go live" button in the live output panel with a Radix Switch component for a cleaner, more standard toggle interaction.

- **Before:** a custom `<button>` with a pulsing dot indicator and text toggling between "Go live" / "Live"
- **After:** a proper `<Switch>` toggle that turns emerald green when active, with a text label alongside it

## What changed

### Live output panel (`live-output-panel.tsx`)

- Replaced the pill button with a `<Switch>` from `@/components/ui/switch`
- Switch uses `data-[state=checked]:bg-emerald-500` to match the existing live-state color scheme
- Wrapped in a `<label>` so clicking the text also toggles the switch
- Label text still toggles between "Go live" (muted) and "Live" (emerald)

## Files changed (1 file)

| File | Change |
|------|--------|
| `src/components/panels/live-output-panel.tsx` | Replace go-live button with Switch toggle |

## Test plan

- [x] TypeScript compiles with zero errors
- [x] Manual: live display panel shows a switch toggle instead of a pill button
- [x] Manual: toggling the switch turns it emerald green and activates live mode
- [x] Manual: toggling off returns to muted/inactive state
- [x] Manual: clicking the "Go live" / "Live" label text also toggles the switch

## Demo
<img width="426" height="345" alt="image" src="https://github.com/user-attachments/assets/21b53031-8c3c-4061-9f79-00d9a92a21b4" />
