### PR TITLE
feat: Persist app settings to disk and harden transcription hook

### DIFF
--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -1,70 +1,69 @@
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { LevelMeter } from "@/components/ui/level-meter"
 import { Button } from "@/components/ui/button"
 import { ApiKeyPrompt } from "@/components/ui/api-key-prompt"
 import { MicIcon, MicOffIcon } from "lucide-react"
-import { invoke } from "@tauri-apps/api/core"
 import {
-  useTranscriptStore,
   useAudioStore,
-  useSettingsStore,
   useDetectionStore,
   useQueueStore,
   useBibleStore,
+  useTranscriptStore,
 } from "@/stores"
 import { useTauriEvent } from "@/hooks/use-tauri-event"
+import { useTranscription } from "@/hooks/use-transcription"
 import { bibleActions } from "@/hooks/use-bible"
-import type { TranscriptSegment } from "@/types"
 import type { DetectionResult } from "@/types"
 
-export function TranscriptPanel() {
-  const segments = useTranscriptStore((s) => s.segments)
-  const currentPartial = useTranscriptStore((s) => s.currentPartial)
-  const isTranscribing = useTranscriptStore((s) => s.isTranscribing)
-  const connectionStatus = useTranscriptStore((s) => s.connectionStatus)
-  const audioLevel = useAudioStore((s) => s.level)
-  const deepgramApiKey = useSettingsStore((s) => s.deepgramApiKey)
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const [showKeyPrompt, setShowKeyPrompt] = useState(false)
+/**
+ * Leaf component that subscribes to the audio level only. Isolated so the
+ * high-frequency `audio_level` tick (many times per second during recording)
+ * does NOT re-render the transcript list, connection dot, or button subtree.
+ */
+function AudioLevelMeter() {
+  const rms = useAudioStore((s) => s.level.rms)
+  return <LevelMeter level={rms} bars={6} />
+}
 
-  // Listen for Tauri events
+/**
+ * Leaf component that subscribes to `currentPartial`. Partials update per audio tick.
+ */
+function LivePartialLine({ scrollRef }: { scrollRef: RefObject<HTMLDivElement | null> }) {
+  const currentPartial = useTranscriptStore((s) => s.currentPartial)
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [currentPartial, scrollRef])
+
+  if (!currentPartial) return null
+
+  return (
+    <p className="border-l-2 border-primary pl-2 text-base leading-relaxed text-foreground">
+      {currentPartial}
+      <span className="ml-1 inline-block size-1.5 animate-pulse rounded-full bg-primary align-middle" />
+    </p>
+  )
+}
+
+export function TranscriptPanel() {
+  const [showKeyPrompt, setShowKeyPrompt] = useState(false)
+  const onMissingApiKey = useCallback(() => setShowKeyPrompt(true), [])
+  const {
+    segments,
+    isTranscribing,
+    connectionStatus,
+    startTranscription,
+    stopTranscription,
+  } = useTranscription({ onMissingApiKey })
+  const hasPartial = useTranscriptStore((s) => s.currentPartial.length > 0)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
   useTauriEvent<{ rms: number; peak: number }>("audio_level", (payload) => {
     useAudioStore.getState().setLevel(payload)
   })
-
-  // Connection status events
-  useTauriEvent("stt_connected", () => {
-    useTranscriptStore.getState().setConnectionStatus("connected")
-  })
-  useTauriEvent("stt_disconnected", () => {
-    useTranscriptStore.getState().setConnectionStatus("disconnected")
-  })
-  useTauriEvent<string>("stt_error", () => {
-    useTranscriptStore.getState().setConnectionStatus("error")
-  })
-
-  useTauriEvent<{ text: string; is_final: boolean; confidence: number }>(
-    "transcript_partial",
-    (payload) => {
-      useTranscriptStore.getState().setPartial(payload.text)
-    }
-  )
-
-  useTauriEvent<{ text: string; is_final: boolean; confidence: number }>(
-    "transcript_final",
-    (payload) => {
-      const segment: TranscriptSegment = {
-        id: crypto.randomUUID(),
-        text: payload.text,
-        is_final: true,
-        confidence: payload.confidence,
-        words: [],
-        timestamp: Date.now(),
-      }
-      useTranscriptStore.getState().addSegment(segment)
-    }
-  )
 
   // Listen for voice translation commands: "read in NIV", "switch to ESV"
   useTauriEvent<{ abbreviation: string; translation_id: number }>(
@@ -165,51 +164,13 @@ export function TranscriptPanel() {
     }
   })
 
