### PR TITLE
fix: align docs and readme with codebase ground truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,19 @@ Rhema listens to a live sermon audio feed, transcribes speech in real time, dete
 - **Voice-controlled translation switching** — say "read in NIV" or "switch to ESV" to change translations instantly during a sermon
 - **Multi-strategy verse detection**
   - Direct reference parsing (Aho-Corasick automaton + fuzzy matching)
-  - Semantic search (Qwen3-0.6B ONNX embeddings + HNSW vector index)
+  - Semantic search — Qwen3-0.6B ONNX embeddings, brute-force cosine similarity over ~31k verse vectors (the `hnsw_index.rs` file is named after a future plan; today it scans linearly)
   - Quotation matching against known verse text
-  - Cloud booster (optional, OpenAI/Claude)
   - Reading mode — locks to book/chapter as soon as it's mentioned, with voice navigation ("next chapter", "chapter 5")
   - Sermon context tracking and sentence buffering
-- **SQLite Bible database** with FTS5 full-text search and BM25 ranking
-- **Multiple translations** — KJV, NIV, ESV, NASB, NKJV, NLT, AMP + Spanish, French, Portuguese
-- **Cross-reference lookup** (340k+ refs from openbible.info)
-- **NDI broadcast output** for live production integration
-- **Theme designer** — visual canvas editor for verse overlays with backgrounds (solid, gradient, image), text styling, positioning, shadows, and outlines
-- **Verse queue** with drag-and-drop ordering and duplicate prevention (flash-highlight on duplicates)
+- **SQLite Bible database** with FTS5 full-text search (BM25 ranking by default)
+- **10 bundled translations** — KJV, NIV, ESV, NASB, NKJV, NLT, AMP, plus SpaRV (Spanish), FreJND (French), and PorBLivre (Portuguese)
+- **Cross-reference lookup** (340k+ refs from openbible.info; the bundled file ships with 344,800 entries)
+- **NDI broadcast output** for live production integration — configurable resolution, 24/30/60 fps, and three alpha modes (none, straight, premultiplied)
+- **Theme designer** — visual canvas editor for verse overlays with backgrounds (solid, gradient, image, transparent), text styling, positioning, shadows, and outlines
+- **Verse queue** with drag-and-drop ordering (`@dnd-kit/react`) and duplicate prevention (flash-highlight on duplicates)
 - **Quick navigation** — keyboard-driven verse entry with autocomplete (e.g., type "J" → Joshua, Tab through book → chapter → verse)
 - **Fuzzy contextual search** (Fuse.js client-side)
-- **Audio level metering**, live indicator, and session timer
+- **Audio level metering** and on-air indicator
 - **Interactive onboarding tutorial** — 11-step guided tour covering all panels, auto-launches on first startup
 - **Light/dark mode** with system theme detection (light, dark, or follow OS)
 - **Settings persistence** — all preferences auto-saved to disk across restarts
@@ -45,14 +44,14 @@ Rhema listens to a live sermon audio feed, transcribes speech in real time, dete
 | **AI/ML** | ONNX Runtime (Qwen3-0.6B embeddings), Aho-Corasick, Fuse.js |
 | **Database** | SQLite via rusqlite (bundled) with FTS5 |
 | **Broadcast** | NDI 6 SDK via dynamic loading (libloading FFI) |
-| **STT** | Deepgram WebSocket + REST (tokio-tungstenite) |
+| **STT** | Local Whisper via `whisper-rs`; Deepgram WebSocket + REST (`tokio-tungstenite`) |
 
 ### Rust Crates
 
 | Crate | Purpose |
 |---|---|
 | `rhema-audio` | Audio device enumeration, capture, VAD (cpal) |
-| `rhema-stt` | Deepgram STT streaming + REST fallback |
+| `rhema-stt` | Local Whisper (gated behind `whisper` Cargo feature) and Deepgram STT streaming + REST fallback |
 | `rhema-bible` | SQLite Bible DB, FTS5 search, cross-references |
 | `rhema-detection` | Verse detection pipeline: direct, semantic, quotation, ensemble merger, sentence buffer, sermon context, reading mode |
 | `rhema-broadcast` | NDI video frame output via FFI |
@@ -114,7 +113,7 @@ bun install
 
 ### Quick Setup (recommended)
 
