### PR TITLE
feat(build): add Windows build workflow and configuration files

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,127 @@
+name: Windows Build
+
+# Builds the Windows installer (.exe via NSIS and .msi via WiX) and uploads
+# them as workflow artifacts. On a version tag (v*) the installers are also
+# attached to a GitHub Release.
+#
+# Trigger manually from the Actions tab (Run workflow) or by pushing a tag.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # needed to create/attach the release on tags
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    env:
+      # whisper-rs builds via bindgen, which needs libclang.dll from LLVM.
+      LIBCLANG_PATH: C:\Program Files\LLVM\bin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (MSVC)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Ensure LLVM + CMake (for whisper-rs)
+        shell: pwsh
+        run: |
+          # windows-latest ships LLVM + CMake, but guard against images that don't.
+          if (-not (Test-Path "$env:LIBCLANG_PATH\libclang.dll")) {
+            Write-Host "libclang.dll not found; installing LLVM via choco..."
+            choco install llvm --no-progress -y
+          }
+          if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
+            Write-Host "cmake not found; installing via choco..."
+            choco install cmake --no-progress -y --installargs 'ADD_CMAKE_TO_PATH=System'
+          }
+          Write-Host "Using LIBCLANG_PATH=$env:LIBCLANG_PATH"
+
+      - name: Install JS dependencies
+        run: bun install --frozen-lockfile
+
+      # --- Bundled runtime assets (cached so flaky/large downloads only run once) ---
+
+      - name: Cache Whisper model
+        uses: actions/cache@v4
+        with:
+          path: models/whisper
+          key: whisper-${{ hashFiles('data/download-whisper-model.ts') }}
+
+      - name: Cache NDI SDK
+        uses: actions/cache@v4
+        with:
+          path: sdk/ndi
+          key: ndi-${{ hashFiles('data/download-ndi-sdk.ts') }}
+
+      - name: Cache Bible database
+        uses: actions/cache@v4
+        with:
+          path: data/rhema.db
+          key: bible-db-${{ hashFiles('data/build-bible-db.ts', 'data/download-sources.ts', 'data/schema.sql') }}
+
+      - name: Download Whisper model (~834MB)
+        run: bun run download:whisper
+
+      - name: Download NDI SDK (Windows DLL)
+        run: bun run download:ndi-sdk
+
+      - name: Build Bible database
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "data/rhema.db")) {
+            bun run download:bible-data
+            bun run build:bible
+          } else {
+            Write-Host "data/rhema.db restored from cache; skipping rebuild."
+          }
+
+      - name: Verify bundled resources exist
+        shell: pwsh
+        run: |
+          $required = @(
+            "data/rhema.db",
+            "models/whisper/ggml-large-v3-turbo-q8_0.bin",
+            "sdk/ndi/windows/Processing.NDI.Lib.x64.dll"
+          )
+          foreach ($f in $required) {
+            if (-not (Test-Path $f)) { throw "Missing bundled resource: $f" }
+            Write-Host "OK: $f"
+          }
+
+      # --- Build the installers ---
+
+      - name: Build Tauri app
+        run: bun run tauri build
+
+      - name: Upload installers as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rhema-windows-installers
+          path: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/msi/*.msi
+          if-no-files-found: error
+
+      - name: Attach installers to release (tags only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/msi/*.msi

--- a/src-tauri/crates/broadcast/src/ndi.rs
+++ b/src-tauri/crates/broadcast/src/ndi.rs
@@ -397,14 +397,28 @@ fn resolve_library_path() -> Result<PathBuf, NdiError> {
         ]
     };
 
-    let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
-    for candidate in &candidates {
-        if candidate.is_empty() {
-            continue;
+    // Search roots, in priority order:
+    //  1. The dev workspace root (compile-time path) so `tauri dev` works
+    //     from a source checkout.
+    //  2. The directory containing the running executable, which in a
+    //     bundled install is the Tauri resource dir where the DLL/dylib is
+    //     shipped as a bundled resource.
+    let mut roots: Vec<PathBuf> = vec![Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..")];
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            roots.push(dir.to_path_buf());
         }
-        let absolute = base.join(candidate);
-        if absolute.exists() {
-            return Ok(absolute);
+    }
+
+    for root in &roots {
+        for candidate in &candidates {
+            if candidate.is_empty() {
+                continue;
+            }
+            let absolute = root.join(candidate);
+            if absolute.exists() {
+                return Ok(absolute);
+            }
         }
     }
 

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "targets": ["nsis", "msi"],
+    "resources": {
+      "../data/rhema.db": "./",
+      "../models/whisper/ggml-large-v3-turbo-q8_0.bin": "models/whisper/",
+      "../sdk/ndi/windows/Processing.NDI.Lib.x64.dll": "sdk/ndi/windows/"
+    }
+  }
+}

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -3,7 +3,7 @@ import { PanelHeader } from "@/components/ui/panel-header"
 import { LevelMeter } from "@/components/ui/level-meter"
 import { Button } from "@/components/ui/button"
 import { ApiKeyPrompt } from "@/components/ui/api-key-prompt"
-import { MicIcon, MicOffIcon } from "lucide-react"
+import { EraserIcon, MicIcon, MicOffIcon } from "lucide-react"
 import {
   useAudioStore,
   useDetectionStore,
@@ -59,6 +59,7 @@ export function TranscriptPanel() {
     stopTranscription,
   } = useTranscription({ onMissingApiKey })
   const hasPartial = useTranscriptStore((s) => s.currentPartial.length > 0)
+  const clearTranscript = useTranscriptStore((s) => s.clearTranscript)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useTauriEvent<{ rms: number; peak: number }>("audio_level", (payload) => {
@@ -277,6 +278,15 @@ export function TranscriptPanel() {
             Start transcribing
           </Button>
         )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={clearTranscript}
+          disabled={segments.length === 0 && !hasPartial}
+        >
+          <EraserIcon className="size-3" />
+          Clear
+        </Button>
       </div>
 
       <ApiKeyPrompt


### PR DESCRIPTION
## Description

Adds Windows build support to the project by introducing a dedicated GitHub Actions workflow for producing Windows installers.

### What's included

* Added a GitHub Actions workflow to build Windows NSIS (`.exe`) and WiX (`.msi`) installers.
* Configured caching for Rust dependencies, Whisper models, the NDI SDK, and the generated Bible database to speed up CI.
* Added automatic download and validation of required runtime resources during the build.
* Configured Tauri Windows bundling to package:

  * Bible database
  * Whisper model
  * NDI runtime DLL
* Updated NDI library resolution to search both the development workspace and bundled application resources, allowing the app to work correctly after installation.
* Added a **Clear Transcript** button to the transcript panel.

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Refactoring (no functional changes)
* [ ] Documentation
* [x] Build / CI
* [ ] Performance improvement

## Areas affected

* [x] Frontend (React / TypeScript)
* [x] Backend (Rust / Tauri commands)
* [x] Rust crate: `broadcast`
* [ ] Remote control (OSC / HTTP)
* [x] Broadcast / NDI
* [ ] Theme Designer
* [x] Bible data / search
* [x] Audio / STT

## Checklist

* [x] I have tested this change locally
* [ ] `bun run typecheck` passes
* [ ] `cargo clippy` passes without warnings
* [ ] `bun run test` passes (if applicable)
* [ ] I have added tests for new functionality (if applicable)
* [ ] UI changes include a screenshot or recording below

## Tested on

* [ ] macOS
* [x] Windows
* [ ] Linux
  :::