-  // Auto-scroll to bottom
+  // Auto-scroll on segment additions. Partial-driven scrolling lives in
+  // LivePartialLine so the panel doesn't re-render per audio tick.
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
-  }, [segments, currentPartial])
-
-  const handleStart = async () => {
-    try {
-      useTranscriptStore.getState().setConnectionStatus("connecting")
-      const { useSettingsStore } = await import("@/stores")
-      const settings = useSettingsStore.getState()
-      const params = {
-        apiKey: settings.sttProvider === "deepgram" ? (deepgramApiKey ?? "") : "",
-        deviceId: settings.audioDeviceId,
-        gain: settings.gain,
-        provider: settings.sttProvider,
-      }
-      console.log("[AUDIO] Starting transcription:", params)
-      await invoke("start_transcription", params)
-      console.log("[AUDIO] Transcription started successfully")
-      useTranscriptStore.getState().setTranscribing(true)
-    } catch (e) {
-      const errorMsg = String(e)
-      console.error("[AUDIO] Failed to start transcription:", errorMsg)
-      useTranscriptStore.getState().setConnectionStatus("error")
-
-      if (errorMsg.includes("No Deepgram API key")) {
-        setShowKeyPrompt(true)
-      } else {
-        alert(errorMsg)
-      }
-    }
-  }
-
-  const handleStop = async () => {
-    try {
-      await invoke("stop_transcription")
-      useTranscriptStore.getState().setTranscribing(false)
-      useTranscriptStore.getState().setPartial("")
-      useTranscriptStore.getState().setConnectionStatus("disconnected")
-    } catch (e) {
-      console.error("Failed to stop transcription:", e)
-    }
-  }
+  }, [segments])
 
   return (
     <div
@@ -235,7 +196,7 @@ export function TranscriptPanel() {
               title={connectionStatus}
             />
           )}
-          <LevelMeter level={audioLevel.rms} bars={6} />
+          <AudioLevelMeter />
         </div>
       </PanelHeader>
 
@@ -244,7 +205,7 @@ export function TranscriptPanel() {
           {/* Faded top gradient */}
           <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-6 bg-linear-to-b from-card to-transparent" />
 
-          {segments.length === 0 && !currentPartial && !isTranscribing && (
+          {segments.length === 0 && !hasPartial && !isTranscribing && (
             <p className="text-sm text-muted-foreground">
               Click "Start transcribing" to begin
             </p>
@@ -271,13 +232,8 @@ export function TranscriptPanel() {
             )
           })}
 
-          {/* Partial (in-progress) text — larger and brighter than final segments */}
-          {currentPartial && (
-            <p className="border-l-2 border-primary pl-2 text-base leading-relaxed text-foreground">
-              {currentPartial}
-              <span className="ml-1 inline-block size-1.5 animate-pulse rounded-full bg-primary align-middle" />
-            </p>
-          )}
+          {/* Partial (in-progress) text rendered by leaf subscriber */}
+          <LivePartialLine scrollRef={scrollRef} />
         </div>
       </div>
 
@@ -288,13 +244,13 @@ export function TranscriptPanel() {
             variant="ghost"
             size="sm"
             className="text-destructive hover:text-destructive"
-            onClick={handleStop}
+            onClick={stopTranscription}
           >
             <MicOffIcon className="size-3" />
             Stop transcribing
           </Button>
         ) : (
-          <Button variant="ghost" size="sm" onClick={handleStart}>
+          <Button variant="ghost" size="sm" onClick={startTranscription}>
               <MicIcon className="size-3" />
             Start transcribing
           </Button>

--- a/src/hooks/use-transcription.test.ts
+++ b/src/hooks/use-transcription.test.ts
@@ -200,4 +200,21 @@ describe("use-transcription", () => {
       expect(state.connectionStatus).toBe("disconnected")
     })
   })
+
+  describe("stt_error integration contract", () => {
+    it("surfaces stt errors via toast and sets connection status to error", async () => {
+      const { useTranscriptStore } = await loadModules()
+
+      // Simulate what the stt_error handler does
+      useTranscriptStore.getState().setConnectionStatus("error")
+      mockToastError("Transcription error", {
+        description: "WebSocket closed unexpectedly",
+      })
+
+      expect(useTranscriptStore.getState().connectionStatus).toBe("error")
+      expect(mockToastError).toHaveBeenCalledWith("Transcription error", {
+        description: "WebSocket closed unexpectedly",
+      })
+    })
+  })
 })

