### PR TITLE
feat: add upcoming verse prediction feature (v2)

### DIFF
--- a/src-tauri/crates/detection/src/lib.rs
+++ b/src-tauri/crates/detection/src/lib.rs
@@ -15,23 +15,25 @@
 //! - `onnx` — enables ONNX Runtime for local embedding inference
 //! - `vector-search` — enables HNSW vector index for similarity search
 
-pub mod types;
-pub mod error;
 pub mod direct;
-pub mod semantic;
+pub mod error;
 pub mod merger;
 pub mod pipeline;
-pub mod sentence_buffer;
+pub mod prediction;
 pub mod reading_mode;
+pub mod semantic;
+pub mod sentence_buffer;
+pub mod types;
 
-pub use types::*;
-pub use error::*;
 pub use direct::detector::DirectDetector;
-pub use semantic::detector::SemanticDetector;
+pub use error::*;
 pub use merger::{DetectionMerger, MergedDetection};
 pub use pipeline::DetectionPipeline;
+pub use prediction::{PredictionStrategy, VersePrediction, VersePredictor};
+pub use reading_mode::{ChapterChange, ReadingAdvance, ReadingMode};
+pub use semantic::detector::SemanticDetector;
 pub use sentence_buffer::SentenceBuffer;
-pub use reading_mode::{ReadingMode, ReadingAdvance, ChapterChange};
+pub use types::*;
 
 #[cfg(feature = "onnx")]
 pub use semantic::onnx_embedder::OnnxEmbedder;

