### PR TITLE
Display Rhema as the app name across platforms

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "vite-app",
+      "name": "rhema",
       "dependencies": {
         "@dnd-kit/react": "^0.3.2",
         "@fontsource-variable/geist": "^5.2.8",

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>vite-app</title>
+    <title>Rhema</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -168,32 +168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "app"
-version = "0.1.0"
-dependencies = [
- "base64 0.22.1",
- "crossbeam-channel",
- "dotenvy",
- "log",
- "rhema-api",
- "rhema-audio",
- "rhema-bible",
- "rhema-broadcast",
- "rhema-detection",
- "rhema-stt",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
- "tauri-plugin-fs",
- "tauri-plugin-global-shortcut",
- "tauri-plugin-log",
- "tauri-plugin-store",
- "tokio",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4094,6 +4068,32 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rhema"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "crossbeam-channel",
+ "dotenvy",
+ "log",
+ "rhema-api",
+ "rhema-audio",
+ "rhema-bible",
+ "rhema-broadcast",
+ "rhema-detection",
+ "rhema-stt",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
+ "tauri-plugin-global-shortcut",
+ "tauri-plugin-log",
+ "tauri-plugin-store",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 
 [package]
-name = "app"
+name = "rhema"
 version = "0.1.0"
 description = "Rhema - Real-Time AI Bible Verse Detection"
 authors = ["Faithful"]
@@ -38,8 +38,12 @@ edition = "2021"
 rust-version = "1.77.2"
 
 [lib]
-name = "app_lib"
+name = "rhema_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
+
+[[bin]]
+name = "Rhema"
+path = "src/main.rs"
 
 [build-dependencies]
 tauri-build = { version = "2.5.6", features = [] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    app_lib::run();
+    rhema_lib::run();
 }


### PR DESCRIPTION
## Problem

The Tauri binary was named `app` because the Cargo package was `[package] name = "app"`. That leaked into the OS shell on every platform:

- **macOS** — dev builds showed `app` (or `rhema` after an initial rename) in the menu bar next to the Apple logo.
- **Windows** — Task Manager listed the process as `app.exe`, and the built executable shipped as `app.exe`.
- **Linux** — the process and binary were called `app`.

The window title, bundle identifier, and installer display name were already correct (`productName: "Rhema"` in `tauri.conf.json`), so the issue only surfaced in places that read the raw executable name.

## Change

Rename the Tauri Cargo package and add an explicit binary target named `Rhema`:

- `src-tauri/Cargo.toml`
  - `[package] name`: `app` → `rhema` (lowercase per Rust convention)
  - `[lib] name`: `app_lib` → `rhema_lib`
  - Added `[[bin]] name = "Rhema"` so the produced executable is `Rhema` / `Rhema.exe`
- `src-tauri/src/main.rs` — `app_lib::run()` → `rhema_lib::run()`
- `src-tauri/Cargo.lock` — regenerated by `cargo check`
- `index.html` — `<title>vite-app</title>` → `<title>Rhema</title>`
- `bun.lock` — workspace name `vite-app` → `rhema` (follows `package.json`)

Keeping the Cargo package lowercase (`rhema`) preserves idiomatic crate naming while the `[[bin]]` name (`Rhema`) controls what end users see.

## Why this approach

- `productName` in `tauri.conf.json` already sets `CFBundleName` for packaged macOS builds, but in dev mode the menu bar reads the executable name, so the Cargo binary name has to match.
- Renaming via `[[bin]]` avoids giving the Rust crate a capitalized name (which triggers Cargo warnings and breaks convention) while still producing an executable with the desired display casing.
- No runtime code, menu APIs, or `Info.plist` overrides were needed — the fix is entirely in build configuration.

## Verification

- `cargo check -p rhema` compiles cleanly.
- No references to `app_lib` or the old `app` package remain (`grep` across repo).
- Stale `target/debug/app` artifacts are harmless; `cargo clean -p rhema` removes them if desired.

## Manual test plan

- [x] macOS: `bun tauri dev` — menu bar next to the Apple logo shows `Rhema`.
- [x] Windows: `bun tauri dev` — Task Manager lists the process as `Rhema.exe`; built artifact at `src-tauri/target/release/Rhema.exe`.
- [x] Linux: `bun tauri dev` — `ps` shows the process as `Rhema`.


## Demo

<img width="94" height="85" alt="image" src="https://github.com/user-attachments/assets/568d3ae4-8ed7-4c13-aff6-1c92eb766635" />