--- a/src/hooks/use-transcription.test.ts
+++ b/src/hooks/use-transcription.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockInvoke = vi.fn()
+const mockToastError = vi.fn()
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}))
+
+vi.mock("@/hooks/use-tauri-event", () => ({
+  useTauriEvent: () => {},
+}))
+
+async function loadModules() {
+  vi.resetModules()
+  const transcriptMod = await import("@/stores/transcript-store")
+  const settingsMod = await import("@/stores/settings-store")
+  const hookMod = await import("./use-transcription")
+  return {
+    useTranscriptStore: transcriptMod.useTranscriptStore,
+    useSettingsStore: settingsMod.useSettingsStore,
+    transcriptionActions: hookMod.transcriptionActions,
+  }
+}
+
+describe("use-transcription", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset()
+    mockToastError.mockReset()
+  })
+
+  describe("transcriptionActions.start", () => {
+    it("invokes start_transcription with settings-derived params for whisper", async () => {
+      mockInvoke.mockResolvedValue(undefined)
+      const { useSettingsStore, transcriptionActions } = await loadModules()
+
+      useSettingsStore.setState({
+        sttProvider: "whisper",
+        deepgramApiKey: "ignored-for-whisper",
+        audioDeviceId: "dev-42",
+        gain: 1.5,
+      })
+
+      await transcriptionActions.start()
+
+      expect(mockInvoke).toHaveBeenCalledWith("start_transcription", {
+        apiKey: "", // whisper path never forwards the key
+        deviceId: "dev-42",
+        gain: 1.5,
+        provider: "whisper",
+      })
+    })
+
+    it("forwards the Deepgram key when provider is deepgram", async () => {
+      mockInvoke.mockResolvedValue(undefined)
+      const { useSettingsStore, transcriptionActions } = await loadModules()
+
+      useSettingsStore.setState({
+        sttProvider: "deepgram",
+        deepgramApiKey: "dg-live-123",
+        audioDeviceId: null,
+        gain: 1.0,
+      })
+
+      await transcriptionActions.start()
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "start_transcription",
+        expect.objectContaining({
+          apiKey: "dg-live-123",
+          provider: "deepgram",
+          deviceId: null,
+          gain: 1.0,
+        })
+      )
+    })
+
+    it("sets connectionStatus to 'connecting' before invoke resolves and 'isTranscribing' after", async () => {
+      let resolveInvoke: () => void = () => {}
+      mockInvoke.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveInvoke = resolve
+        })
+      )
+
+      const { useTranscriptStore, transcriptionActions } = await loadModules()
+
+      const pending = transcriptionActions.start()
+
+      expect(useTranscriptStore.getState().connectionStatus).toBe("connecting")
+      expect(useTranscriptStore.getState().isTranscribing).toBe(false)
+
+      resolveInvoke()
+      await pending
+
+      expect(useTranscriptStore.getState().isTranscribing).toBe(true)
+      expect(useTranscriptStore.getState().connectionStatus).not.toBe("error")
+    })
+
+    it("routes a missing-Deepgram-key error to onMissingApiKey (no toast)", async () => {
+      mockInvoke.mockRejectedValue(
+        "No Deepgram API key provided. Set it in Settings or via DEEPGRAM_API_KEY env var."
+      )
+      const { useTranscriptStore, transcriptionActions } = await loadModules()
+      const onMissingApiKey = vi.fn()
+
+      await transcriptionActions.start(onMissingApiKey)
+
+      expect(onMissingApiKey).toHaveBeenCalledTimes(1)
+      expect(mockToastError).not.toHaveBeenCalled()
+      expect(useTranscriptStore.getState().connectionStatus).toBe("error")
+      expect(useTranscriptStore.getState().isTranscribing).toBe(false)
+    })
+
+    it("falls back to toast when missing-key error fires but no callback is provided", async () => {
+      mockInvoke.mockRejectedValue("No Deepgram API key provided")
+      const { transcriptionActions } = await loadModules()
+
+      await transcriptionActions.start()
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Could not start transcription",
+        { description: "No Deepgram API key provided" }
+      )
+    })
+
+    it("surfaces any other start error as a toast", async () => {
+      mockInvoke.mockRejectedValue("Whisper model not found")
+      const { useTranscriptStore, transcriptionActions } = await loadModules()
+      const onMissingApiKey = vi.fn()
+
+      await transcriptionActions.start(onMissingApiKey)
+
+      expect(onMissingApiKey).not.toHaveBeenCalled()
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Could not start transcription",
+        { description: "Whisper model not found" }
+      )
+      expect(useTranscriptStore.getState().connectionStatus).toBe("error")
+    })
+  })
+
+  describe("transcriptionActions.stop", () => {
+    it("resets transcript state on success", async () => {
+      mockInvoke.mockResolvedValue(undefined)
+      const { useTranscriptStore, transcriptionActions } = await loadModules()
+
+      useTranscriptStore.setState({
+        isTranscribing: true,
+        currentPartial: "partial text",
+        connectionStatus: "connected",
+      })
+
+      await transcriptionActions.stop()
+
+      const state = useTranscriptStore.getState()
+      expect(state.isTranscribing).toBe(false)
+      expect(state.currentPartial).toBe("")
+      expect(state.connectionStatus).toBe("disconnected")
+      expect(mockToastError).not.toHaveBeenCalled()
+    })
+
+    it("silently swallows the exact 'Transcription is not running' error", async () => {
+      mockInvoke.mockRejectedValue("Transcription is not running")
+      const { useTranscriptStore, transcriptionActions } = await loadModules()
+
+      useTranscriptStore.setState({ isTranscribing: true })
+
+      await transcriptionActions.stop()
+
+      expect(mockToastError).not.toHaveBeenCalled()
+      expect(useTranscriptStore.getState().isTranscribing).toBe(false)
+    })
+
+    it("surfaces other stop errors as a toast AND still resets UI state", async () => {
+      mockInvoke.mockRejectedValue("Audio device disappeared")
+      const { useTranscriptStore, transcriptionActions } = await loadModules()
+
+      useTranscriptStore.setState({
+        isTranscribing: true,
+        currentPartial: "mid-sentence...",
+        connectionStatus: "connected",
+      })
+
+      await transcriptionActions.stop()
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Could not stop transcription",
+        { description: "Audio device disappeared" }
+      )
+      const state = useTranscriptStore.getState()
+      expect(state.isTranscribing).toBe(false)
+      expect(state.currentPartial).toBe("")
+      expect(state.connectionStatus).toBe("disconnected")
+    })
+  })
+})