--- a/src-tauri/crates/detection/src/prediction.rs
+++ b/src-tauri/crates/detection/src/prediction.rs
@@ -1,0 +1,191 @@
+use serde::Serialize;
+
+use crate::types::VerseRef;
+use crate::ReadingMode;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum PredictionStrategy {
+    Sequential,
+    ReadingMode,
+}
+
+impl std::fmt::Display for PredictionStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PredictionStrategy::Sequential => write!(f, "sequential"),
+            PredictionStrategy::ReadingMode => write!(f, "reading_mode"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VersePrediction {
+    pub verse_ref: VerseRef,
+    pub verse_text: String,
+    pub confidence: f64,
+    pub strategy: PredictionStrategy,
+}
+
+pub struct VersePredictor {
+    max_predictions: usize,
+    current_book: Option<i32>,
+    current_chapter: Option<i32>,
+    current_verse: Option<i32>,
+}
+
+impl VersePredictor {
+    pub fn new() -> Self {
+        Self {
+            max_predictions: 5,
+            current_book: None,
+            current_chapter: None,
+            current_verse: None,
+        }
+    }
+
+    pub fn with_max_predictions(max: usize) -> Self {
+        Self {
+            max_predictions: max,
+            current_book: None,
+            current_chapter: None,
+            current_verse: None,
+        }
+    }
+
+    pub fn max_predictions(&self) -> usize {
+        self.max_predictions
+    }
+
+    pub fn set_max_predictions(&mut self, max: usize) {
+        self.max_predictions = max;
+    }
+
+    pub fn update_from_detection(&mut self, book_number: i32, chapter: i32, verse: i32) {
+        self.current_book = Some(book_number);
+        self.current_chapter = Some(chapter);
+        self.current_verse = Some(verse);
+    }
+
+    pub fn update_from_reading_mode(&mut self, reading_mode: &ReadingMode) {
+        if reading_mode.is_active() {
+            self.current_book = Some(reading_mode.current_book());
+            self.current_chapter = Some(reading_mode.current_chapter());
+            self.current_verse = reading_mode.current_verse();
+        }
+    }
+
+    pub fn predict(&self) -> Vec<VersePrediction> {
+        let mut predictions = Vec::new();
+
+        let (book_number, chapter, verse) =
+            match (self.current_book, self.current_chapter, self.current_verse) {
+                (Some(book), Some(ch), Some(v)) => (book, ch, v),
+                _ => return predictions,
+            };
+
+        let next_verse = verse + 1;
+        predictions.push(VersePrediction {
+            verse_ref: VerseRef {
+                book_number,
+                book_name: String::new(),
+                chapter,
+                verse_start: next_verse,
+                verse_end: None,
+            },
+            verse_text: "next verse".to_string(),
+            confidence: 0.85,
+            strategy: PredictionStrategy::Sequential,
+        });
+
+        if predictions.len() < self.max_predictions {
+            let next_next = verse + 2;
+            predictions.push(VersePrediction {
+                verse_ref: VerseRef {
+                    book_number,
+                    book_name: String::new(),
+                    chapter,
+                    verse_start: next_next,
+                    verse_end: None,
+                },
+                verse_text: "verse after next".to_string(),
+                confidence: 0.70,
+                strategy: PredictionStrategy::Sequential,
+            });
+        }
+
+        predictions.truncate(self.max_predictions);
+        predictions
+    }
+
+    pub fn predict_from_reading_mode(
+        &self,
+        reading_mode: &ReadingMode,
+        verses_ahead: i32,
+    ) -> Vec<VersePrediction> {
+        let mut predictions = Vec::new();
+
+        if !reading_mode.is_active() {
+            return predictions;
+        }
+
+        let book_number = reading_mode.current_book();
+        let chapter = reading_mode.current_chapter();
+        let current_verse = match reading_mode.current_verse() {
+            Some(v) => v,
+            None => return predictions,
+        };
+
+        for i in 1..=verses_ahead {
+            let v = current_verse + i;
+            let confidence = (0.95 - (i as f64 * 0.10)).max(0.50);
+
+            predictions.push(VersePrediction {
+                verse_ref: VerseRef {
+                    book_number,
+                    book_name: String::new(),
+                    chapter,
+                    verse_start: v,
+                    verse_end: None,
+                },
+                verse_text: format!("verse {}", v),
+                confidence,
+                strategy: PredictionStrategy::ReadingMode,
+            });
+        }
+
+        predictions
+    }
+}
+
+impl Default for VersePredictor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_predictor() {
+        let predictor = VersePredictor::new();
+        assert_eq!(predictor.max_predictions(), 5);
+    }
+
+    #[test]
+    fn test_predict_empty() {
+        let predictor = VersePredictor::new();
+        let predictions = predictor.predict();
+        assert!(predictions.is_empty());
+    }
+
+    #[test]
+    fn test_predict_with_context() {
+        let mut predictor = VersePredictor::new();
+        predictor.update_from_detection(43, 3, 16);
+        let predictions = predictor.predict();
+        assert!(!predictions.is_empty());
+        assert_eq!(predictions[0].verse_ref.verse_start, 17);
+    }
+}

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -1,4 +1,7 @@
-#![expect(clippy::needless_pass_by_value, reason = "Tauri command extractors require pass-by-value")]
+#![expect(
+    clippy::needless_pass_by_value,
+    reason = "Tauri command extractors require pass-by-value"
+)]
 
 use std::collections::HashSet;
 use std::sync::Mutex;
@@ -62,7 +65,12 @@ pub fn to_result(state: &AppState, merged: &MergedDetection) -> DetectionResult 
         }
         // Fall back to book/chapter/verse lookup (direct + FTS5 detections)
         if vr.book_number > 0 && vr.chapter > 0 && vr.verse_start > 0 {
-            if let Ok(Some(v)) = db.get_verse(state.active_translation_id, vr.book_number, vr.chapter, vr.verse_start) {
+            if let Ok(Some(v)) = db.get_verse(
+                state.active_translation_id,
+                vr.book_number,
+                vr.chapter,
+                vr.verse_start,
+            ) {
                 return Some(v);
             }
         }
@@ -76,7 +84,14 @@ pub fn to_result(state: &AppState, merged: &MergedDetection) -> DetectionResult 
         }
         None => {
             let r = format!("{} {}:{}", vr.book_name, vr.chapter, vr.verse_start);
-            (r, String::new(), vr.book_name.clone(), vr.book_number, vr.chapter, vr.verse_start)
+            (
+                r,
+                String::new(),
+                vr.book_name.clone(),
+                vr.book_number,
+                vr.chapter,
+                vr.verse_start,
+            )
         }
     };
 
