### PR TITLE
feat: deploy web marketing site to github pages

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,68 @@
+name: Deploy web to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/deploy-web.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/deploy-web.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Next.js build
+        uses: actions/cache@v5
+        with:
+          path: web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('web/bun.lock') }}-${{ hashFiles('web/**/*.ts', 'web/**/*.tsx') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('web/bun.lock') }}-
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: web/out
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/web/README.md
+++ b/web/README.md
@@ -1,36 +1,35 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Rhema marketing site
 
-## Getting Started
+Next.js 16 marketing site for [Rhema](https://openrhema.com). Static-only — no API routes, no server actions. Deployed to GitHub Pages on push to `main`.
 
-First, run the development server:
+## Develop
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cd web
+bun install
+bun run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Opens [http://localhost:3029](http://localhost:3029).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Build
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+bun run build
+```
 
-## Learn More
+Outputs a static site to `web/out/`.
 
-To learn more about Next.js, take a look at the following resources:
+## Deploy
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Pushes to `main` that touch `web/**` trigger `.github/workflows/deploy-web.yml`, which builds the static export and publishes it to GitHub Pages at [https://openrhema.com](https://openrhema.com).
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+To trigger a deploy without code changes (e.g., to refresh the GitHub stars count baked into the page), use the **Run workflow** button on the *Deploy web to GitHub Pages* action in the GitHub UI.
 
-## Deploy on Vercel
+PRs touching `web/**` run the build job only (no deploy) as a smoke test.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Notes
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `output: "export"` in `next.config.ts` — static export is required for GitHub Pages. Anything that needs a Node server (route handlers, server actions, ISR, `next/image` optimization) will fail the build.
+- Self-hosted fonts under `public/fonts/`. Referenced from `app/globals.css` via absolute paths — do not introduce a `basePath`, it does not rewrite CSS `url()` values.
+- `getGitHubStars()` runs at build time. Authenticated via `GITHUB_TOKEN` in CI to avoid the 60/hr unauthenticated rate limit; falls back to a hardcoded count if the API call fails.

--- a/web/app/_lib/site.ts
+++ b/web/app/_lib/site.ts
@@ -3,7 +3,7 @@ export const SITE = {
   tagline: "Your Pastor speaks. Rhema finds the verse.",
   description:
     "Rhema listens to a live sermon audio feed, transcribes speech in real time, detects Bible verse references (both explicit citations and quoted passages), and renders them as broadcast-ready overlays via NDI for live production.",
-  url: "https://rhema.app",
+  url: "https://openrhema.com",
   repo: {
     owner: "openbezal",
     name: "rhema",
@@ -26,12 +26,15 @@ export const SITE = {
 
 export async function getGitHubStars(): Promise<number> {
   try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+    };
+    const token = process.env.GITHUB_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
+
     const res = await fetch(
       `https://api.github.com/repos/${SITE.repo.owner}/${SITE.repo.name}`,
-      {
-        next: { revalidate: 3600 },
-        headers: { Accept: "application/vnd.github+json" },
-      }
+      { headers }
     );
     if (!res.ok) return SITE.repo.stars.fallback;
     const data = (await res.json()) as { stargazers_count?: number };

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -13,8 +13,6 @@ import { FinalCtaSection } from "./_components/sections/final-cta-section";
 import { SiteFooter } from "./_components/sections/site-footer";
 import { getGitHubStars } from "./_lib/site";
 
-export const revalidate = 3600;
-
 export default async function Home() {
   const stars = await getGitHubStars();
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,12 @@
 import type { NextConfig } from "next";
+import { fileURLToPath } from "node:url";
 
 const nextConfig: NextConfig = {
+  output: "export",
+  trailingSlash: true,
+  turbopack: {
+    root: fileURLToPath(new URL(".", import.meta.url)),
+  },
   experimental: {
     optimizePackageImports: ["@tabler/icons-react"],
   },

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,0 +1,1 @@
+openrhema.com


### PR DESCRIPTION
Adds a static-export pipeline so the Next.js marketing site at /web is published to GitHub Pages on the custom apex domain openrhema.com:

- Configure Next.js for static export and trailing-slash URLs
- Drop ISR directives (revalidate) that are incompatible with output: export
- Authenticate the build-time GitHub stars fetch via GITHUB_TOKEN to avoid the unauthenticated 60/hr rate limit on shared CI egress
- Switch canonical site URL from rhema.app to openrhema.com
- Ship a CNAME so the artifact carries the custom domain
- Add a deploy workflow with PR build-only checks and a deploy job gated to push and workflow_dispatch
- Replace boilerplate web README with project-specific deploy notes

## Description

<!-- What does this PR do? Reference any related issues (e.g., `fixes #123`). -->

## Type of change

<!-- Check the one that applies: -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

<!-- Check all that apply: -->

- [x] Marketing website (React / TypeScript)
- [ ] Frontend (React / TypeScript)
- [ ] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [x] I have tested this change locally
- [x] `bun run typecheck` passes
- [ ] `cargo clippy` passes without warnings
- [ ] `bun run test` passes (if applicable)
- [ ] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

<!-- Check the platforms you tested on: -->

- [ ] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

<!-- If this PR includes UI changes, add screenshots or recordings here. -->
