### PR TITLE
Bug: CSP fix for #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,17 +212,7 @@ rhema/
 
 ## Security
 
-Rhema implements a restrictive **Content Security Policy (CSP)** to protect against script injection attacks and unauthorized data exfiltration. The CSP:
-
-- ✅ Blocks inline scripts and external script loading (`script-src 'self'`)
-- ✅ Whitelists only Deepgram API for network connections
-- ✅ Prevents clickjacking with `frame-src 'none'`
-- ✅ Allows theme background images from HTTPS sources only
-- ✅ Blocks forms from submitting to external sites
-
-For detailed security documentation, including threat model, CSP configuration, and security best practices, see **[SECURITY.md](SECURITY.md)**.
-
-To report security vulnerabilities,please reachout to the maintainer instead of opening public issues.
+Rhema enforces a restrictive Content Security Policy on the Tauri webview to prevent script injection and unauthorized data exfiltration. The policy is defined in `src-tauri/tauri.conf.json`; see **[SECURITY.md](SECURITY.md)** for the directive-by-directive rationale, threat model, and vulnerability reporting process.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ rhema/
 | `quantize:model` | Quantize ONNX model to INT8 for ARM64 |
 | `download:ndi-sdk` | Download NDI 6 SDK headers and platform libraries |
 
+## Security
+
+Rhema implements a restrictive **Content Security Policy (CSP)** to protect against script injection attacks and unauthorized data exfiltration. The CSP:
+
+- ✅ Blocks inline scripts and external script loading (`script-src 'self'`)
+- ✅ Whitelists only Deepgram API for network connections
+- ✅ Prevents clickjacking with `frame-src 'none'`
+- ✅ Allows theme background images from HTTPS sources only
+- ✅ Blocks forms from submitting to external sites
+
+For detailed security documentation, including threat model, CSP configuration, and security best practices, see **[SECURITY.md](SECURITY.md)**.
+
+To report security vulnerabilities,please reachout to the maintainer instead of opening public issues.
+
 ## Environment Variables
 
 Create a `.env` file in the project root (optional):

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,258 +1,72 @@
 # Security Policy
 
-## Content Security Policy (CSP)
+This document describes Rhema's Content Security Policy and how to report vulnerabilities.
 
-This application implements a restrictive Content Security Policy to protect against script injection attacks and unauthorized data exfiltration.
+## Content Security Policy
 
-### Current CSP Configuration
+Rhema sets the webview CSP via `src-tauri/tauri.conf.json`. CSP applies only to the webview (JavaScript, HTML, and CSS loaded inside the Tauri window); it does **not** gate network calls made by the Rust process.
 
-```
+```text
 default-src 'self';
 script-src 'self';
 style-src 'self' 'unsafe-inline';
-img-src 'self' data: blob: https:;
+img-src 'self' data: blob:;
 font-src 'self' data:;
-connect-src 'self' wss://api.deepgram.com https://api.deepgram.com;
+connect-src 'self';
 media-src 'self' blob:;
+worker-src 'self';
 frame-src 'none';
+frame-ancestors 'none';
 object-src 'none';
 base-uri 'self';
 form-action 'self';