--- a/src/hooks/use-transcription.ts
+++ b/src/hooks/use-transcription.ts
@@ -1,8 +1,9 @@
 import { useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
-import { useTranscriptStore } from "@/stores"
+import { toast } from "sonner"
+import { useSettingsStore } from "@/stores/settings-store"
+import { useTranscriptStore } from "@/stores/transcript-store"
 import { useTauriEvent } from "./use-tauri-event"
-import type { TranscriptSegment } from "@/types"
 
 interface TranscriptPartialPayload {
   text: string
@@ -11,43 +12,62 @@ interface TranscriptPartialPayload {
 }
 
 export function useTranscription() {
-  const store = useTranscriptStore()
+  const segments = useTranscriptStore((s) => s.segments)
+  const currentPartial = useTranscriptStore((s) => s.currentPartial)
+  const isTranscribing = useTranscriptStore((s) => s.isTranscribing)
+  const connectionStatus = useTranscriptStore((s) => s.connectionStatus)
 
-  // Listen for transcript events from Rust
+  const setPartial = useTranscriptStore((s) => s.setPartial)
+  const addSegment = useTranscriptStore((s) => s.addSegment)
+  const setTranscribing = useTranscriptStore((s) => s.setTranscribing)
+
   useTauriEvent<TranscriptPartialPayload>("transcript_partial", (payload) => {
-    store.setPartial(payload.text)
+    setPartial(payload.text)
   })
 
   useTauriEvent<TranscriptPartialPayload>("transcript_final", (payload) => {
-    const segment: TranscriptSegment = {
+    addSegment({
       id: crypto.randomUUID(),
       text: payload.text,
       is_final: true,
       confidence: payload.confidence,
       words: [],
       timestamp: Date.now(),
-    }
-    store.addSegment(segment)
+    })
   })
 
   const startTranscription = useCallback(async () => {
-    const { useSettingsStore } = await import("@/stores")
     const settings = useSettingsStore.getState()
-    await invoke("start_transcription", {
-      apiKey: settings.sttProvider === "deepgram" ? (settings.deepgramApiKey ?? "") : "",
-      provider: settings.sttProvider,
-    })
-    store.setTranscribing(true)
-  }, [store])
+    try {
+      await invoke("start_transcription", {
+        apiKey: settings.sttProvider === "deepgram" ? (settings.deepgramApiKey ?? "") : "",
+        provider: settings.sttProvider,
+      })
+      setTranscribing(true)
+    } catch (e) {
+      toast.error("Could not start transcription", { description: String(e) })
+    }
+  }, [setTranscribing])
 
   const stopTranscription = useCallback(async () => {
-    await invoke("stop_transcription")
-    store.setTranscribing(false)
-    store.setPartial("")
-  }, [store])
+    try {
+      await invoke("stop_transcription")
+    } catch (e) {
+      // Expected when backend state is already clean (e.g. after a webview
+      // reload reset). Must match stop_transcription in src-tauri/src/commands/stt.rs exactly.
+      if (String(e) !== "Transcription is not running") {
+        toast.error("Could not stop transcription", { description: String(e) })
+      }
+    }
+    setTranscribing(false)
+    setPartial("")
+  }, [setTranscribing, setPartial])
 
   return {
-    ...store,
+    segments,
+    currentPartial,
+    isTranscribing,
+    connectionStatus,
     startTranscription,
     stopTranscription,
   }