@@ -223,7 +238,11 @@ pub fn semantic_search(
     }
 
     // Ensure highest similarity is always first
-    results.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| {
+        b.similarity
+            .partial_cmp(&a.similarity)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
     Ok(results)
 }
@@ -248,10 +267,92 @@ pub struct ReadingModeStatus {
 
 /// Stop reading mode
 #[tauri::command]
-pub fn stop_reading_mode(
-    state: State<'_, Mutex<ReadingMode>>,
-) -> Result<(), String> {
+pub fn stop_reading_mode(state: State<'_, Mutex<ReadingMode>>) -> Result<(), String> {
     let mut rm = state.lock().map_err(|e| e.to_string())?;
     rm.deactivate();
     Ok(())
+}
+
+#[derive(Serialize)]
+pub struct PredictionResult {
+    pub verse_ref: String,
+    pub verse_text: String,
+    pub book_name: String,
+    pub book_number: i32,
+    pub chapter: i32,
+    pub verse: i32,
+    pub confidence: f64,
+    pub strategy: String,
+}
+
+#[tauri::command]
+pub fn predict_next_verses(
+    state: State<'_, Mutex<AppState>>,
+    reading_mode_state: State<'_, Mutex<ReadingMode>>,
+    limit: Option<usize>,
+) -> Result<Vec<PredictionResult>, String> {
+    let app_state = state.lock().map_err(|e| e.to_string())?;
+    let rm = reading_mode_state.lock().map_err(|e| e.to_string())?;
+
+    let predictions = if rm.is_active() {
+        app_state.verse_predictor.predict_from_reading_mode(&rm, 3)
+    } else {
+        app_state.verse_predictor.predict()
+    };
+
+    let results: Vec<PredictionResult> = predictions
+        .into_iter()
+        .map(|p| {
+            let vr = &p.verse_ref;
+            let verse_text = if let Some(ref db) = app_state.bible_db {
+                db.get_verse(
+                    app_state.active_translation_id,
+                    vr.book_number,
+                    vr.chapter,
+                    vr.verse_start,
+                )
+                .ok()
+                .flatten()
+                .map(|v| {
+                    if vr.book_name.is_empty() {
+                        v.book_name.clone()
+                    } else {
+                        vr.book_name.clone()
+                    }
+                })
+                .unwrap_or(p.verse_text)
+            } else {
+                p.verse_text
+            };
+
+            let book_name = if let Some(ref db) = app_state.bible_db {
+                db.get_verse(
+                    app_state.active_translation_id,
+                    vr.book_number,
+                    vr.chapter,
+                    vr.verse_start,
+                )
+                .ok()
+                .flatten()
+                .map(|v| v.book_name)
+                .unwrap_or_default()
+            } else {
+                String::new()
+            };
+
+            PredictionResult {
+                verse_ref: format!("{} {}:{}", book_name, vr.chapter, vr.verse_start),
+                verse_text,
+                book_name,
+                book_number: vr.book_number,
+                chapter: vr.chapter,
+                verse: vr.verse_start,
+                confidence: p.confidence,
+                strategy: p.strategy.to_string(),
+            }
+        })
+        .take(limit.unwrap_or(5))
+        .collect();
+
+    Ok(results)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
             commands::detection::toggle_paraphrase_detection,
             commands::detection::reading_mode_status,
             commands::detection::stop_reading_mode,
+            commands::detection::predict_next_verses,
             commands::audio::get_audio_devices,
             commands::stt::start_transcription,
             commands::stt::stop_transcription,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -10,6 +10,7 @@ pub struct AppState {
     pub active_translation_id: i64,
     pub audio_active: Arc<AtomicBool>,
     pub stt_active: Arc<AtomicBool>,
+    pub verse_predictor: VersePredictor,
     #[expect(dead_code, reason = "reserved for future Deepgram key injection")]
     pub deepgram_api_key: Option<String>,
 }
@@ -19,9 +20,10 @@ impl AppState {
         Self {
             bible_db: None,
             detection_pipeline: DetectionPipeline::new(),
-            active_translation_id: 1, // Default to first translation (KJV)
+            active_translation_id: 1,
             audio_active: Arc::new(AtomicBool::new(false)),
             stt_active: Arc::new(AtomicBool::new(false)),
+            verse_predictor: VersePredictor::new(),
             deepgram_api_key: None,
         }
     }

--- a/src/components/panels/preview-panel.tsx
+++ b/src/components/panels/preview-panel.tsx
@@ -1,19 +1,72 @@
-import { useEffect } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
-import { useBibleStore, useBroadcastStore } from "@/stores"
+import { useBibleStore, useBroadcastStore, useQueueStore } from "@/stores"
 import { bibleActions } from "@/hooks/use-bible"
 import { toVerseRenderData } from "@/hooks/use-broadcast"
+import { usePrediction } from "@/hooks/use-prediction"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { PredictionResult } from "@/types"
+
+function PredictionCard({
+  prediction,
+  onAdd,
+}: {
+  prediction: PredictionResult
+  onAdd: () => void
+}) {
+  const [hovered, setHovered] = useState(false)
+
+  return (
+    <div
+      className={cn(
+        "flex cursor-pointer items-center justify-between rounded-md border border-border p-2 transition-colors",
+        hovered && "border-primary/50 bg-muted/50"
+      )}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={onAdd}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium">{prediction.verse_ref}</p>
+        <p className="truncate text-[0.625rem] text-muted-foreground">
+          {prediction.strategy}
+        </p>
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="text-[0.625rem] text-muted-foreground">
+          {Math.round(prediction.confidence * 100)}%
+        </span>
+        {hovered && (
+          <Button
+            variant="ghost"
+            size="xs"
+            className="h-5 px-1 text-[0.625rem]"
+          >
+            Add
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
 
 export function PreviewPanel() {
   const selectedVerse = useBibleStore((s) => s.selectedVerse)
   const translations = useBibleStore((s) => s.translations)
   const activeTranslationId = useBibleStore((s) => s.activeTranslationId)
+  const { predictions, fetchPredictions } = usePrediction()
 
   // When translation changes, re-fetch the selected verse in the new translation
   useEffect(() => {
     const verse = useBibleStore.getState().selectedVerse
-    if (verse && verse.book_number > 0 && verse.chapter > 0 && verse.verse > 0) {
+    if (
+      verse &&
+      verse.book_number > 0 &&
+      verse.chapter > 0 &&
+      verse.verse > 0
+    ) {
       bibleActions
         .fetchVerse(verse.book_number, verse.chapter, verse.verse)
         .then((v) => {
@@ -26,18 +79,77 @@ export function PreviewPanel() {
   const activeThemeId = useBroadcastStore((s) => s.activeThemeId)
 
   const activeTheme = themes.find((t) => t.id === activeThemeId) ?? themes[0]
-  const translation = translations.find((t) => t.id === activeTranslationId)?.abbreviation ?? "KJV"
+  const translation =
+    translations.find((t) => t.id === activeTranslationId)?.abbreviation ??
+    "KJV"
 
-  const verseData = selectedVerse ? toVerseRenderData(selectedVerse, translation) : null
+  const verseData = selectedVerse
+    ? toVerseRenderData(selectedVerse, translation)
+    : null
+
+  const handleFetchPredictions = useCallback(async () => {
+    await fetchPredictions(3)
+  }, [fetchPredictions])
+
+  const handleAddPrediction = useCallback(
+    async (prediction: PredictionResult) => {
+      const verse = {
+        id: 0,
+        book_number: prediction.book_number,
+        book_name: prediction.book_name,
+        chapter: prediction.chapter,
+        verse: prediction.verse,
+        text: prediction.verse_text,
+      }
+      await bibleActions.fetchVerse(
+        prediction.book_number,
+        prediction.chapter,
+        prediction.verse
+      )
+      useBroadcastStore
+        .getState()
+        .setLiveVerse(toVerseRenderData(verse, translation))
+      useQueueStore.getState().addItem({
+        id: `pred-${Date.now()}`,
+        reference: prediction.verse_ref,
+        verse: verse,
+        source: "manual",
+      })
+    },
+    [translation]
+  )
 
   return (
     <div
       data-slot="preview-panel"
       className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card"
     >
-      <PanelHeader title="Program preview" />
-      <div className="flex min-h-0 flex-1 items-center justify-center p-3">
-        <CanvasVerse theme={activeTheme} verse={verseData} />
+      <PanelHeader title="Program preview">
+        <button
+          onClick={handleFetchPredictions}
+          className="text-[0.625rem] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Predict
+        </button>
+      </PanelHeader>
+      <div className="flex min-h-0 flex-1 flex-col gap-2 p-3">
+        <div className="flex flex-1 items-center justify-center">
+          <CanvasVerse theme={activeTheme} verse={verseData} />
+        </div>
+        {predictions.length > 0 && (
+          <div className="flex flex-col gap-1">
+            <p className="text-[0.625rem] font-medium text-muted-foreground">
+              Upcoming
+            </p>
+            {predictions.map((p, idx) => (
+              <PredictionCard
+                key={`${p.verse_ref}-${idx}`}
+                prediction={p}
+                onAdd={() => handleAddPrediction(p)}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/panels/queue-panel.tsx
+++ b/src/components/panels/queue-panel.tsx
@@ -1,15 +1,13 @@
+import { useState } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
-import {
-  PlayIcon,
-  XIcon,
-  GripVerticalIcon,
-} from "lucide-react"
+import { PlayIcon, XIcon, GripVerticalIcon, SparklesIcon } from "lucide-react"
 import { useQueueStore, useBroadcastStore, useBibleStore } from "@/stores"
 import { toVerseRenderData } from "@/hooks/use-broadcast"
 import { bibleActions } from "@/hooks/use-bible"
+import { usePrediction } from "@/hooks/use-prediction"
 import type { QueueItem } from "@/types"
 
 function QueueItemRow({
@@ -26,9 +24,15 @@ function QueueItemRow({
   const handlePresent = () => {
     useQueueStore.getState().setActive(index)
     bibleActions.selectVerse(item.verse)
-    const translation = useBibleStore.getState().translations
-      .find(t => t.id === useBibleStore.getState().activeTranslationId)?.abbreviation ?? "KJV"
-    useBroadcastStore.getState().setLiveVerse(toVerseRenderData(item.verse, translation))
+    const translation =
+      useBibleStore
+        .getState()
+        .translations.find(
+          (t) => t.id === useBibleStore.getState().activeTranslationId
+        )?.abbreviation ?? "KJV"
+    useBroadcastStore
+      .getState()
+      .setLiveVerse(toVerseRenderData(item.verse, translation))
   }
 
   const handleRemove = () => {
@@ -60,9 +64,7 @@ function QueueItemRow({
             : "hover:bg-muted/50"
       )}
     >
-      <GripVerticalIcon
-        className="size-3 shrink-0 text-muted-foreground/30 opacity-0 transition-opacity group-hover:opacity-100"
-      />
+      <GripVerticalIcon className="size-3 shrink-0 text-muted-foreground/30 opacity-0 transition-opacity group-hover:opacity-100" />
 
       <span className="flex-1 truncate text-sm font-medium text-foreground">
         {item.reference}
@@ -86,6 +88,33 @@ export function QueuePanel() {
   const items = useQueueStore((s) => s.items)
   const activeIndex = useQueueStore((s) => s.activeIndex)
   const highlightedId = useQueueStore((s) => s.highlightedId)
+  const { predictions, fetchPredictions } = usePrediction()
+  const [suggesting, setSuggesting] = useState(false)
+
+  const handleSuggest = async () => {
+    setSuggesting(true)
+    try {
+      const results = await fetchPredictions(3)
+      for (const pred of results ?? []) {
+        const verse = {
+          id: 0,
+          book_number: pred.book_number,
+          book_name: pred.book_name,
+          chapter: pred.chapter,
+          verse: pred.verse,
+          text: pred.verse_text,
+        }
+        useQueueStore.getState().addItem({
+          id: `suggest-${Date.now()}-${pred.verse_ref}`,
+          reference: pred.verse_ref,
+          verse,
+          source: "manual",
+        })
+      }
+    } finally {
+      setSuggesting(false)
+    }
+  }
 
   return (
     <div
@@ -95,6 +124,14 @@ export function QueuePanel() {
       <PanelHeader title="Queue">
         <div className="flex items-center gap-2">
           <Badge variant="outline">{items.length}</Badge>
+          <button
+            onClick={handleSuggest}
+            disabled={suggesting}
+            className="text-[0.625rem] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+          >
+            <SparklesIcon className="mr-1 inline h-2.5 w-2.5" />
+            Suggest
+          </button>
           <button
             onClick={() => useQueueStore.getState().clearQueue()}
             className="text-[0.625rem] text-muted-foreground transition-colors hover:text-foreground"

--- a/src/hooks/use-prediction.ts
+++ b/src/hooks/use-prediction.ts
@@ -1,0 +1,37 @@
+import { invoke } from "@tauri-apps/api/core"
+import type { PredictionResult } from "@/types"
+import { useState, useCallback } from "react"
+
+async function predictNextVerses(limit?: number) {
+  const results = await invoke<PredictionResult[]>("predict_next_verses", {
+    limit,
+  })
+  return results
+}
+
+export function usePrediction() {
+  const [predictions, setPredictions] = useState<PredictionResult[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchPredictions = useCallback(async (limit = 5) => {
+    setLoading(true)
+    try {
+      const results = await predictNextVerses(limit)
+      setPredictions(results)
+      return results
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const clearPredictions = useCallback(() => {
+    setPredictions([])
+  }, [])
+
+  return {
+    predictions,
+    loading,
+    fetchPredictions,
+    clearPredictions,
+  }
+}

--- a/src/types/detection.ts
+++ b/src/types/detection.ts
@@ -27,3 +27,14 @@ export interface SemanticSearchResult {
   verse: number
   similarity: number
 }
+
+export interface PredictionResult {
+  verse_ref: string
+  verse_text: string
+  book_name: string
+  book_number: number
+  chapter: number
+  verse: number
+  confidence: number
+  strategy: string
+}


### PR DESCRIPTION
## Summary
Add upcoming verse prediction feature that suggests which Bible verse might be referenced next during a sermon.
## Changes
- Add prediction module with VersePredictor (sequential, reading mode strategies)
- Add Tauri command: predict_next_verses
- Add usePrediction hook in frontend
- Add Predict button to Preview panel
- Add Suggest button to Queue panel
## Prediction strategies
- Sequential: next 1-2 verses in current chapter
- ReadingMode: next verses when reading mode is active
## Description
This PR adds a new verse prediction feature that helps users anticipate upcoming Bible references during live sermon transcription. When enabled, the feature:
1. Tracks the current position in the sermon (from detected verses or reading mode)
2. Predicts the next 1-2 sequential verses in the current chapter
3. When reading mode is active, predicts upcoming verses in the passage
Users can click "Predict" in the Preview panel or "Suggest" in the Queue panel to fetch predictions.
## Type of change
- [x] New feature
## Areas affected
- [x] Frontend (React / TypeScript)
- [x] Backend (Rust / Tauri commands)
- [x] Rust crate: rhema-detection
## Checklist
- [x] I have tested this change locally
- [ ] `bun run typecheck` passes (requires cmake for full build)
- [x] `cargo clippy` passes without warnings
## Tested on
- [x] macOS