### PR TITLE
fix(types): resolve TypeScript errors blocking production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -558,8 +558,6 @@ interface CommandLogEntry {
 }
 
 function RemoteControlSection() {
-  const [oscEnabled, setOscEnabled] = useState(false)
-  const [httpEnabled, setHttpEnabled] = useState(false)
   const [oscPort, setOscPort] = useState("8000")
   const [httpPort, setHttpPort] = useState("8080")
   const [oscStatus, setOscStatus] = useState<RemoteStatus>({ running: false, port: null })
@@ -625,12 +623,10 @@ function RemoteControlSection() {
     try {
       if (oscStatus.running) {
         await invoke("stop_osc")
-        setOscEnabled(false)
         setOscError(null)
       } else {
         const port = parseInt(oscPort) || 8000
         const boundPort = await invoke<number>("start_osc", { port })
-        setOscEnabled(true)
         setOscPort(String(boundPort))
         setOscError(null)
       }
@@ -643,12 +639,10 @@ function RemoteControlSection() {
     try {
       if (httpStatus.running) {
         await invoke("stop_http")
-        setHttpEnabled(false)
         setHttpError(null)
       } else {
         const port = parseInt(httpPort) || 8080
         const boundPort = await invoke<number>("start_http", { port })
-        setHttpEnabled(true)
         setHttpPort(String(boundPort))
         setHttpError(null)
       }

--- a/src/components/tutorial/tutorial-overlay.tsx
+++ b/src/components/tutorial/tutorial-overlay.tsx
@@ -72,12 +72,14 @@ export function TutorialOverlay() {
       steps={steps}
       run={isRunning}
       continuous
-      buttons={["back", "primary", "skip"]}
-      skipScroll
       tooltipComponent={TutorialTooltip}
       onEvent={handleEvent}
-      zIndex={60}
-      overlayColor="rgba(0, 0, 0, 0.5)"
+      options={{
+        buttons: ["back", "primary", "skip"],
+        skipScroll: true,
+        zIndex: 60,
+        overlayColor: "rgba(0, 0, 0, 0.5)",
+      }}
     />
   )
 }

--- a/src/components/tutorial/tutorial-steps.ts
+++ b/src/components/tutorial/tutorial-steps.ts
@@ -1,7 +1,6 @@
 import type { Step } from "react-joyride"
 
 const STEP_DEFAULTS = {
-  disableBeacon: true,
   skipBeacon: true,
 } as const satisfies Partial<Step>
 

--- a/src/lib/settings-dialog.ts
+++ b/src/lib/settings-dialog.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
 
-type SettingsSection = "audio" | "speech" | "bible" | "display" | "api-keys" | "help"
+type SettingsSection = "audio" | "speech" | "bible" | "display" | "api-keys" | "remote" | "help"
 
 interface SettingsDialogState {
   isOpen: boolean

--- a/src/stores/bible-store.test.ts
+++ b/src/stores/bible-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockGet = vi.fn()
 const mockSet = vi.fn()
@@ -37,7 +37,10 @@ describe("bible store persistence", () => {
 
       await hydrateBibleStore()
 
-      expect(mockLoad).toHaveBeenCalledWith("bible.json", { autoSave: false })
+      expect(mockLoad).toHaveBeenCalledWith("bible.json", {
+        autoSave: false,
+        defaults: {},
+      })
       expect(mockGet).toHaveBeenCalledWith("activeTranslationId")
       expect(useBibleStore.getState().activeTranslationId).toBe(5)
     })

--- a/src/stores/bible-store.ts
+++ b/src/stores/bible-store.ts
@@ -57,7 +57,7 @@ export const useBibleStore = create<BibleState>((set) => ({
 /** Load persisted activeTranslationId from disk into Zustand, then sync to Rust backend. */
 export async function hydrateBibleStore(): Promise<void> {
   try {
-    const store = await load("bible.json", { autoSave: false })
+    const store = await load("bible.json", { autoSave: false, defaults: {} })
     const value = await store.get<number>("activeTranslationId")
     if (typeof value === "number") {
       useBibleStore.getState().setActiveTranslation(value)
@@ -73,7 +73,7 @@ export async function hydrateBibleStore(): Promise<void> {
 /** Subscribe to activeTranslationId changes and persist to disk with debounce. */
 export async function initBiblePersistence(): Promise<void> {
   try {
-    const store = await load("bible.json", { autoSave: false })
+    const store = await load("bible.json", { autoSave: false, defaults: {} })
     let timer: ReturnType<typeof setTimeout> | null = null
     let prev = useBibleStore.getState().activeTranslationId
 

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -55,7 +55,6 @@ const PERSISTED_KEYS = [
   "deepgramApiKey",
   "openaiApiKey",
   "claudeApiKey",
-  "activeTranslationId",
   "audioDeviceId",
   "gain",
   "autoMode",
@@ -64,8 +63,6 @@ const PERSISTED_KEYS = [
   "onboardingComplete",
   "sttProvider",
 ] as const satisfies readonly (keyof SettingsState)[]
-
-type PersistedKey = (typeof PERSISTED_KEYS)[number]
 
 let tauriStore: Store | null = null
 let hydrationPromise: Promise<void> | null = null

--- a/src/stores/tutorial-store.test.ts
+++ b/src/stores/tutorial-store.test.ts
@@ -46,6 +46,7 @@ describe("tutorial store", () => {
     await persistOnboardingComplete()
     expect(mockLoad).toHaveBeenCalledWith("settings.json", {
       autoSave: false,
+      defaults: {},
     })
     expect(mockSet).toHaveBeenCalledWith("onboardingComplete", true)
     expect(mockSave).toHaveBeenCalled()

--- a/src/stores/tutorial-store.ts
+++ b/src/stores/tutorial-store.ts
@@ -17,7 +17,7 @@ export const useTutorialStore = create<TutorialState>((set) => ({
 /** Load onboardingComplete from disk into settings store. */
 export async function hydrateOnboardingState(): Promise<void> {
   try {
-    const store = await load("settings.json", { autoSave: false })
+    const store = await load("settings.json", { autoSave: false, defaults: {} })
     const completed = await store.get<boolean>("onboardingComplete")
     if (completed) {
       useSettingsStore.getState().setOnboardingComplete(true)
@@ -31,7 +31,7 @@ export async function hydrateOnboardingState(): Promise<void> {
 export async function persistOnboardingComplete(): Promise<void> {
   useSettingsStore.getState().setOnboardingComplete(true)
   try {
-    const store = await load("settings.json", { autoSave: false })
+    const store = await load("settings.json", { autoSave: false, defaults: {} })
     await store.set("onboardingComplete", true)
     await store.save()
   } catch {


### PR DESCRIPTION
Re-enable the type check in the build script (tsc -b && vite build) and fix the 15 errors that were preventing it from passing:

- plugin-store: add required `defaults: {}` to load() calls in bible-store and tutorial-store (StoreOptions.defaults is now required)
- settings-store: drop bogus "activeTranslationId" from PERSISTED_KEYS (it is not a SettingsState field; bible-store persists it in bible.json) and remove the now-unused PersistedKey type
- react-joyride v3: remove dropped `disableBeacon` step option (skipBeacon already covers it) and move buttons/skipScroll/zIndex/overlayColor into the new `options` prop
- settings-dialog: add missing "remote" member to SettingsSection and remove dead oscEnabled/httpEnabled state
- tests: align store mock assertions with the new load() options shape

## Description

<!-- What does this PR do? Reference any related issues (e.g., `fixes #123`). -->

## Type of change

<!-- Check the one that applies: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

<!-- Check all that apply: -->

- [ ] Frontend (React / TypeScript)
- [ ] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [ ] I have tested this change locally
- [ ] `bun run typecheck` passes
- [ ] `cargo clippy` passes without warnings
- [ ] `bun run test` passes (if applicable)
- [ ] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

<!-- Check the platforms you tested on: -->

- [ ] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

<img width="834" height="494" alt="image" src="https://github.com/user-attachments/assets/a58c14c3-2926-4286-aa7f-7f21e6afeeca" />