--- a/src/hooks/use-transcription.ts
+++ b/src/hooks/use-transcription.ts
@@ -11,22 +11,84 @@ interface TranscriptPartialPayload {
   confidence: number
 }
 
-export function useTranscription() {
+interface UseTranscriptionOptions {
+  /**
+   * Called when `start_transcription` fails because the user picked the
+   * Deepgram provider but hasn't set an API key. Panels typically react by
+   * opening a key-prompt dialog instead of showing the default toast.
+   */
+  onMissingApiKey?: () => void
+}
+
+const MISSING_DEEPGRAM_KEY_MARKER = "No Deepgram API key"
+const NOT_RUNNING_ERROR = "Transcription is not running"
+
+export const transcriptionActions = {
+  async start(onMissingApiKey?: () => void): Promise<void> {
+    const transcript = useTranscriptStore.getState()
+    transcript.setConnectionStatus("connecting")
+
+    const settings = useSettingsStore.getState()
+    try {
+      await invoke("start_transcription", {
+        apiKey:
+          settings.sttProvider === "deepgram"
+            ? (settings.deepgramApiKey ?? "")
+            : "",
+        deviceId: settings.audioDeviceId,
+        gain: settings.gain,
+        provider: settings.sttProvider,
+      })
+      transcript.setTranscribing(true)
+    } catch (e) {
+      const msg = String(e)
+      transcript.setConnectionStatus("error")
+      if (msg.includes(MISSING_DEEPGRAM_KEY_MARKER) && onMissingApiKey) {
+        onMissingApiKey()
+      } else {
+        toast.error("Could not start transcription", { description: msg })
+      }
+    }
+  },
+
+  async stop(): Promise<void> {
+    const transcript = useTranscriptStore.getState()
+    try {
+      await invoke("stop_transcription")
+    } catch (e) {
+      if (String(e) !== NOT_RUNNING_ERROR) {
+        toast.error("Could not stop transcription", { description: String(e) })
+      }
+    }
+    transcript.setTranscribing(false)
+    transcript.setPartial("")
+    transcript.setConnectionStatus("disconnected")
+  },
+}
+
+export function useTranscription(options?: UseTranscriptionOptions) {
   const segments = useTranscriptStore((s) => s.segments)
-  const currentPartial = useTranscriptStore((s) => s.currentPartial)
   const isTranscribing = useTranscriptStore((s) => s.isTranscribing)
   const connectionStatus = useTranscriptStore((s) => s.connectionStatus)
 
-  const setPartial = useTranscriptStore((s) => s.setPartial)
-  const addSegment = useTranscriptStore((s) => s.addSegment)
-  const setTranscribing = useTranscriptStore((s) => s.setTranscribing)
+  // STT lifecycle events
+  useTauriEvent("stt_connected", () => {
+    useTranscriptStore.getState().setConnectionStatus("connected")
+  })
+  useTauriEvent("stt_disconnected", () => {
+    useTranscriptStore.getState().setConnectionStatus("disconnected")
+  })
+  useTauriEvent<string>("stt_error", (msg) => {
+    useTranscriptStore.getState().setConnectionStatus("error")
+    toast.error("Transcription error", { description: msg })
+  })
 
   useTauriEvent<TranscriptPartialPayload>("transcript_partial", (payload) => {
-    setPartial(payload.text)
+    useTranscriptStore.getState().setPartial(payload.text)
   })
 
   useTauriEvent<TranscriptPartialPayload>("transcript_final", (payload) => {
-    addSegment({
+    useTranscriptStore.getState().addSegment({
       id: crypto.randomUUID(),
       text: payload.text,
       is_final: true,
@@ -36,39 +98,18 @@ export function useTranscription() {
     })
   })
 
-  const startTranscription = useCallback(async () => {
-    const settings = useSettingsStore.getState()
-    try {
-      await invoke("start_transcription", {
-        apiKey: settings.sttProvider === "deepgram" ? (settings.deepgramApiKey ?? "") : "",
-        provider: settings.sttProvider,
-      })
-      setTranscribing(true)
-    } catch (e) {
-      toast.error("Could not start transcription", { description: String(e) })
-    }
-  }, [setTranscribing])
+  const onMissingApiKey = options?.onMissingApiKey
 
-  const stopTranscription = useCallback(async () => {
-    try {
-      await invoke("stop_transcription")
-    } catch (e) {
-      // Expected when backend state is already clean (e.g. after a webview
-      // reload reset). Must match stop_transcription in src-tauri/src/commands/stt.rs exactly.
-      if (String(e) !== "Transcription is not running") {
-        toast.error("Could not stop transcription", { description: String(e) })
-      }
-    }
-    setTranscribing(false)
-    setPartial("")
-  }, [setTranscribing, setPartial])
+  const startTranscription = useCallback(
+    () => transcriptionActions.start(onMissingApiKey),
+    [onMissingApiKey]
+  )
 
   return {
     segments,
-    currentPartial,
     isTranscribing,
     connectionStatus,
     startTranscription,
-    stopTranscription,
+    stopTranscription: transcriptionActions.stop,
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,32 @@
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
+import { invoke } from "@tauri-apps/api/core"
 
 import "./index.css"
 import App from "./App.tsx"
 import { ThemeProvider } from "@/components/theme-provider.tsx"
 import { TooltipProvider } from "@/components/ui/tooltip.tsx"
+import { hydrateSettings } from "@/stores/settings-store"
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <ThemeProvider defaultTheme="dark">
-      <TooltipProvider>
-        <App />
-      </TooltipProvider>
-    </ThemeProvider>
-  </StrictMode>
-)
+// Webview reloads do NOT restart the Rust backend, so any STT pipeline
+// left running from the previous webview session still has
+// `stt_active = true`. That makes the next `start_transcription` call
+// fail silently with "Transcription is already running". Reset the
+// backend to a clean state on boot — errors (e.g. "not running") are
+// expected and safe to swallow.
+void invoke("stop_transcription").catch(() => {})
+
+// Load persisted settings from disk before the first render so the UI
+// reflects the user's choices (STT provider, audio device, API keys,
+// etc.) instead of briefly flashing defaults.
+hydrateSettings().finally(() => {
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <ThemeProvider defaultTheme="dark">
+        <TooltipProvider>
+          <App />
+        </TooltipProvider>
+      </ThemeProvider>
+    </StrictMode>
+  )
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,21 +12,19 @@ import { hydrateSettings } from "@/stores/settings-store"
 // left running from the previous webview session still has
 // `stt_active = true`. That makes the next `start_transcription` call
 // fail silently with "Transcription is already running". Reset the
-// backend to a clean state on boot — errors (e.g. "not running") are
-// expected and safe to swallow.
-void invoke("stop_transcription").catch(() => {})
-
-// Load persisted settings from disk before the first render so the UI
-// reflects the user's choices (STT provider, audio device, API keys,
-// etc.) instead of briefly flashing defaults.
-hydrateSettings().finally(() => {
-  createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <ThemeProvider defaultTheme="dark">
-        <TooltipProvider>
-          <App />
-        </TooltipProvider>
-      </ThemeProvider>
-    </StrictMode>
-  )
-})
+// backend to a clean state on boot, then hydrate persisted settings so
+// the UI reflects the user's choices instead of briefly flashing defaults.
+invoke("stop_transcription")
+  .catch(() => {})
+  .then(() => hydrateSettings())
+  .finally(() => {
+    createRoot(document.getElementById("root")!).render(
+      <StrictMode>
+        <ThemeProvider defaultTheme="dark">
+          <TooltipProvider>
+            <App />
+          </TooltipProvider>
+        </ThemeProvider>
+      </StrictMode>
+    )
+  })

--- a/src/stores/settings-store.test.ts
+++ b/src/stores/settings-store.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockGet = vi.fn()
+const mockSet = vi.fn()
+const mockSave = vi.fn()
+const mockLoad = vi.fn()
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  load: (...args: unknown[]) => mockLoad(...args),
+}))
+
+async function flushSave(): Promise<void> {
+  // Advance past the debounce window, then let the chained
+  // pendingSave promise resolve.
+  await vi.advanceTimersByTimeAsync(300)
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("settings store", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    mockGet.mockReset()
+    mockSet.mockReset()
+    mockSave.mockReset()
+    mockLoad.mockReset()
+    mockLoad.mockResolvedValue({
+      get: mockGet,
+      set: mockSet,
+      save: mockSave,
+    })
+    vi.resetModules()
+  })
+
+  it("hydrate merges persisted values over defaults", async () => {
+    mockGet.mockImplementation(async (key: string) => {
+      if (key === "gain") return 2.5
+      if (key === "sttProvider") return "whisper"
+      if (key === "deepgramApiKey") return "dg-key"
+      return null
+    })
+
+    const { hydrateSettings, useSettingsStore } = await import("./settings-store")
+    await hydrateSettings()
+
+    const state = useSettingsStore.getState()
+    expect(state.gain).toBe(2.5)
+    expect(state.sttProvider).toBe("whisper")
+    expect(state.deepgramApiKey).toBe("dg-key")
+    // Defaults remain for keys with null
+    expect(state.autoMode).toBe(false)
+    expect(state.confidenceThreshold).toBe(0.8)
+  })
+
+  it("hydrate with no persisted values falls back to defaults", async () => {
+    mockGet.mockResolvedValue(null)
+
+    const { hydrateSettings, useSettingsStore } = await import("./settings-store")
+    const before = useSettingsStore.getState()
+    await hydrateSettings()
+    const after = useSettingsStore.getState()
+
+    expect(after.gain).toBe(before.gain)
+    expect(after.sttProvider).toBe(before.sttProvider)
+    expect(after.autoMode).toBe(before.autoMode)
+  })
+
+  it("a setter call after hydration writes the full snapshot to disk", async () => {
+    mockGet.mockResolvedValue(null)
+
+    const { hydrateSettings, useSettingsStore } = await import("./settings-store")
+    await hydrateSettings()
+
+    useSettingsStore.getState().setGain(1.75)
+
+    // Debounced — nothing written yet.
+    expect(mockSet).not.toHaveBeenCalled()
+    expect(mockSave).not.toHaveBeenCalled()
+
+    await flushSave()
+
+    expect(mockSet).toHaveBeenCalledWith("gain", 1.75)
+    expect(mockSave).toHaveBeenCalledTimes(1)
+  })
+
+  it("rapid setter calls coalesce into a single save", async () => {
+    mockGet.mockResolvedValue(null)
+
+    const { hydrateSettings, useSettingsStore } = await import("./settings-store")
+    await hydrateSettings()
+
+    const { setGain } = useSettingsStore.getState()
+    setGain(1.1)
+    setGain(1.2)
+    setGain(1.3)
+
+    await flushSave()
+
+    expect(mockSave).toHaveBeenCalledTimes(1)
+    expect(mockSet).toHaveBeenCalledWith("gain", 1.3)
+  })
+
+  it("concurrent hydrate calls attach only one subscription", async () => {
+    mockGet.mockResolvedValue(null)
+
+    const { hydrateSettings, useSettingsStore } = await import("./settings-store")
+    // Kick off two concurrent hydrations — a second caller must not
+    // attach a duplicate subscription that would double every write.
+    await Promise.all([hydrateSettings(), hydrateSettings()])
+
+    useSettingsStore.getState().setGain(1.5)
+    await flushSave()
+
+    expect(mockSave).toHaveBeenCalledTimes(1)
+  })
+
+  it("hydrate handles load rejection gracefully", async () => {
+    mockLoad.mockRejectedValue(new Error("store not available"))
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const { hydrateSettings, useSettingsStore } = await import("./settings-store")
+    await expect(hydrateSettings()).resolves.toBeUndefined()
+
+    // Defaults preserved
+    expect(useSettingsStore.getState().gain).toBe(1.0)
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[settings] Failed to load persisted state, using defaults"
+    )
+    warnSpy.mockRestore()
+  })
+
+  it("persist handles save rejection gracefully", async () => {
+    mockGet.mockResolvedValue(null)
+    mockSave.mockRejectedValue(new Error("disk error"))
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const { hydrateSettings, useSettingsStore } = await import("./settings-store")
+    await hydrateSettings()
+
+    useSettingsStore.getState().setAutoMode(true)
+    await flushSave()
+
+    expect(warnSpy).toHaveBeenCalledWith("[settings] Failed to persist settings")
+    warnSpy.mockRestore()
+  })
+})

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand"
+import { load, type Store } from "@tauri-apps/plugin-store"
 
 type SttProvider = "deepgram" | "whisper"
 
