### PR TITLE
Fix: Enable theme export by allowing `fs` write

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:default",
     "store:default",
     "dialog:default",
-    "fs:default"
+    "fs:default",
+    "fs:allow-write-text-file"
   ]
 }


### PR DESCRIPTION
Enables file write permissions in Tauri to allow exporting themes without runtime errors.

Fixes Issue #56

## Type of change

<!-- Check the one that applies: -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

<!-- Check all that apply: -->

- [ ] Frontend (React / TypeScript)
- [x] Backend (Rust / Tauri commands)
- [ ] Rust crate
- [ ] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [x] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [x] I have tested this change locally
- [x] `bun run typecheck` passes
- [x] `cargo clippy` passes without warnings
- [x] `bun run test` passes (if applicable)
- [ ] I have added tests for new functionality (if applicable)
- [x] UI changes include a screenshot or recording below

## Tested on

<!-- Check the platforms you tested on: -->

- [x] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

https://github.com/user-attachments/assets/fd33dfed-4937-469b-b6ca-180d557bca94