+manifest-src 'self';
 ```
 
-### Policy Breakdown
+### Directive rationale
 
-#### `default-src 'self'`
-All resources default to same-origin only. This is the foundation of the security policy.
+- **`default-src 'self'`** — same-origin fallback for any directive not listed.
+- **`script-src 'self'`** — no inline scripts, no `eval`, no external CDNs. The frontend bundle is the only script source.
+- **`style-src 'self' 'unsafe-inline'`** — `'unsafe-inline'` is required by Tailwind utility generation, React inline `style={}` props, and the `<style>` block in `broadcast-output.html`.
+- **`img-src 'self' data: blob:`** — `data:` covers theme background images (loaded via `@tauri-apps/plugin-fs` and converted to base64 in `src/lib/theme-designer-files.ts`); `blob:` covers canvas-derived images in the broadcast output window. External HTTPS images are deliberately **not** allowed: there is no feature that accepts an HTTPS URL from a user, and allowing `https:` would open an `<img src>`-based exfil path.
+- **`font-src 'self' data:`** — fonts ship bundled via `@fontsource-variable/*`; `data:` permits inline font data.
+- **`connect-src 'self'`** — the frontend makes no direct external network calls. All external traffic (e.g., Deepgram STT over WebSocket in `src-tauri/crates/stt/`) is initiated from Rust and is out of scope for CSP.
+- **`media-src 'self' blob:`** — audio capture and playback via MediaStream-derived blob URLs.
+- **`worker-src 'self'`** — explicit; prevents workers from remote origins if any are added later.
+- **`frame-src 'none'`** and **`frame-ancestors 'none'`** — the app does not use iframes and must not be embedded.
+- **`object-src 'none'`** — no plugins, applets, or `<object>` content.
+- **`base-uri 'self'`** — prevents `<base>` tag hijacking.
+- **`form-action 'self'`** — forms cannot submit to external origins.
+- **`manifest-src 'self'`** — no PWA manifest is used; lock it down.
 
-#### `script-src 'self'`
-**Scripts must be from the app bundle only.**
-- ✅ Prevents inline script injection
-- ✅ Blocks external script loading
-- ✅ Protects against XSS attacks
+## Threat model
 
-#### `style-src 'self' 'unsafe-inline'`
-**Styles from app bundle or inline.**
-- ⚠️ `'unsafe-inline'` required for:
-  - Tailwind CSS utility classes
-  - shadcn/ui component styles
-  - Dynamic theme styling
-- ✅ Still blocks external stylesheet loading
+### What the CSP protects against
 
-#### `img-src 'self' data: blob: https:`
-**Images from multiple sources (controlled risk).**
-- `'self'` - App bundle images
-- `data:` - Base64-encoded images (safe, inline data)
-- `blob:` - Canvas-generated images for broadcast output
-- `https:` - **User-supplied theme background images**
+- Script injection in the webview (reflected or stored) — no `'unsafe-inline'` or `'unsafe-eval'` in `script-src`.
+- Data exfiltration via `<img>`, `<script>`, `<iframe>`, `fetch`, or WebSocket from the webview.
+- Clickjacking — the app will not be framed.
+- External form-target CSRF and `<base>` tag redirection.
 
-**Security Note:** This is the primary attack surface. Users can set arbitrary HTTPS URLs as theme background images. However:
-1. Only HTTPS allowed (no HTTP)
-2. No JavaScript execution from images
-3. No script-src allows inline scripts
-4. Images are sandboxed in Tauri webview
+### What the CSP does NOT cover
 
-**Mitigation:** Theme background images are validated and rendered in an isolated context (broadcast output window).
+- Network calls from Rust (the STT crate's Deepgram WebSocket, any future `reqwest` calls). Audit Rust-side outbound traffic separately.
+- Local IPC via Tauri `invoke()` — this uses custom protocols that are same-origin from the webview's perspective.
+- Supply-chain risks (a compromised npm or cargo dependency that injects code at build time).
 
-#### `font-src 'self' data:`
-**Fonts from app bundle or data URIs.**
-- ✅ Blocks external font loading
-- ✅ `data:` allows embedded font resources
+## Notes for contributors
 
-#### `connect-src 'self' wss://api.deepgram.com https://api.deepgram.com`
-**Network connections strictly whitelisted.**
-- `'self'` - Local Tauri commands and IPC
-- `wss://api.deepgram.com` - Deepgram WebSocket for STT
-- `https://api.deepgram.com` - Deepgram HTTPS API
+- Do **not** add `'unsafe-eval'` or `'unsafe-inline'` to `script-src` to unblock a dev tool. Fix the tool or bundle it locally.
+- If we ever render local files in `<img>` or `<video>` via `@tauri-apps/api/core.convertFileSrc`, add `asset:` (Linux/macOS) and `http://asset.localhost` (Windows) to the relevant `*-src` directive.
+- If a future feature requires the webview to talk to an external API, add only the specific origin to `connect-src`. Avoid scheme-wildcards like `https:`.
+- On Windows, if `invoke()` starts failing with CSP errors after a Tauri upgrade, try adding `ipc: http://ipc.localhost` to `connect-src` — Tauri v2 routes Windows IPC through that custom host.
 
-**Explicitly Blocked:**
-- ❌ OpenAI API (not currently used)
-- ❌ Anthropic API (not currently used)
-- ❌ Any other external services
+## Reporting vulnerabilities
 
-**Note:** If OpenAI or Anthropic APIs are added in the future, update CSP to:
-```
-connect-src 'self' wss://api.deepgram.com https://api.deepgram.com https://api.openai.com https://api.anthropic.com;
-```
-
-#### `media-src 'self' blob:`
-**Media from app bundle or blob URLs.**
-- `'self'` - App audio files
-- `blob:` - Audio recording and playback
-
-#### `frame-src 'none'`
-**Frames/iframes completely blocked.**
-- ✅ Prevents clickjacking
-- ✅ Prevents embedded malicious content
-
-#### `object-src 'none'`
-**Object/embed/applet tags blocked.**
-- ✅ No Flash or legacy plugins
-- ✅ No object-based injections
-
-#### `base-uri 'self'`
-**Base tag restricted to same-origin.**
-- ✅ Prevents base tag hijacking
-
-#### `form-action 'self'`
-**Forms can only submit to same-origin.**
-- ✅ Prevents form submission to external sites
-- ✅ Protects against CSRF
-
-## Threat Model
-
-### Protected Against
-
-✅ **Script Injection (XSS)**
-- `script-src 'self'` prevents inline and external scripts
-- Even if user input is reflected in HTML, scripts cannot execute
-
-✅ **Clickjacking**
-- `frame-src 'none'` prevents embedding in iframes
-
-✅ **Data Exfiltration via Scripts**
-- No external script loading means no attacker-controlled code
-
-✅ **Unauthorized API Connections**
-- `connect-src` whitelist blocks connections to unknown origins
-
-✅ **CSRF Attacks**
-- `form-action 'self'` prevents form submissions to external sites
-
-### Residual Risks
-
-⚠️ **Theme Background Image URLs**
-- Users can set HTTPS URLs for theme backgrounds
-- **Risk Level:** Low
-- **Reason:** Images cannot execute JavaScript
-- **Mitigation:**
-  - Only HTTPS allowed
-  - Rendered in isolated broadcast window
-  - No `script-src` allows code execution from images
-
-⚠️ **Inline Styles (`unsafe-inline`)**
-- Required for Tailwind and shadcn/ui
-- **Risk Level:** Very Low
-- **Reason:** Styles cannot execute code
-- **Note:** CSS injection attacks are limited without script execution
-
-## Security Best Practices
-
-### For Developers
-
-1. **Never add `'unsafe-eval'` to `script-src`**
-   - This would allow `eval()` and `Function()` constructors
-   - Defeats most XSS protections
-
-2. **Validate user input on the backend (Rust)**
-   - Don't rely solely on CSP for input validation
-   - Sanitize and validate all user-supplied data
-
-3. **Keep external API whitelist minimal**
-   - Only add APIs that are actively used
-   - Remove APIs when features are deprecated
-
-4. **Test CSP violations**
-   - Monitor browser console for CSP violations during development
-   - Fix violations rather than loosening policy
-
-### For Theme Developers
-
-1. **Use trusted image sources**
-   - Prefer local images (`file://` or data URIs)
-   - Use reputable HTTPS image hosts if external images needed
-
-2. **Avoid SVG images with embedded scripts**
-   - SVG can contain `<script>` tags
-   - CSP blocks script execution, but avoid as defense-in-depth
-
-## CSP Violation Reporting
-
-CSP violations appear in the browser console during development:
-
-```
-Refused to load <resource> because it violates the following Content Security Policy directive: <directive>
-```
-
-### Common Violations and Fixes
-
-#### ❌ External script blocked
-```
-Refused to load script from 'https://evil.com/script.js' because it violates CSP directive: script-src 'self'
-```
-**Fix:** Remove external script or bundle it locally.
-
-#### ❌ Inline event handler blocked
-```
-Refused to execute inline event handler because it violates CSP directive: script-src 'self'
-```
-**Fix:** Use `addEventListener()` in a separate `.ts` file instead of `onclick=""`.
-
-#### ❌ External API connection blocked
-```
-Refused to connect to 'https://unknown-api.com' because it violates CSP directive: connect-src ...
-```
-**Fix:** Add the API to `connect-src` whitelist if it's a legitimate service.
-
-## Future Enhancements
-
-### Potential Improvements
-
-1. **Image URL Validation**
-   - Add backend validation for theme background image URLs
-   - Restrict to specific domains or patterns
-
-2. **Remove `'unsafe-inline'` from `style-src`**
-   - Possible if Tailwind uses nonce or hash-based CSP
-   - Would require build-time style extraction
-
-3. **Add CSP Reporting**
-   - Configure `report-uri` or `report-to` directive
-   - Log CSP violations to backend for monitoring
-
-4. **Subresource Integrity (SRI)**
-   - Add integrity hashes for critical resources
-   - Further prevents tampering
-
-## Testing
-
-### Manual CSP Verification
-
-1. **Open DevTools Console**
-2. **Trigger each app feature:**
-   - Theme designer with background images
-   - Voice transcription (Deepgram connection)
-   - Broadcast output window
-3. **Check for CSP violations**
-   - Should see zero violations under normal operation
-
-### Automated Testing
-
-```bash
-# Check CSP configuration
-cat src-tauri/tauri.conf.json | jq '.app.security.csp'
-
-# Build and run
-bun run tauri dev
-
-# Monitor console for violations
-```
-
-## Reporting Security Issues
-
-If you discover a security vulnerability, please email security@openbezal.com instead of opening a public issue.
-
-**Do NOT:**
-- Open public GitHub issues for security vulnerabilities
-- Disclose vulnerabilities publicly before a fix is available
-
-**DO:**
-- Provide detailed reproduction steps
-- Include proof-of-concept (if applicable)
-- Allow time for a fix before public disclosure
+Email **faithfulojebiyi@gmail.com**. Please do not open public issues for security reports. Include reproduction steps and, if possible, a proof of concept.
 
 ## References
 
-- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
-- [OWASP: CSP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)
-- [Tauri Security Best Practices](https://tauri.app/v1/references/architecture/security/)
+- [MDN — Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+- [OWASP — CSP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)
+- [Tauri v2 Security](https://v2.tauri.app/security/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ manifest-src 'self';
 
 - **`default-src 'self'`** — same-origin fallback for any directive not listed.
 - **`script-src 'self'`** — no inline scripts, no `eval`, no external CDNs. The frontend bundle is the only script source.
-- **`style-src 'self' 'unsafe-inline'`** — `'unsafe-inline'` is required by Tailwind utility generation, React inline `style={}` props, and the `<style>` block in `broadcast-output.html`.
+- **`style-src 'self' 'unsafe-inline'`** — `'unsafe-inline'` is required by Tailwind utility generation, React inline `style={}` props, the `<style>` block in `broadcast-output.html`, and the dynamic `<style>` element that `src/components/theme-provider.tsx` injects during theme switches to suppress transitions.
 - **`img-src 'self' data: blob:`** — `data:` covers theme background images (loaded via `@tauri-apps/plugin-fs` and converted to base64 in `src/lib/theme-designer-files.ts`); `blob:` covers canvas-derived images in the broadcast output window. External HTTPS images are deliberately **not** allowed: there is no feature that accepts an HTTPS URL from a user, and allowing `https:` would open an `<img src>`-based exfil path.
 - **`font-src 'self' data:`** — fonts ship bundled via `@fontsource-variable/*`; `data:` permits inline font data.
 - **`connect-src 'self'`** — the frontend makes no direct external network calls. All external traffic (e.g., Deepgram STT over WebSocket in `src-tauri/crates/stt/`) is initiated from Rust and is out of scope for CSP.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,258 @@
+# Security Policy
+
+## Content Security Policy (CSP)
+
+This application implements a restrictive Content Security Policy to protect against script injection attacks and unauthorized data exfiltration.
+
+### Current CSP Configuration
+
+```
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob: https:;
+font-src 'self' data:;
+connect-src 'self' wss://api.deepgram.com https://api.deepgram.com;
+media-src 'self' blob:;
+frame-src 'none';
+object-src 'none';
+base-uri 'self';
+form-action 'self';
+```
+
+### Policy Breakdown
+
+#### `default-src 'self'`
+All resources default to same-origin only. This is the foundation of the security policy.
+
+#### `script-src 'self'`
+**Scripts must be from the app bundle only.**
+- ✅ Prevents inline script injection
+- ✅ Blocks external script loading
+- ✅ Protects against XSS attacks
+
+#### `style-src 'self' 'unsafe-inline'`
+**Styles from app bundle or inline.**
+- ⚠️ `'unsafe-inline'` required for:
+  - Tailwind CSS utility classes
+  - shadcn/ui component styles
+  - Dynamic theme styling
+- ✅ Still blocks external stylesheet loading
+
+#### `img-src 'self' data: blob: https:`
+**Images from multiple sources (controlled risk).**
+- `'self'` - App bundle images
+- `data:` - Base64-encoded images (safe, inline data)
+- `blob:` - Canvas-generated images for broadcast output
+- `https:` - **User-supplied theme background images**
+
+**Security Note:** This is the primary attack surface. Users can set arbitrary HTTPS URLs as theme background images. However:
+1. Only HTTPS allowed (no HTTP)
+2. No JavaScript execution from images
+3. No script-src allows inline scripts
+4. Images are sandboxed in Tauri webview
+
+**Mitigation:** Theme background images are validated and rendered in an isolated context (broadcast output window).
+
+#### `font-src 'self' data:`
+**Fonts from app bundle or data URIs.**
+- ✅ Blocks external font loading
+- ✅ `data:` allows embedded font resources
+
+#### `connect-src 'self' wss://api.deepgram.com https://api.deepgram.com`
+**Network connections strictly whitelisted.**
+- `'self'` - Local Tauri commands and IPC
+- `wss://api.deepgram.com` - Deepgram WebSocket for STT
+- `https://api.deepgram.com` - Deepgram HTTPS API
+
+**Explicitly Blocked:**
+- ❌ OpenAI API (not currently used)
+- ❌ Anthropic API (not currently used)
+- ❌ Any other external services
+
+**Note:** If OpenAI or Anthropic APIs are added in the future, update CSP to:
+```
+connect-src 'self' wss://api.deepgram.com https://api.deepgram.com https://api.openai.com https://api.anthropic.com;
+```
+
+#### `media-src 'self' blob:`
+**Media from app bundle or blob URLs.**
+- `'self'` - App audio files
+- `blob:` - Audio recording and playback
+
+#### `frame-src 'none'`
+**Frames/iframes completely blocked.**
+- ✅ Prevents clickjacking
+- ✅ Prevents embedded malicious content
+
+#### `object-src 'none'`
+**Object/embed/applet tags blocked.**
+- ✅ No Flash or legacy plugins
+- ✅ No object-based injections
+
+#### `base-uri 'self'`
+**Base tag restricted to same-origin.**
+- ✅ Prevents base tag hijacking
+
+#### `form-action 'self'`
+**Forms can only submit to same-origin.**
+- ✅ Prevents form submission to external sites
+- ✅ Protects against CSRF
+
+## Threat Model
+
+### Protected Against
+
+✅ **Script Injection (XSS)**
+- `script-src 'self'` prevents inline and external scripts
+- Even if user input is reflected in HTML, scripts cannot execute
+
+✅ **Clickjacking**
+- `frame-src 'none'` prevents embedding in iframes
+
+✅ **Data Exfiltration via Scripts**
+- No external script loading means no attacker-controlled code
+
+✅ **Unauthorized API Connections**
+- `connect-src` whitelist blocks connections to unknown origins
+
+✅ **CSRF Attacks**
+- `form-action 'self'` prevents form submissions to external sites
+
+### Residual Risks
+
+⚠️ **Theme Background Image URLs**
+- Users can set HTTPS URLs for theme backgrounds
+- **Risk Level:** Low
+- **Reason:** Images cannot execute JavaScript
+- **Mitigation:**
+  - Only HTTPS allowed
+  - Rendered in isolated broadcast window
+  - No `script-src` allows code execution from images
+
+⚠️ **Inline Styles (`unsafe-inline`)**
+- Required for Tailwind and shadcn/ui
+- **Risk Level:** Very Low
+- **Reason:** Styles cannot execute code
+- **Note:** CSS injection attacks are limited without script execution
+
+## Security Best Practices
+
+### For Developers
+
+1. **Never add `'unsafe-eval'` to `script-src`**
+   - This would allow `eval()` and `Function()` constructors
+   - Defeats most XSS protections
+
+2. **Validate user input on the backend (Rust)**
+   - Don't rely solely on CSP for input validation
+   - Sanitize and validate all user-supplied data
+
+3. **Keep external API whitelist minimal**
+   - Only add APIs that are actively used
+   - Remove APIs when features are deprecated
+
+4. **Test CSP violations**
+   - Monitor browser console for CSP violations during development
+   - Fix violations rather than loosening policy
+
+### For Theme Developers
+
+1. **Use trusted image sources**
+   - Prefer local images (`file://` or data URIs)
+   - Use reputable HTTPS image hosts if external images needed
+
+2. **Avoid SVG images with embedded scripts**
+   - SVG can contain `<script>` tags
+   - CSP blocks script execution, but avoid as defense-in-depth
+
+## CSP Violation Reporting
+
+CSP violations appear in the browser console during development:
+
+```
+Refused to load <resource> because it violates the following Content Security Policy directive: <directive>
+```
+
+### Common Violations and Fixes
+
+#### ❌ External script blocked
+```
+Refused to load script from 'https://evil.com/script.js' because it violates CSP directive: script-src 'self'
+```
+**Fix:** Remove external script or bundle it locally.
+
+#### ❌ Inline event handler blocked
+```
+Refused to execute inline event handler because it violates CSP directive: script-src 'self'
+```
+**Fix:** Use `addEventListener()` in a separate `.ts` file instead of `onclick=""`.
+
+#### ❌ External API connection blocked
+```
+Refused to connect to 'https://unknown-api.com' because it violates CSP directive: connect-src ...
+```
+**Fix:** Add the API to `connect-src` whitelist if it's a legitimate service.
+
+## Future Enhancements
+
+### Potential Improvements
+
+1. **Image URL Validation**
+   - Add backend validation for theme background image URLs
+   - Restrict to specific domains or patterns
+
+2. **Remove `'unsafe-inline'` from `style-src`**
+   - Possible if Tailwind uses nonce or hash-based CSP
+   - Would require build-time style extraction
+
+3. **Add CSP Reporting**
+   - Configure `report-uri` or `report-to` directive
+   - Log CSP violations to backend for monitoring
+
+4. **Subresource Integrity (SRI)**
+   - Add integrity hashes for critical resources
+   - Further prevents tampering
+
+## Testing
+
+### Manual CSP Verification
+
+1. **Open DevTools Console**
+2. **Trigger each app feature:**
+   - Theme designer with background images
+   - Voice transcription (Deepgram connection)
+   - Broadcast output window
+3. **Check for CSP violations**
+   - Should see zero violations under normal operation
+
+### Automated Testing
+
+```bash
+# Check CSP configuration
+cat src-tauri/tauri.conf.json | jq '.app.security.csp'
+
+# Build and run
+bun run tauri dev
+
+# Monitor console for violations
+```
+
+## Reporting Security Issues
+
+If you discover a security vulnerability, please email security@openbezal.com instead of opening a public issue.
+
+**Do NOT:**
+- Open public GitHub issues for security vulnerabilities
+- Disclose vulnerabilities publicly before a fix is available
+
+**DO:**
+- Provide detailed reproduction steps
+- Include proof-of-concept (if applicable)
+- Allow time for a fix before public disclosure
+
+## References
+
+- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+- [OWASP: CSP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)
+- [Tauri Security Best Practices](https://tauri.app/v1/references/architecture/security/)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss://api.deepgram.com https://api.deepgram.com; media-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; media-src 'self' blob:; worker-src 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss://api.deepgram.com https://api.deepgram.com; media-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Description

Implements a restrictive Content Security Policy (CSP) to fix a critical security vulnerability where CSP was completely disabled (`"csp": null`), leaving the application vulnerable to script injection attacks, data exfiltration, clickjacking, and CSRF.

This PR replaces the null CSP with a hardened policy that follows the principle of least privilege, restricting the webview to same-origin resources and explicitly denying frames, objects, external forms, and base-URI hijacking. All external API traffic (Deepgram STT) is initiated from the Rust backend and is therefore out of CSP scope — this is now documented explicitly in `SECURITY.md`.

> **Update on follow-up commits (`7c0728c`, `0300d36`)** — the original patch allowlisted Deepgram in `connect-src` and `https:` in `img-src` based on misread assumptions about how those features are wired. Review found that the webview makes no direct external calls (Deepgram runs in Rust) and theme images are loaded as `data:` URLs from local file picker (not HTTPS). Both allowlists were dropped, `worker-src`, `frame-ancestors`, and `manifest-src` were added as baseline hardening, and the branch was merged with `main`. Sections below reflect the final state.

### Security Impact

**Before this PR:**
- CSP was disabled (`"csp": null`)
- Any injected content could execute arbitrary scripts
- Unrestricted network connections to any domain
- Vulnerable to XSS, clickjacking, and data exfiltration attacks

**After this PR:**
- Strict CSP blocks inline scripts and external script loading
- ~~Network connections whitelisted to Deepgram API only~~ **Network connections restricted to `'self'` only.** Deepgram STT runs in the Rust STT crate, which is outside CSP scope; the webview itself makes no direct external calls (verified by grep across `src/`).
- ~~Allows theme background images from HTTPS sources only~~ **`img-src` narrowed to `'self' data: blob:`.** Theme images are loaded from local files via `@tauri-apps/plugin-fs` and stored as `data:` URLs — no HTTPS image input path exists in the codebase.
- Frames completely blocked (prevents clickjacking)
- `frame-ancestors 'none'` prevents the app from being embedded
- Forms cannot submit to external sites (prevents CSRF)
- Workers locked to `'self'`, `manifest-src 'self'`, `object-src 'none'`, `base-uri 'self'`

### CSP Configuration

```
default-src 'self';
script-src 'self';
style-src 'self' 'unsafe-inline';
img-src 'self' data: blob:;
font-src 'self' data:;
connect-src 'self';
media-src 'self' blob:;
worker-src 'self';
frame-src 'none';
frame-ancestors 'none';
object-src 'none';
base-uri 'self';
form-action 'self';
manifest-src 'self';
```

### What This Protects Against

- ✅ **Cross-Site Scripting (XSS)** — `script-src 'self'` blocks inline and external scripts; no `'unsafe-eval'` or `'unsafe-inline'` in `script-src`.
- ✅ **Data Exfiltration from webview** — `connect-src 'self'` blocks outbound requests; `img-src` no longer permits arbitrary HTTPS targets (which could otherwise be used as `<img>`-based beacons).
- ✅ **Clickjacking** — `frame-src 'none'` and `frame-ancestors 'none'`.
- ✅ **CSRF** — `form-action 'self'`.
- ✅ **Base-tag hijacking** — `base-uri 'self'`.
- ✅ **Plugin-based injection** — `object-src 'none'`.

### What This Does NOT Cover (documented in SECURITY.md)

- Network calls initiated from Rust (Deepgram WebSocket, any future `reqwest` calls). These are not CSP-gated and should be audited separately.
- Local IPC via Tauri `invoke()`. Same-origin from the webview's perspective.
- Supply-chain risk (compromised npm/cargo dependency injecting code at build time).

### Files Changed

**Modified:**
- `src-tauri/tauri.conf.json` — replaced `"csp": null` with the final restrictive policy above.
- `README.md` — added a two-sentence `## Security` section pointing at `SECURITY.md` (no duplicated contact details, no inaccurate bullet list).

**Created:**
- `SECURITY.md` — ~72 lines covering:
  - Current CSP (verbatim)
  - Per-directive rationale
  - Threat model split into "what CSP covers" vs. "what it does not cover"
  - Notes for contributors (no `'unsafe-eval'`, future `convertFileSrc` needs `asset:`, Windows `ipc:` escape hatch)
  - Responsible-disclosure contact

## Type of change

- [X] Bug fix (security vulnerability)

## Areas affected

- [X] Frontend (React / TypeScript) — CSP applies to all webview code
- [X] Backend (Rust / Tauri commands) — configuration change only, no Rust code affected

## Checklist

- [X] I have tested this change locally
- [X] `cargo clippy` passes without warnings
- [X] Security documentation (`SECURITY.md`) reflects the shipped policy

## Tested on

- [X] macOS — `bun run tauri dev`, DevTools Console, exercised transcription, theme designer (image background), and broadcast output window; zero CSP violations observed.
- [ ] Windows — **not tested by this PR.** Tauri v2 routes Windows IPC through `http://ipc.localhost`. If `invoke()` fails with a CSP error on Windows, add `ipc: http://ipc.localhost` to `connect-src`. (See the Notes for Contributors section in `SECURITY.md`.)

## Screenshots / recordings

**CSP in `tauri.conf.json`:**

Before:
```json
"security": {
  "csp": null
}
```

After:
```json
"security": {
  "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; media-src 'self' blob:; worker-src 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
}
```

### Manual Testing Verification

To validate locally:

1. Launch the app: `bun run tauri dev`
2. Open DevTools Console (`Cmd+Option+I` on macOS)
3. Exercise:
   - Main window loads; navigate all panels (stresses `default-src`, `script-src`, `style-src`, IPC via `'self'`)
   - Start transcription (stresses `media-src blob:`; Deepgram itself is Rust-side and unaffected by CSP)
   - Theme designer → pick a background image from disk (stresses `img-src data:`)
   - Open broadcast output window + push a verse (second webview inherits CSP; stresses inline `<style>` in `broadcast-output.html` against `style-src 'unsafe-inline'`)
   - `Cmd+R` reload (stresses Vite HMR same-origin WS against `connect-src 'self'`)
4. Console should show zero `Refused to ...` CSP violations.
5. All interactive features continue to function.

**Expected results:**

- ✅ No CSP violations in the webview console.
- ✅ All Tauri `invoke()` calls succeed.
- ✅ Theme background images render from `data:` URLs.
- ✅ Broadcast output window renders and updates via events.
- ✅ Transcription works end-to-end (STT traffic is Rust-side, not visible in webview CSP).

### Maintainer notes

- Please **squash-merge** so the final commit on `main` uses a Conventional Commits title, e.g. `fix: replace disabled CSP with restrictive policy (#54)`. The branch contains the original `security fix` commit which does not meet project convention; squashing avoids carrying it into `main`.
- Branch has been merged with `main` (`0300d36`); no rebase needed before merge.