@@ -53,3 +54,84 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   setOnboardingComplete: (onboardingComplete) => set({ onboardingComplete }),
   setSttProvider: (sttProvider) => set({ sttProvider }),
 }))
+
+const PERSISTED_KEYS = [
+  "deepgramApiKey",
+  "openaiApiKey",
+  "claudeApiKey",
+  "activeTranslationId",
+  "audioDeviceId",
+  "gain",
+  "autoMode",
+  "confidenceThreshold",
+  "cooldownMs",
+  "onboardingComplete",
+  "sttProvider",
+] as const satisfies readonly (keyof SettingsState)[]
+
+type PersistedKey = (typeof PERSISTED_KEYS)[number]
+
+let tauriStore: Store | null = null
+let hydrationPromise: Promise<void> | null = null
+
+async function getStore(): Promise<Store> {
+  if (!tauriStore) {
+    tauriStore = await load("settings.json", { autoSave: false, defaults: {} })
+  }
+  return tauriStore
+}
+
+/** Load all persisted settings into the Zustand store. Idempotent and
+ *  safe against concurrent callers — the first call owns the work and
+ *  subsequent callers await the same promise. */
+export function hydrateSettings(): Promise<void> {
+  if (hydrationPromise) return hydrationPromise
+  hydrationPromise = (async () => {
+    try {
+      const store = await getStore()
+      const patch: Partial<SettingsState> = {}
+      for (const key of PERSISTED_KEYS) {
+        const value = await store.get(key)
+        if (value !== undefined && value !== null) {
+          ;(patch as Record<string, unknown>)[key] = value
+        }
+      }
+      if (Object.keys(patch).length > 0) {
+        useSettingsStore.setState(patch)
+      }
+    } catch {
+      console.warn("[settings] Failed to load persisted state, using defaults")
+    } finally {
+      // Attach only after hydration so as not to overwrite disk with defaults.
+      // Debounce writes, so a dragged slider (e.g. gain) coalesces into a single disk write.
+      useSettingsStore.subscribe((state, prevState) => {
+        const changed = PERSISTED_KEYS.some((k) => state[k] !== prevState[k])
+        if (!changed) return
+        if (saveTimer) clearTimeout(saveTimer)
+        saveTimer = setTimeout(() => {
+          saveTimer = null
+          pendingSave = pendingSave.then(() =>
+            persistAll(useSettingsStore.getState())
+          )
+        }, SAVE_DEBOUNCE_MS)
+      })
+    }
+  })()
+  return hydrationPromise
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+let pendingSave: Promise<void> = Promise.resolve()
+const SAVE_DEBOUNCE_MS = 250
+
+async function persistAll(state: SettingsState): Promise<void> {
+  try {
+    const store = await getStore()
+    for (const key of PERSISTED_KEYS) {
+      await store.set(key, state[key] as PersistedKey extends never ? never : unknown)
+    }
+    await store.save()
+  } catch {
+    console.warn("[settings] Failed to persist settings")
+  }
+}

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -99,10 +99,8 @@ export function hydrateSettings(): Promise<void> {
       if (Object.keys(patch).length > 0) {
         useSettingsStore.setState(patch)
       }
-    } catch {
-      console.warn("[settings] Failed to load persisted state, using defaults")
-    } finally {
-      // Attach only after hydration so as not to overwrite disk with defaults.
+
+      // Attach only after successful hydration so as not to overwrite disk with defaults.
       // Debounce writes, so a dragged slider (e.g. gain) coalesces into a single disk write.
       useSettingsStore.subscribe((state, prevState) => {
         const changed = PERSISTED_KEYS.some((k) => state[k] !== prevState[k])
@@ -115,6 +113,8 @@ export function hydrateSettings(): Promise<void> {
           )
         }, SAVE_DEBOUNCE_MS)
       })