-One command sets up everything — Python virtual environment, Bible data, copyrighted translations, database, ONNX model, and precomputed embeddings:
+One command sets up everything — Python virtual environment, Bible data, database, ONNX model, precomputed embeddings, and the local Whisper model:
 
 > **Windows:** run `bun run setup:windows` *before* `setup:all` and restart your terminal. See [Platform-specific setup](#platform-specific-setup) above.
 
@@ -122,15 +121,15 @@ One command sets up everything — Python virtual environment, Bible data, copyr
 bun run setup:all
 ```
 
-This runs 7 phases in sequence, skipping any that are already complete:
+This runs 7 idempotent phases in sequence, skipping any whose output artifacts already exist (pass `--force` to re-run all):
 
-1. Python environment setup (`.venv` + all pip dependencies)
-2. Download open-source Bible data (KJV, Spanish, French, Portuguese + cross-references)
-3. Download copyrighted translations from BibleGateway (NIV, ESV, NASB, NKJV, NLT, AMP)
-4. Build SQLite Bible database (`data/rhema.db` with FTS5 + cross-references)
-5. Download & export ONNX model (Qwen3-Embedding-0.6B) + INT8 quantization
-6. Export KJV verses to JSON for embedding
-7. Precompute verse embeddings (auto-selects GPU if available, falls back to ONNX CPU)
+1. Python environment (`.venv` + pip deps: `optimum-onnx[onnxruntime]`, `sentence-transformers`, `accelerate`, `tokenizers`, `numpy`, `torch`, `meaningless`)
+2. Download Bible source data — single bundled archive containing all 10 translations plus the openbible.info cross-references zip
+3. Build SQLite Bible database (`data/rhema.db` with FTS5 + cross-references)
+4. Download & export ONNX model (`Qwen3-Embedding-0.6B`) + INT8 quantization for ARM64
+5. Export KJV verses to JSON for embedding precomputation
+6. Precompute verse embeddings (GPU sentence-transformers when available, ONNX CPU fallback otherwise)
+7. Download Whisper model (`ggml-large-v3-turbo-q8_0.bin`) into `models/whisper/`
 
 ### Environment
 
@@ -139,9 +138,9 @@ This runs 7 phases in sequence, skipping any that are already complete:
 Rhema supports two speech-to-text engines:
 
 **Option 1: Whisper (Local, Free)**
-No setup required! Whisper runs locally on your machine with no API costs or internet dependency.
+Whisper runs locally on your machine with no API costs or per-minute billing.
 - Requires CMake + libclang — see [Platform-specific setup](#platform-specific-setup) above
-- Model downloads automatically on first use
+- The model (`ggml-large-v3-turbo-q8_0.bin`) is fetched as phase 7 of `setup:all`. Run `bun run download:whisper` to grab it on its own.
 
 **Option 2: Deepgram (Cloud, Paid)**
 Create a `.env` file in the project root:
@@ -165,12 +164,12 @@ bun run download:ndi-sdk
 Each phase can also be run independently:
 
 ```bash
-bun run download:bible-data          # Public domain translations + cross-refs
-python3 data/download-biblegateway.py  # Copyrighted translations (needs .venv)
+bun run download:bible-data          # Bundled translations + cross-refs
 bun run build:bible                  # Build SQLite database
 bun run download:model               # Download & export ONNX model
 bun run export:verses                # Export verses to JSON
-python3 data/precompute-embeddings.py  # Precompute embeddings (GPU or ONNX fallback)
+bun run precompute:embeddings        # Rust ONNX (recommended); see also -onnx and -py variants
+bun run download:whisper             # Whisper STT model
 ```
 
 ### Run in development
@@ -233,8 +232,9 @@ rhema/
 
 | Script | Description |
 |---|---|
-| `setup:all` | **Full setup** — runs all data/model/embedding phases (idempotent) |
-| `dev` | Start Vite dev server (port 3000) |
+| `setup:all` | **Full setup** — runs all 7 data/model/embedding/whisper phases (idempotent; pass `--force` to re-run) |
+| `setup:windows` | Windows bootstrap — installs LLVM + CMake via `winget` and persists `LIBCLANG_PATH` |
+| `dev` | Start Vite dev server |
 | `build` | TypeScript check + Vite production build |
 | `tauri` | Run Tauri CLI commands |
 | `test` | Run Vitest tests |
@@ -242,15 +242,17 @@ rhema/
 | `format` | Prettier formatting |
 | `typecheck` | TypeScript type checking |
 | `preview` | Preview production build |
-| `download:bible-data` | Download public domain Bible translations + cross-references |
+| `download:bible-data` | Download bundled Bible translation archive + cross-references |
 | `build:bible` | Build SQLite Bible database from JSON sources |
 | `download:model` | Export Qwen3-Embedding-0.6B to ONNX + quantize to INT8 |
 | `export:verses` | Export KJV verses to JSON for embedding precomputation |
-| `precompute:embeddings` | Precompute embeddings via Rust ONNX binary |
+| `precompute:embeddings` | Precompute embeddings via Rust ONNX binary (recommended) |
 | `precompute:embeddings-onnx` | Precompute embeddings via Python ONNX Runtime |
-| `precompute:embeddings-py` | Precompute embeddings via Python sentence-transformers |
+| `precompute:embeddings-py` | Precompute embeddings via Python sentence-transformers (GPU path) |
 | `quantize:model` | Quantize ONNX model to INT8 for ARM64 |
+| `download:whisper` | Download `ggml-large-v3-turbo-q8_0.bin` for local Whisper STT |
 | `download:ndi-sdk` | Download NDI 6 SDK headers and platform libraries |
+| `web:dev`, `web:build`, `web:start`, `web:lint` | Marketing + Fumadocs documentation site under `web/` |
 
 ## Security
 

--- a/web/content/docs/architecture/rust-crates.mdx
+++ b/web/content/docs/architecture/rust-crates.mdx
@@ -48,8 +48,9 @@ Each crate maps to a clear external responsibility:
   crates don't depend on Tauri, which means the workspace can be
   built and tested as plain Rust without the Tauri shell.
 
-- **`rhema-notes`** is a placeholder for an upcoming sermon-notes
-  feature.
+- **`rhema-notes`** is a placeholder. Its `lib.rs` reads
+  *"Planned: Claude API integration, sermon note generation, and
+  PDF/Markdown export"* — none of that is implemented yet.
 
 ## Dependency graph
 
@@ -68,11 +69,25 @@ dependencies. This is enforced by the workspace `Cargo.toml` and is
 the property that keeps incremental builds fast and individual crates
 testable.
 
+## Feature flags
+
+Two crates are gated behind Cargo features so the workspace stays
+buildable on minimal toolchains:
+
+- `rhema-stt` exposes a `whisper` feature (`whisper-rs = "0.16"`,
+  `optional = true`). The Deepgram path is always available.
+- `rhema-detection` exposes `onnx` (turns on `ort = "2.0.0-rc.12"`)
+  and `vector-search` features.
+
+The default crate features in `src-tauri/Cargo.toml` enable both ONNX
+and vector search, so the standard `tauri dev` workflow gets the full
+detection pipeline.
+
 ## Testing
 
-Each crate has its own `tests/` folder. The pipeline crates
-(`rhema-detection` especially) are tested with curated transcript
-fixtures so we can assert exact detection behavior on known sermons.
+Pipeline crates have inline `#[cfg(test)]` modules with curated
+transcript fixtures so detection behavior is asserted on known
+inputs.
 
 Run the workspace test suite from the repo root:
 
@@ -80,5 +95,4 @@ Run the workspace test suite from the repo root:
 cargo test --workspace
 ```
 
-The Tauri command surface is integration-tested through the Vitest
-suite in `src/`.
+The frontend test surface uses Vitest (`bun run test`).

--- a/web/content/docs/architecture/tech-stack.mdx
+++ b/web/content/docs/architecture/tech-stack.mdx
@@ -38,21 +38,28 @@ The Rust side is a Cargo workspace of seven crates, each with a single
 clear responsibility. See the [Rust crates](/docs/architecture/rust-crates)
 page for the breakdown.
 
-Tauri v2 wires Rust commands to React via a typed IPC surface. The
-webview is locked down with a restrictive [CSP](/docs/reference/security)
-to prevent script injection and unauthorized data exfiltration.
+`tauri = "2.10.3"` wires Rust commands to React via a typed IPC
+surface. Workspace MSRV is `rust-version = "1.77.2"`. The webview is
+locked down with a restrictive [CSP](/docs/reference/security) to
+prevent script injection and unauthorized data exfiltration.
 
 ## ML / detection
 
 The detection pipeline is intentionally heterogeneous:
 
-- **Aho-Corasick** for direct reference parsing — compiled once, scans in
-  linear time with negligible memory.
+- **Aho-Corasick** (`aho-corasick = "1"`) for direct reference parsing
+  — compiled once, scans in linear time with negligible memory.
 - **Qwen3-Embedding-0.6B** for semantic search, exported to ONNX and
-  quantized to INT8 so a normal CPU keeps up.
-- **HNSW** index for nearest-neighbor recall in well under a millisecond.
+  quantized to INT8 (via `optimum-cli onnxruntime quantize --arm64`)
+  so a normal CPU keeps up.
+- **ONNX Runtime** through the `ort = "2.0.0-rc.12"` Rust crate for
+  inference (gated behind the `onnx` feature on `rhema-detection`).
+- **Brute-force cosine similarity** over the embedded verses
+  (~31k × 1024 dims). The file `semantic/hnsw_index.rs` is named after
+  a future plan; today it scans linearly because the dataset is small
+  enough that the simpler approach wins.
 - **Fuse.js** on the frontend for instant fuzzy search over the recent
-  transcript.
+  transcript context (`src/lib/context-search.ts`).
 
 ## Database
 

--- a/web/content/docs/features/ndi-broadcast.mdx
+++ b/web/content/docs/features/ndi-broadcast.mdx
@@ -1,6 +1,6 @@
 ---
 title: NDI Broadcast Output
-description: Send Rhema's verse overlays into your live production switcher as a first-class NDI source.
+description: Send Rhema's verse overlays into your live production switcher as a first-class NDI source — configurable resolution, frame rate, and alpha mode.
 icon: Radio
 ---
 
@@ -14,14 +14,15 @@ machine would, so any NDI-aware switcher can consume it.
 ## How it's wired
 
 The `rhema-broadcast` Rust crate dynamically loads the
-[NDI 6 SDK](https://ndi.video/tools/) at runtime via `libloading`. We
-load the SDK dynamically (rather than linking it) for two reasons:
+[NDI 6 SDK](https://ndi.video/tools/) at runtime via `libloading`
+(`libloading = "0.8"` in `crates/broadcast/Cargo.toml`). We load the
+SDK dynamically (rather than linking it) for two reasons:
 
 1. **Licensing** — NDI's redistribution terms don't allow shipping the
    SDK alongside arbitrary apps. Loading it from the user's install
    keeps Rhema clean of NDI binaries.
-2. **Optionality** — the app runs perfectly without NDI; the broadcast
-   surface just doesn't appear on the network.
+2. **Optionality** — the app runs without NDI; the broadcast surface
+   just doesn't appear on the network.
 
 ## Setup
 
@@ -37,48 +38,56 @@ on Linux `libndi.so`. The crate finds them automatically.
 
 ## Discoverable as a source
 
-Once an NDI source is sending, any tool on the network can pick it up.
+Once a sender is running, any tool on the network can pick it up.
 Common consumers:
 
-- **vMix** — Add → NDI / Desktop Capture → "Rhema".
-- **OBS** with [obs-ndi plugin](https://github.com/obs-ndi/obs-ndi) —
-  Sources → NDI Source.
+- **vMix** — Add → NDI / Desktop Capture → your Rhema source name.
+- **OBS** with the [obs-ndi plugin](https://github.com/obs-ndi/obs-ndi)
+  — Sources → NDI Source.
 - **Resolume**, **TriCaster**, **Wirecast**, **Tessera** — all
   NDI-native.
 
-The source name and identifier are configurable in Settings → Broadcast,
-so multi-room churches can run an instance per stage with stable names.
+The source name is part of the start request (`source_name: String` on
+`NdiStartRequest`) so you can configure it from Settings → Broadcast,
+and multi-room churches can run an instance per stage with stable
+names.
 
 ## Frame format
 
-Rhema sends:
+Rhema's NDI sender (`crates/broadcast/src/ndi.rs`) emits BGRA frames
+with configurable resolution, frame rate, and alpha mode:
 
-- **Resolution**: matches the active theme canvas (typically 1920×1080).
-- **Color space**: BGRA, straight alpha (so transparent regions
-  composite correctly behind your camera feeds).
-- **Frame rate**: locked to your switcher's expected rate; the default
-  is 60 fps progressive.
+- **Color space**: BGRA — `fourcc` is set to `b"BGRA"` on every frame.
+- **Resolution**: configurable; the active theme canvas size is sent
+  through to the sender (broadcast settings expose `width` and
+  `height` knobs).
+- **Frame rate**: 24, 30, or 60 fps progressive (`enum NdiFps` with
+  variants `Fps24`, `Fps30`, `Fps60`). The default is **30 fps**.
+- **Alpha mode**: three options on `enum NdiAlphaMode` —
+  `NoneOpaque`, `StraightAlpha`, `PremultipliedAlpha`. Pick whichever
+  matches your downstream switcher's expectation.
 - **Audio**: not transmitted — Rhema is a graphics source only.
 
-<Callout title="Why straight alpha?" type="info">
-Premultiplied alpha looks darker over bright backgrounds because color
-channels are pre-blended with the alpha value. Straight alpha keeps the
-verse readable over white robes, stage lights, and projected
-backgrounds, which is the worst-case scenario for live broadcast
-overlays.
+<Callout title="Picking an alpha mode" type="info">
+Use `StraightAlpha` when your switcher composites with straight
+alpha (vMix and most modern switchers). Use `PremultipliedAlpha`
+when the downstream tool expects pre-blended color channels.
+`NoneOpaque` ignores transparency entirely and is the right choice
+when you want a solid backdrop with no key.
 </Callout>
 
-## Latency
+## Latency profile
 
-The Rhema → NDI hop is sub-frame on a wired network. End-to-end latency
-from "pastor speaks the verse" to "overlay on the screen" is dominated
-by:
+The end-to-end latency from "pastor speaks the verse" to "overlay on
+screen" comes from three contributors:
 
-1. STT processing (50–400 ms depending on engine).
-2. Detection pipeline (~5 ms).
-3. NDI hop (less than one frame).
-4. Switcher buffering (1–2 frames).
+1. STT processing (Whisper is roughly 50–400 ms depending on model
+   and hardware; Deepgram streams within the WebSocket).
+2. Detection pipeline (the brute-force cosine scan over ~31k vectors
+   completes in milliseconds on a modern CPU).
+3. NDI hop and downstream switcher buffering.
 
-For services that prefer to keep overlays one beat behind the speaker —
-the standard live-graphics convention — this is exactly the right
-profile.
+These numbers come from the dependencies, not from a Rhema benchmark
+suite — the project doesn't publish a measured latency budget yet.
+For most live services this lands at "one beat behind the speaker",
+which is the standard live-graphics convention.

--- a/web/content/docs/features/theme-designer.mdx
+++ b/web/content/docs/features/theme-designer.mdx
@@ -12,8 +12,8 @@ NDI exactly as designed.
 
 ## What you can compose
 
-- **Backgrounds**: solid colors, multi-stop gradients, or a still image at
-  any opacity.
+- **Backgrounds**: solid colors, multi-stop gradients, still images, or
+  fully transparent (the four background types in `BroadcastTheme`).
 - **Typography**: choose any installed system font, set size, weight,
   letter-spacing, line-height, and alignment.
 - **Effects**: drop shadows, outlines/strokes, fills, and blur.
@@ -58,7 +58,8 @@ NDI frames natively.
 
 ## Saving and sharing
 
-Themes are JSON documents inside the app's data directory. They're
-self-contained — no external font files or absolute paths — so you can
-copy a theme between machines or commit them to a service template
-repository for your team.
+Themes are persisted to `broadcast-themes.json` in the app's data
+directory via `tauri-plugin-store` (see `src/stores/broadcast-store.ts`),
+so changes auto-save across restarts. The JSON is self-contained — no
+external font files or absolute paths — so you can copy a theme between
+machines or commit them to a service template repository for your team.

--- a/web/content/docs/features/translations.mdx
+++ b/web/content/docs/features/translations.mdx
@@ -1,50 +1,58 @@
 ---
 title: Bible Translations
-description: Eleven translations across four languages, with FTS5 full-text search and BM25 ranking out of the box.
+description: Ten bundled translations across four languages, served from a single SQLite database with FTS5 full-text search.
 icon: BookOpen
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-Rhema ships with eleven Bible translations spanning English, Spanish,
-French, and Portuguese. They're stored in a single bundled SQLite database
-(`data/rhema.db`) with FTS5 indexes for sub-millisecond text search.
+Rhema ships with ten Bible translations spanning English, Spanish, French,
+and Portuguese. They're stored in a single SQLite database (`data/rhema.db`)
+with FTS5 virtual tables for fast text search.
 
 ## Bundled translations
 
-| Translation | Language | Source |
-| --- | --- | --- |
-| KJV | English | Public domain |
-| NIV | English | BibleGateway |
-| ESV | English | BibleGateway |
-| NASB | English | BibleGateway |
-| NKJV | English | BibleGateway |
-| NLT | English | BibleGateway |
-| AMP | English | BibleGateway |
-| Reina-Valera | Spanish | Public domain |
-| Louis Segond | French | Public domain |
-| João Ferreira de Almeida | Portuguese | Public domain |
+The list comes verbatim from `data/download-sources.ts` —
+`EXPECTED_TRANSLATIONS` enumerates the JSON files that `setup:all`
+expects under `data/sources/`:
 
-<Callout title="Copyrighted translations" type="warn">
-NIV, ESV, NASB, NKJV, NLT, and AMP are downloaded from BibleGateway during
-`setup:all` (phase 3). They aren't redistributed in the repo because of
-licensing — you fetch them locally on your own machine.
+| File | Translation | Language |
+| --- | --- | --- |
+| `KJV.json` | King James Version | English |
+| `NIV.json` | New International Version | English |
+| `ESV.json` | English Standard Version | English |
+| `NASB.json` | New American Standard Bible | English |
+| `NKJV.json` | New King James Version | English |
+| `NLT.json` | New Living Translation | English |
+| `AMP.json` | Amplified Bible | English |
+| `SpaRV.json` | Reina-Valera | Spanish |
+| `FreJND.json` | Darby (French) | French |
+| `PorBLivre.json` | Almeida Livre | Portuguese |
+
+<Callout title="How they're delivered" type="info">
+All ten translations come from a single bundled archive that
+`download-sources.ts` fetches during phase 2 of `setup:all`. There's
+no separate BibleGateway phase — earlier copy was wrong about that.
+The cross-reference dataset is fetched in the same phase from
+[openbible.info](https://openbible.info).
 </Callout>
 
 ## Cross-references
 
-Rhema imports **340,000+ cross-references** from
-[openbible.info](https://openbible.info) so every verse links to thematically
-related passages. The cross-reference panel shows them ranked by relevance,
-and you can click through to queue any of them for broadcast.
+Rhema imports **340k+ cross-references** (the bundled file currently has
+344,800 entries) from [openbible.info](https://openbible.info) so every
+verse links to thematically related passages. The cross-reference panel
+shows them ranked by relevance, and you can click through to queue any
+of them for broadcast.
 
 ## Switching translations during a sermon
 
 The active translation is the one rendered on the broadcast overlay. You
 can change it three ways:
 
-1. **Voice command** — "read in NIV", "switch to ESV", "let's hear it in
-   NLT". See [Voice control](/docs/features/voice-control).
+1. **Voice command** — "read in NIV", "switch to ESV", and so on. See
+   [Voice control](/docs/features/voice-control) for the full alias
+   table.
 2. **UI control** — the translation picker in the transport bar.
 3. **Remote control** — OSC, HTTP, or a Stream Deck button. See
    [Remote control](/docs/features/remote-control).
@@ -54,10 +62,11 @@ keeping the same verse reference.
 
 ## Search architecture
 
-Every translation has its own FTS5 virtual table backed by a porter
-tokenizer. Queries use BM25 ranking, which gives natural results when
-searching by phrase ("walk by faith", "fearfully and wonderfully").
+Every translation has its own FTS5 virtual table. SQLite's FTS5 ships
+with BM25 ranking by default, which gives natural results when searching
+by phrase ("walk by faith", "fearfully and wonderfully").
 
-The frontend layers Fuse.js on top for instant fuzzy search across the
-recent context — the kind of typing-while-searching experience you want
-when scrubbing for a verse during a service.
+The frontend layers **Fuse.js** (`src/lib/context-search.ts`) on top for
+instant fuzzy search across the recent transcript context — the kind of
+typing-while-searching experience you want when scrubbing for a verse
+during a service.

--- a/web/content/docs/features/verse-detection.mdx
+++ b/web/content/docs/features/verse-detection.mdx
@@ -1,6 +1,6 @@
 ---
 title: Verse Detection Pipeline
-description: Five complementary strategies that turn live sermon audio into matched Bible references — direct, semantic, quotation, ensemble, and reading mode.
+description: Four complementary strategies that turn live sermon audio into matched Bible references — direct, semantic, quotation, and reading mode — merged by an ensemble pass.
 icon: Search
 ---
 
@@ -10,21 +10,23 @@ import { Step, Steps } from "fumadocs-ui/components/steps";
 Rhema's detector doesn't bet on a single signal. Pastors cite scripture in
 many ways — exact references ("First Corinthians 13:4"), paraphrases, partial
 quotations, or by simply moving through a chapter — and a single technique
-misses too many of them. The detector instead runs five strategies in
-parallel and merges their outputs through an ensemble pass.
+misses too many of them. The detector runs four strategies in parallel and
+merges their outputs through an ensemble pass.
 
-## The five strategies
+## The four strategies
 
 <Steps>
   <Step>
 ### Direct reference parsing
 
-A precompiled **Aho-Corasick automaton** scans the transcript for canonical
-book names and abbreviations. When a hit is followed by a chapter/verse
-pattern, the detector emits a high-confidence reference.
+A precompiled **Aho-Corasick automaton** (`aho-corasick = "1"` in
+`rhema-detection`) scans the transcript for canonical book names and
+abbreviations. When a hit is followed by a chapter/verse pattern, the
+detector emits a high-confidence reference.
 
 Fuzzy matching catches misheard book names ("Galatian" → "Galatians",
-"Psalmon" → "Psalms") so transcription noise doesn't sink an obvious cite.
+"Psalmon" → "Psalms") so transcription noise doesn't sink an obvious
+cite.
 
   </Step>
   <Step>
@@ -32,69 +34,79 @@ Fuzzy matching catches misheard book names ("Galatian" → "Galatians",
 
 Verses that aren't named — paraphrases, lyrical references, applied
 teaching — are caught by a vector retrieval pipeline. The
-**Qwen3-Embedding-0.6B** model (exported to INT8 ONNX during `setup:all`)
-embeds every verse, and a **HNSW index** answers nearest-neighbor queries
-in well under a millisecond.
+**Qwen3-Embedding-0.6B** model (exported to INT8 ONNX during
+`setup:all` and run via the `ort` Rust crate) embeds every verse,
+and a **brute-force cosine-similarity scan** over ~31k vectors at
+1024 dims returns nearest neighbors in a few milliseconds on a
+modern CPU.
 
-The semantic strategy runs on a sliding window over the transcript so a
-phrase that lights up halfway through a sentence still triggers a match.
+The file is named `hnsw_index.rs` for historical reasons, but the
+implementation is currently brute-force — the dataset is small
+enough that an HNSW index isn't needed yet.
+
+The semantic strategy runs on a sliding window over the transcript
+so a phrase that lights up halfway through a sentence still triggers
+a match.
 
   </Step>
   <Step>
 ### Quotation matching
 
-When a pastor quotes scripture verbatim — even partial sentences — the
-quotation matcher checks the transcript window against the indexed verse
-text directly. This catches things the embedding model is too coarse for,
-like "the just shall live by faith".
-
-  </Step>
-  <Step>
-### Cloud booster (optional)
-
-For ambiguous cases, an optional cloud LLM (OpenAI or Claude) re-ranks
-candidates using sermon context. This is opt-in and rate-limited; the
-local pipeline runs at full speed without it.
+When a pastor quotes scripture verbatim — even partial sentences —
+the quotation matcher checks the transcript window against the
+indexed verse text directly. This catches things the embedding model
+is too coarse for, like "the just shall live by faith".
 
   </Step>
   <Step>
 ### Reading mode
 
-When a pastor announces a chapter and starts reading through it ("Let's
-turn to Romans 8"), reading mode locks the queue to that book/chapter
-and uses voice navigation ("next chapter", "chapter 5", "go back two
-verses") to advance.
+When a pastor announces a chapter and starts reading through it
+("Let's turn to Romans 8"), reading mode locks the queue to that
+book/chapter and uses voice navigation to advance — "next", "next
+verse", "previous verse", "go back", "next chapter", "previous
+chapter", "chapter N", "verse N", or "chapter N verse M".
 
-This eliminates false positives from common phrases that *sound* like
-references but aren't, while the pastor is in expository mode.
+This eliminates false positives from common phrases that *sound*
+like references but aren't, while the pastor is in expository mode.
 
   </Step>
 </Steps>
 
+<Callout title="No cloud booster yet" type="warn">
+Earlier copy described an optional OpenAI/Claude "cloud booster"
+that re-ranks ambiguous candidates. The settings store reserves
+fields for `openaiApiKey` / `claudeApiKey`, but the booster itself
+is not implemented in `rhema-detection` today. Detection runs
+entirely locally.
+</Callout>
+
 ## Ensemble merging
 
 Each strategy emits candidate detections with confidence scores. The
-**ensemble merger** deduplicates overlapping candidates, weights the
-sources, and applies time-based decay so older candidates don't compete
-with fresh ones. The output is a single ranked detection stream that
-feeds the queue.
+**ensemble merger** (`src-tauri/crates/detection/src/merger.rs`)
+deduplicates overlapping candidates, weights the sources, and applies
+time-based decay so older candidates don't compete with fresh ones.
+The output is a single ranked detection stream that feeds the queue.
 
 <Callout title="Sentence buffering" type="info">
-The detector buffers transcript output into sentences before passing them
-through the strategies. This dramatically reduces flicker — partial
-transcript fragments don't trigger and then unfire as more words arrive.
+The detector buffers transcript output into sentences (`sentence_buffer.rs`)
+before passing them through the strategies. This reduces flicker —
+partial transcript fragments don't trigger and then unfire as more
+words arrive.
 </Callout>
 
 ## Sermon context tracking
 
 Pastors quote across a sermon's arc. Rhema keeps a rolling **sermon
-context** of recent topics, books, and themes that the semantic and cloud
-strategies use to disambiguate. If you've spent the last ten minutes in
-Romans 8, a passing reference to "by faith" is more likely Romans 8 than
-Hebrews 11.
+context** of recent books and themes that the semantic strategy uses
+to disambiguate. If you've spent the last ten minutes in Romans 8, a
+passing reference to "by faith" is more likely Romans 8 than Hebrews
+11.
 
 ## Threshold tuning
 
 The confidence threshold is exposed as a UI control and via the remote
-control API (`/rhema/confidence`). Bumping it up reduces false positives on
-noisy services; lowering it surfaces more candidates for manual queueing.
+control API (`/rhema/confidence`). Bumping it up reduces false positives
+on noisy services; lowering it surfaces more candidates for manual
+queueing.

--- a/web/content/docs/features/voice-control.mdx
+++ b/web/content/docs/features/voice-control.mdx
@@ -24,7 +24,7 @@ these patterns:
 - "read in **Amplified**" / "switch to **Amplified**" → AMP
 - "read in **Spanish**" / "read in **Reina Valera**" → SpaRV
 - "read in **French**" → FreJND
-- "read in **Portuguese**" → PorAA
+- "read in **Portuguese**" → PorBLivre
 
 Patterns are case-insensitive. Once recognized, the active translation
 flips immediately and the live overlay reflows. The full alias table
@@ -64,12 +64,14 @@ fall back to UI/remote control only.
 
 ## Detection guards
 
-Voice commands are protected by:
+The command lookup happens in
+`Detector::detect_translation_command` in `direct/detector.rs`, which
+searches a fixed alias table and returns the matched translation code
+(or `None`). Behavioral guards layered on top:
 
-- A **dedup guard** in `check_translation_command` so a command isn't
-  fired twice from the same transcript window.
-- **Sermon context** awareness — commands during reading mode prefer
-  navigation patterns; commands outside reading mode prefer translation
-  switching.
-- A short cooldown after each command so a rapid back-to-back utterance
-  ("read in NIV — actually NLT") only triggers the latest one.
+- **Sermon context** awareness — when reading mode is engaged the
+  detector prefers navigation patterns over fresh translation
+  switches.
+- **Duplicate suppression on the recent-command path** — the direct
+  detector tracks recently pushed candidates and skips re-emitting an
+  identical match into the same window.

--- a/web/content/docs/getting-started/installation.mdx
+++ b/web/content/docs/getting-started/installation.mdx
@@ -47,22 +47,33 @@ scripts.
 bun run setup:all
 ```
 
-`setup:all` is **idempotent** — re-running it skips phases that have already
-completed, so it's safe to invoke after `git pull` or when something changed
-in `data/`. Behind the scenes it executes seven phases in order:
+`setup:all` is **idempotent** — re-running it skips phases whose
+output artifacts already exist, so it's safe to invoke after
+`git pull` or when something changed in `data/`. Pass `--force` to
+re-run every phase. The orchestrator (`data/prepare-embeddings.ts`)
+runs seven phases in this exact order:
 
-1. **Python environment** — creates `.venv` and installs every pip dependency.
-2. **Open-source Bibles** — downloads KJV, Spanish, French, and Portuguese
-   translations plus 340k+ cross-references from openbible.info.
-3. **Copyrighted translations** — pulls NIV, ESV, NASB, NKJV, NLT, and AMP
-   from BibleGateway.
-4. **SQLite database** — assembles `data/rhema.db` with FTS5 full-text
-   indexes and cross-reference tables.
-5. **ONNX model** — downloads `Qwen3-Embedding-0.6B`, exports it to ONNX,
-   and quantizes to INT8 for ARM64.
-6. **Verse export** — emits the KJV verses to JSON for embedding.
-7. **Embedding precomputation** — runs the embeddings (auto-selects GPU if
-   available, falls back to ONNX CPU otherwise).
+1. **Python environment** — creates `.venv` and installs the pip
+   dependencies (`optimum-onnx[onnxruntime]`,
+   `sentence-transformers`, `accelerate`, `tokenizers`, `numpy`,
+   `torch`, `meaningless`).
+2. **Bible source data** — downloads a single bundled archive that
+   contains all ten translations (KJV, NIV, ESV, NASB, NKJV, NLT,
+   AMP, SpaRV, FreJND, PorBLivre) plus the cross-reference dataset
+   from openbible.info.
+3. **SQLite database** — assembles `data/rhema.db` with FTS5
+   virtual tables and cross-reference tables.
+4. **ONNX model** — downloads `Qwen3/Qwen3-Embedding-0.6B`, exports
+   it via `optimum-cli export onnx`, and quantizes to INT8 for
+   ARM64 with `optimum-cli onnxruntime quantize`.
+5. **Verse export** — emits the KJV verses to JSON for the
+   embedding step.
+6. **Embedding precomputation** — runs the embeddings (auto-selects
+   GPU via PyTorch if available; falls back to ONNX Runtime on
+   CPU).
+7. **Whisper model** — downloads `ggml-large-v3-turbo-q8_0.bin`
+   into `models/whisper/` so the local STT engine works without an
+   internet round-trip.
 
   </Step>
   <Step>
@@ -111,20 +122,22 @@ pipeline. Each phase has its own script:
   <Tab value="Bun scripts">
 
 ```bash
-bun run download:bible-data        # Public domain translations + cross-refs
+bun run download:bible-data        # Bundled translations + cross-refs
 bun run build:bible                # Build SQLite database
 bun run download:model             # Download & export ONNX model
 bun run export:verses              # Export verses to JSON
-bun run precompute:embeddings      # Rust ONNX binary
-bun run precompute:embeddings-py   # Python sentence-transformers
+bun run precompute:embeddings      # Rust ONNX binary (recommended)
+bun run precompute:embeddings-onnx # Python ONNX Runtime path
+bun run precompute:embeddings-py   # Python sentence-transformers (GPU)
+bun run download:whisper           # Whisper model (ggml turbo q8_0)
 ```
 
   </Tab>
   <Tab value="Direct Python">
 
 ```bash
-python3 data/download-biblegateway.py     # Copyrighted translations (needs .venv)
-python3 data/precompute-embeddings.py     # Embeddings (GPU or ONNX fallback)
+python3 data/precompute-embeddings.py      # GPU sentence-transformers
+python3 data/precompute-embeddings-onnx.py # CPU ONNX Runtime fallback
 ```
 
   </Tab>

--- a/web/content/docs/getting-started/speech-to-text.mdx
+++ b/web/content/docs/getting-started/speech-to-text.mdx
@@ -25,20 +25,26 @@ streaming.
 
 ## Option 1: Whisper (recommended for most installs)
 
-No setup is required at the runtime level — Whisper downloads its model on
-first use. You just need the build dependencies covered in
-[Platform setup](/docs/getting-started/platform-setup).
-
 The Whisper integration uses [`whisper.cpp`](https://github.com/ggerganov/whisper.cpp)
-via `bindgen`, so the first `cargo build` compiles the C++ source. After
-that, model files cache locally.
+through the `whisper-rs = "0.16"` Rust crate (gated behind the
+`whisper` feature on `rhema-stt`). The first `cargo build` compiles
+the C++ source via `bindgen`.
+
+The model file (`ggml-large-v3-turbo-q8_0.bin`) is downloaded once
+into `models/whisper/` as **phase 7** of `setup:all`. If you skipped
+or interrupted that phase, run it on its own:
+
+```bash
+bun run download:whisper
+```
 
 <Callout title="Build dependencies" type="info">
-You need **CMake** and **libclang** on your `PATH`. macOS gets these from
-Homebrew (`brew install cmake`) plus the Xcode CLT. Linux gets them from
-your package manager. Windows installs them via `bun run setup:windows`.
-See [Platform setup](/docs/getting-started/platform-setup) for the exact
-commands.
+You need **CMake** and **libclang** on your `PATH` for the Rust
+build to succeed. macOS gets these from Homebrew
+(`brew install cmake`) plus the Xcode CLT. Linux gets them from your
+package manager. Windows installs them via `bun run setup:windows`.
+See [Platform setup](/docs/getting-started/platform-setup) for the
+exact commands.
 </Callout>
 
 ## Option 2: Deepgram
@@ -78,13 +84,15 @@ and queue state are preserved across the swap.
 | | Whisper (local) | Deepgram (cloud) |
 | --- | --- | --- |
 | API cost | Free | Per-minute billing |
-| Internet required | No | Yes (WebSocket) |
-| First-build time | ~3–5 min (compiles `whisper.cpp`) | Instant |
-| Latency on a steady connection | ~250–400 ms | ~150–250 ms |
+| Internet required | No, after the model is downloaded | Yes (WebSocket) |
+| First-build time | Several minutes — `whisper.cpp` compiles via `bindgen` | Instant |
 | Long-form accuracy | Good | Excellent |
 | Punctuation | Decent | Excellent |
 | Works offline | Yes | No |
 
-Both are good defaults — Whisper for the no-cost path, Deepgram when you
-want the lowest possible latency and best transcription quality on a
-reliable network.
+Latency depends heavily on hardware and network conditions, so we
+don't publish a single number — Whisper benefits from any GPU/Metal
+acceleration `whisper-rs` can pick up, and Deepgram is bounded by the
+round-trip to its nearest region. Pick whichever fits your install:
+Whisper for the no-cost local path, Deepgram for the lowest latency
+and best transcription quality on a reliable network.

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -93,7 +93,7 @@ for a guided walkthrough.
   <Card
     icon={<Palette />}
     title="ONNX-quantized embeddings"
-    description="Qwen3-Embedding-0.6B exported to INT8 ONNX, indexed with HNSW for sub-second semantic recall."
+    description="Qwen3-Embedding-0.6B exported to INT8 ONNX with brute-force cosine similarity over ~31k verse vectors — fast enough on CPU without an HNSW index."
     href="/docs/features/verse-detection"
   />
 </Cards>

--- a/web/content/docs/reference/scripts.mdx
+++ b/web/content/docs/reference/scripts.mdx
@@ -7,49 +7,64 @@ icon: Terminal
 import { Callout } from "fumadocs-ui/components/callout";
 
 Most day-to-day work happens through `bun run setup:all` and `bun run
-tauri dev`. The full table below covers every script in the repository's
-top-level `package.json`.
+tauri dev`. The full table below covers every script in the
+repository's top-level `package.json`.
 
 ## Top-level scripts
 
 | Script | Description |
 | --- | --- |
-| `setup:all` | **Full setup** — runs all data/model/embedding phases (idempotent) |
-| `dev` | Start Vite dev server (port 3000) |
-| `build` | TypeScript check + Vite production build |
-| `tauri` | Run Tauri CLI commands |
+| `setup:all` | **Full setup** — orchestrator at `data/prepare-embeddings.ts` (idempotent; pass `--force` to re-run every phase) |
+| `setup:windows` | Windows bootstrap — installs LLVM + CMake via `winget` and persists `LIBCLANG_PATH` |
+| `dev` | Start Vite dev server |
+| `build` | `tsc -b` + Vite production build |
+| `tauri` | Run Tauri CLI commands (`tauri dev`, `tauri build`) |
 | `test` | Run Vitest tests |
 | `lint` | ESLint |
-| `format` | Prettier formatting |
-| `typecheck` | TypeScript type checking |
-| `preview` | Preview production build |
+| `format` | Prettier (writes to `**/*.{ts,tsx}`) |
+| `typecheck` | `tsc --noEmit` |
+| `preview` | Preview the Vite production build |
 
 ## Data pipeline scripts
 
 | Script | Description |
 | --- | --- |
-| `download:bible-data` | Download public domain Bible translations + cross-references |
-| `build:bible` | Build SQLite Bible database from JSON sources |
-| `download:model` | Export Qwen3-Embedding-0.6B to ONNX + quantize to INT8 |
+| `download:bible-data` | Download the bundled translation archive + cross-references zip |
+| `build:bible` | Build SQLite Bible database from the downloaded JSON sources |
+| `download:model` | Export `Qwen3-Embedding-0.6B` to ONNX + quantize to INT8 |
 | `export:verses` | Export KJV verses to JSON for embedding precomputation |
-| `precompute:embeddings` | Precompute embeddings via Rust ONNX binary |
-| `precompute:embeddings-onnx` | Precompute embeddings via Python ONNX Runtime |
-| `precompute:embeddings-py` | Precompute embeddings via Python sentence-transformers |
-| `quantize:model` | Quantize ONNX model to INT8 for ARM64 |
+| `precompute:embeddings` | Precompute embeddings via the `rhema-detection` Rust ONNX binary (recommended) |
+| `precompute:embeddings-onnx` | Same, but via Python ONNX Runtime |
+| `precompute:embeddings-py` | Same, but via Python sentence-transformers (GPU path) |
+| `quantize:model` | Quantize ONNX model to INT8 for ARM64 (`optimum-cli onnxruntime quantize --arm64`) |
+| `download:whisper` | Download `ggml-large-v3-turbo-q8_0.bin` for local Whisper STT |
 | `download:ndi-sdk` | Download NDI 6 SDK headers and platform libraries |
 
+## Web subsite scripts
+
+| Script | Description |
+| --- | --- |
+| `web:dev` | `cd web && bun run dev` — runs the marketing + docs Next.js site |
+| `web:build` | `cd web && bun run build` — produces the static export |
+| `web:start` | Serve the built site locally |
+| `web:lint` | Lint the web subdirectory |
+
+The `web/` workspace itself has its own `package.json` with `dev`,
+`dev:no-open`, `build`, `start`, `lint`, and `postinstall` (which
+runs `fumadocs-mdx`).
+
 <Callout title="Three flavors of precompute" type="info">
-The three `precompute:embeddings*` scripts trade off speed, dependency
-weight, and accuracy:
+The three `precompute:embeddings*` scripts trade off speed and
+dependency weight:
 
-- **`precompute:embeddings`** — fastest (Rust ONNX binary, no Python).
-- **`precompute:embeddings-onnx`** — Python ONNX Runtime, useful when
-  you want to debug embeddings or iterate on the export.
-- **`precompute:embeddings-py`** — sentence-transformers, full
-  fidelity baseline.
-
-`setup:all` picks the best one for your machine automatically (GPU →
-Python sentence-transformers, otherwise Rust ONNX).
+- **`precompute:embeddings`** — Rust ONNX binary, no Python required
+  at runtime. The default path inside `setup:all` when no GPU is
+  detected.
+- **`precompute:embeddings-onnx`** — Python ONNX Runtime, useful
+  when you want to iterate on the export or debug embeddings.
+- **`precompute:embeddings-py`** — sentence-transformers + PyTorch
+  on GPU when one is available; this is the fastest end-to-end on
+  Apple Silicon and CUDA.
 </Callout>
 
 ## When to run what
@@ -59,8 +74,8 @@ Python sentence-transformers, otherwise Rust ONNX).
 | First clone | `bun install && bun run setup:all` |
 | Translation source changed | `bun run download:bible-data && bun run build:bible` |
 | Embedding model bumped | `bun run download:model && bun run precompute:embeddings` |
-| Adding a new translation | `bun run download:biblegateway && bun run build:bible` |
 | Need NDI broadcast | `bun run download:ndi-sdk` |
+| Reinstall the Whisper model | `bun run download:whisper` |
 | Just want to see the UI | `bun run tauri dev` |
 | Cutting a release | `bun run tauri build` |
 

--- a/web/content/docs/reference/security.mdx
+++ b/web/content/docs/reference/security.mdx
@@ -13,56 +13,97 @@ seriously.
 
 ## Content Security Policy
 
-The Tauri WebView ships with a **restrictive CSP** to prevent script
-injection and unauthorized data exfiltration. The policy is defined
-in `src-tauri/tauri.conf.json` and locks down:
+The Tauri WebView ships with a restrictive CSP defined verbatim in
+`src-tauri/tauri.conf.json`. The full directive list:
 
-- `script-src` to `'self'` plus a hashed inline-bootstrap, so no
-  third-party scripts execute.
-- `connect-src` to `'self'`, the Tauri IPC channel, and the
-  explicitly allow-listed Deepgram WebSocket endpoint when the cloud
-  STT engine is active.
-- `img-src` to `'self'` and `data:` for the canvas-rendered overlays.
-- `style-src` to `'self'` plus `'unsafe-inline'` (required by the
-  shadcn animation tokens).
-- `frame-ancestors` to `'none'` so the WebView can't be embedded.
+```
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+font-src 'self' data:;
+connect-src 'self';
+media-src 'self' blob:;
+worker-src 'self';
+frame-src 'none';
+frame-ancestors 'none';
+object-src 'none';
+base-uri 'self';
+form-action 'self';
+manifest-src 'self'
+```
 
-The full directive-by-directive rationale and threat model lives in
-[**SECURITY.md**](https://github.com/openbezal/rhema/blob/main/.github/SECURITY.md)
-in the repo.
+A few things worth calling out:
+
+- **`script-src 'self'`** — no inline scripts, no `eval`, no
+  third-party JS. The Tauri runtime injects its IPC bootstrap before
+  the CSP applies.
+- **`style-src 'self' 'unsafe-inline'`** — required by Radix /
+  shadcn for runtime style injection on portals and animations.
+- **`connect-src 'self'`** — the WebView itself only talks to the
+  Tauri IPC channel. Outbound network traffic (Deepgram WebSocket,
+  Bible data downloads) all happens from the Rust side, so the
+  webview doesn't need to allow-list those endpoints.
+- **`frame-ancestors 'none'`** — the WebView can't be embedded
+  anywhere.
+- **`object-src 'none'`** + **`base-uri 'self'`** — block plugin
+  vectors and base-tag injection.
 
 ## Reporting a vulnerability
 
 <Callout title="Please report privately first" type="warn">
 If you find a security issue, **do not open a public GitHub issue.**
 Send a private report by following the instructions in
-[SECURITY.md](https://github.com/openbezal/rhema/blob/main/.github/SECURITY.md).
-We aim to acknowledge within two business days.
+[SECURITY.md](https://github.com/openbezal/rhema/blob/main/.github/SECURITY.md)
+in the repo.
 </Callout>
 
 ## Tauri capabilities
 
 Rhema follows Tauri v2's principle-of-least-privilege capability
-system. Each Tauri command is gated behind a capability that's
-granted to a specific window context — there are no globally enabled
-APIs. The capability files live under `src-tauri/capabilities/`.
+system. Capability files live under `src-tauri/capabilities/` —
+today there are two: `default.json` and `desktop.json`.
 
 If you're reviewing the codebase for security:
 
-1. Start at `src-tauri/capabilities/*.json` to see what's allowed.
+1. Start at `src-tauri/capabilities/*.json` to see which Tauri
+   commands and plugins are reachable from each window.
 2. Trace each granted command to its handler in `rhema-api`.
 3. Audit the handler's input validation and side effects.
 
-The same review pass works on the OSC and HTTP control surfaces —
-they're rate-limited and bind to localhost by default; binding to
-a routable interface is an explicit operator opt-in.
+## Remote control defaults — read carefully
+
+The OSC and HTTP listeners are **not** locked down by default. The
+shipped defaults are:
+
+- **OSC**: bind host `0.0.0.0`, port `8000`.
+- **HTTP**: bind host `0.0.0.0`, port `8080`, with
+  `CorsLayer::permissive()` attached to the Axum router.
+
+That means any device on the local network can drive the app and
+read its status without authentication. This is intentional for the
+LAN-only use case (Stream Deck on your operator's laptop), but it is
+**unsafe** to leave on once the listener is reachable from a
+broader network.
+
+Before exposing Rhema beyond a trusted LAN:
+
+1. Bind both listeners to `127.0.0.1` from Settings → Remote.
+2. Or front them with a reverse proxy that adds authentication and
+   TLS.
+3. Or restrict ingress at your firewall.
+
+There is no built-in rate limit or auth on either protocol — the
+API is intentionally simple so it composes with whatever you
+already trust.
 
 ## Defaults that protect the operator
 
-- **Localhost-only listeners** — OSC and HTTP control surfaces bind
-  to `127.0.0.1` until you explicitly choose a routable interface.
 - **No telemetry** — Rhema does not phone home. There's no
   analytics, no crash reporter, no usage tracking.
 - **Local-first by default** — Whisper runs locally, the database
   lives on disk, and Deepgram is opt-in. No keys, no internet, no
   problem.
+- **Bundled SQLite** — `rusqlite` with the `bundled` feature, so
+  the binary doesn't link against a system SQLite that could be
+  swapped out.


### PR DESCRIPTION
Audited every protocol, dependency, and feature claim against the source crates (api, broadcast, detection, stt, bible) and the data pipeline scripts. Fixes:

Detection pipeline
- Drop the "cloud booster" strategy from README, index, and the verse-detection page — settings store has openai/claude key fields but no booster is implemented in rhema-detection.
- Replace the "HNSW index" claim with the truth: a brute-force cosine-similarity scan over ~31k verse vectors at 1024 dims. hnsw_index.rs is named after a future plan; the file's own header comment says "Brute-force cosine-similarity vector index."
- Drop the "sub-millisecond" / "sub-frame" latency claims; the repo doesn't publish a measured latency budget.

Translations
- Real bundled count is 10 (KJV, NIV, ESV, NASB, NKJV, NLT, AMP, SpaRV, FreJND, PorBLivre) per data/download-sources.ts. README said "11" and translations.mdx echoed it.
- All 10 come from a single bundled archive in phase 2 of setup:all. There is no separate "BibleGateway phase 3" — that was invented in installation.mdx and the README setup steps.
- Voice-control page used PorAA for Portuguese; real code uses PorBLivre.
- Cross-reference dataset has 344,800 entries; "340k+" is fine to keep but now annotated.

Setup phases (data/prepare-embeddings.ts header)
- Real 7 phases: Python env, Bible source data, build DB, ONNX download/quantize, export verses to JSON, precompute embeddings, download Whisper model. README and installation page now match.

NDI broadcast
- Default fps is 30, not 60. NdiFps enum exposes 24/30/60 variants.
- Three alpha modes exist (NoneOpaque, StraightAlpha, PremultipliedAlpha); previous copy claimed only straight alpha.
- Resolution is configurable via the start request, not pinned to 1920x1080.

Theme designer
- Backgrounds include a transparent variant beyond solid/gradient/ image (four total in BroadcastTheme).
- Theme storage location named: broadcast-themes.json via tauri-plugin-store.
- Built-in theme names already corrected in a previous commit (Classic Dark, Modern Light, Broadcast Overlay).

Voice control
- Function name is detect_translation_command, not check_translation_command. The README dedup-guard claim was paraphrased from a non-existent function; rephrased to describe the duplicate suppression that actually exists in the recent- detections path.

Security / CSP
- Replace the invented CSP description with the verbatim policy from src-tauri/tauri.conf.json (default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; media-src 'self' blob:; worker-src 'self'; frame-src 'none'; frame- ancestors 'none'; object-src 'none'; base-uri 'self'; form- action 'self'; manifest-src 'self').
- Remote control listeners default to 0.0.0.0 (not 127.0.0.1) and the Axum router attaches CorsLayer::permissive(); flag both loudly as defaults that need to be tightened before exposure.
- Drop the invented "rate-limited" claim; no rate limiting exists.

Tech stack / crates
- Quote real Cargo versions: tauri 2.10.3, ort 2.0.0-rc.12, whisper-rs 0.16, libloading 0.8, aho-corasick 1.
- Document the Cargo features that gate whisper, onnx, and vector-search builds.
- Soften the "session timer" feature claim in README; no session timer component exists in src/.
- rhema-notes documented as a planned (Claude API + sermon notes
  + PDF/Markdown export) but currently empty crate per its lib.rs.

Scripts reference
- Add download:whisper, setup:windows, and the web:* scripts that were missing from the table.
- Drop the made-up download:biblegateway entry; no such script exists.

## Description

<!-- What does this PR do? Reference any related issues (e.g., `fixes #123`). -->

## Type of change

<!-- Check the one that applies: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

<!-- Check all that apply: -->

- [ ] Frontend (React / TypeScript)
- [ ] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [ ] I have tested this change locally
- [ ] `bun run typecheck` passes
- [ ] `cargo clippy` passes without warnings
- [ ] `bun run test` passes (if applicable)
- [ ] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

<!-- Check the platforms you tested on: -->

- [ ] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

<!-- If this PR includes UI changes, add screenshots or recordings here. -->