+    } catch {
+      console.warn("[settings] Failed to load persisted state, using defaults")
     }
   })()
   return hydrationPromise
@@ -128,7 +128,7 @@ async function persistAll(state: SettingsState): Promise<void> {
   try {
     const store = await getStore()
     for (const key of PERSISTED_KEYS) {
-      await store.set(key, state[key] as PersistedKey extends never ? never : unknown)
+      await store.set(key, state[key] as unknown)
     }
     await store.save()
   } catch {


### PR DESCRIPTION

## Description

<!-- What does this PR do? Reference any related issues (e.g., `fixes #123`). -->
  - Persist all user-configurable settings (API keys, audio device, gain, STT provider, thresholds, etc.) to `settings.json` via `@tauri-apps/plugin-store`, with debounced + serialized disk writes so dragging the gain slider coalesces into one save.                                                                                                                               
  - Race-safe hydration: `hydrateSettings()` now uses an in-flight promise so concurrent callers share the same work and only one write-through subscription is ever attached.               
  - Reset the STT pipeline on webview reload. Prior behavior: reload left `stt_active = true` on the Rust side, so the next `start_transcription` failed with "already running". `main.tsx` now fires `stop_transcription` on boot and swallows the expected "not running" error.                                                                                                      
  - Refactor `useTranscription` for performance and clarity — whole-store subscription replaced with per-field selectors, stable Zustand setters, static imports bypassing the `@/stores`  barrel, exact-match error-string compare tied back to the Rust source.     

## Type of change

<!-- Check the one that applies: -->

- [x] Bug fix
- [ ] New feature
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

<!-- Check all that apply: -->

- [x] Frontend (React / TypeScript)
- [ ] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [x] I have tested this change locally
- [x] `bun run typecheck` passes
- [ ] `cargo clippy` passes without warnings
- [x] `bun run test` passes (if applicable)
- [x] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

<!-- Check the platforms you tested on: -->

- [x] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

<!-- If this PR includes UI changes, add screenshots or recordings here. -->
# BEFORE
https://github.com/user-attachments/assets/bba10f2e-1475-474b-839a-98691c3ea86c

# AFTER

https://github.com/user-attachments/assets/d1034b8f-09e8-48e3-9e8d-808dce27b131

