### PR TITLE
chore: publish a Windows installer on merge to main

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,163 @@
+name: Release Windows binary
+
+# Builds the Tauri desktop app on every merge to main and publishes the NSIS
+# installer to a rolling `nightly` prerelease, so the newest main always has a
+# stable download URL:
+#   https://github.com/openbezal/rhema/releases/download/nightly/Rhema-windows-x64-setup.exe
+#
+# The release is deleted and recreated each run, so the tag follows the newest
+# commit and stale assets from earlier versions never accumulate.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'web/**'
+      - 'documentation/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/deploy-web.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-windows
+  cancel-in-progress: true
+
+env:
+  RELEASE_TAG: nightly
+  ASSET_NAME: Rhema-windows-x64-setup.exe
+
+jobs:
+  build:
+    runs-on: windows-latest
+    # A cold-cache release build compiles the whole Rust workspace plus
+    # whisper.cpp and ONNX Runtime — budget generously.
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      # `whisper` is a default Cargo feature, so whisper-rs-sys builds
+      # whisper.cpp from source: bindgen needs libclang and whisper.cpp needs
+      # CMake. Both normally ship in the runner image; install only if missing.
+      - name: Ensure LLVM and CMake
+        shell: pwsh
+        run: |
+          $llvmBin = Join-Path $env:ProgramFiles 'LLVM\bin'
+          if (-not (Test-Path (Join-Path $llvmBin 'libclang.dll'))) {
+            Write-Host 'libclang.dll not present in the runner image - installing LLVM'
+            choco install llvm -y --no-progress
+          }
+          if (-not (Test-Path (Join-Path $llvmBin 'libclang.dll'))) {
+            throw "libclang.dll still not found at $llvmBin after install"
+          }
+          "LIBCLANG_PATH=$llvmBin" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "LIBCLANG_PATH=$llvmBin"
+
+          if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
+            Write-Host 'cmake not on PATH - installing CMake'
+            choco install cmake -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System'
+            $cmakeBin = Join-Path $env:ProgramFiles 'CMake\bin'
+            $env:PATH = "$env:PATH;$cmakeBin"
+            $cmakeBin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          }
+          cmake --version
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      # `beforeBuildCommand` runs `tsc -b && vite build`, so this step also
+      # gates on the frontend typechecking clean.
+      - name: Build Windows installer
+        run: bun run tauri build --bundles nsis
+
+      - name: Stage installer
+        id: stage
+        shell: pwsh
+        run: |
+          $version = (Get-Content src-tauri/tauri.conf.json -Raw | ConvertFrom-Json).version
+          $setup = Get-ChildItem -Path 'src-tauri/target/release/bundle/nsis' -Filter '*-setup.exe' -ErrorAction SilentlyContinue |
+                   Select-Object -First 1
+          if (-not $setup) {
+            Write-Host 'Contents of src-tauri/target/release/bundle:'
+            Get-ChildItem -Path 'src-tauri/target/release/bundle' -Recurse -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host "  $($_.FullName)" }
+            throw 'No NSIS installer found under src-tauri/target/release/bundle/nsis'
+          }
+
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          $staged = Join-Path 'dist' $env:ASSET_NAME
+          Copy-Item $setup.FullName $staged
+
+          $sha256 = (Get-FileHash $staged -Algorithm SHA256).Hash.ToLower()
+          $sizeMb = [math]::Round($setup.Length / 1MB, 1)
+
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "sha256=$sha256"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "size_mb=$sizeMb"  | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Staged $($setup.Name) as $env:ASSET_NAME ($sizeMb MB, sha256 $sha256)"
+
+      # Kept regardless of the release outcome, and the only output for
+      # workflow_dispatch runs on a non-main ref.
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: rhema-windows-x64-setup
+          path: dist/*.exe
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Publish rolling prerelease
+        if: github.ref == 'refs/heads/main'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.stage.outputs.version }}
+          SHA256: ${{ steps.stage.outputs.sha256 }}
+          SIZE_MB: ${{ steps.stage.outputs.size_mb }}
+        run: |
+          $shortSha = $env:GITHUB_SHA.Substring(0, 7)
+          $commitUrl = "https://github.com/$env:GITHUB_REPOSITORY/commit/$env:GITHUB_SHA"
+          $notes = @"
+          Automated Windows build of the latest ``main``.
+
+          | | |
+          |---|---|
+          | Version | ``$env:VERSION`` |
+          | Commit | [``$shortSha``]($commitUrl) |
+          | Size | $env:SIZE_MB MB |
+          | SHA-256 | ``$env:SHA256`` |
+
+          This installer is **unsigned**, so Windows SmartScreen warns on first run
+          (More info -> Run anyway).
+
+          The Bible database, embedding model and Whisper model are **not bundled**.
+          Run the setup pipeline from source (``bun run setup:all``) for verse
+          detection and local speech-to-text — see the README.
+          "@
+          $notes | Out-File -FilePath release-notes.md -Encoding utf8
+
+          # Drop the previous rolling release and its tag so the new one points at
+          # this commit and no stale assets survive a version bump. A missing
+          # release is the expected state on the very first run.
+          gh release delete $env:RELEASE_TAG --yes --cleanup-tag
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "No existing '$env:RELEASE_TAG' release to delete - continuing"
+          }
+          $global:LASTEXITCODE = 0
+
+          $asset = Join-Path 'dist' $env:ASSET_NAME
+          gh release create $env:RELEASE_TAG $asset --target $env:GITHUB_SHA --title "Rhema v$env:VERSION (nightly)" --notes-file release-notes.md --prerelease

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@fontsource-variable/source-serif-4": "^5.2.9",
         "@fontsource/geist-mono": "^5.2.7",
         "@tailwindcss/vite": "^4.2.1",
-        "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "~2",
         "@tauri-apps/plugin-fs": "~2",
         "@tauri-apps/plugin-global-shortcut": "~2",
@@ -502,7 +502,7 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
     "@tauri-apps/cli": ["@tauri-apps/cli@2.10.1", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.10.1", "@tauri-apps/cli-darwin-x64": "2.10.1", "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1", "@tauri-apps/cli-linux-arm64-gnu": "2.10.1", "@tauri-apps/cli-linux-arm64-musl": "2.10.1", "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-musl": "2.10.1", "@tauri-apps/cli-win32-arm64-msvc": "2.10.1", "@tauri-apps/cli-win32-ia32-msvc": "2.10.1", "@tauri-apps/cli-win32-x64-msvc": "2.10.1" }, "bin": { "tauri": "tauri.js" } }, "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g=="],
 
@@ -1485,6 +1485,18 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tauri-apps/plugin-dialog/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-fs/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-global-shortcut/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-log/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-opener/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-store/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 


### PR DESCRIPTION
## Description

Right now there's no way to get a Windows build of Rhema without building it yourself. This adds a workflow that does it for you: every merge to `main` builds the app on a Windows runner and puts the installer on a GitHub release.

The download link stays the same every time, so you can bookmark it:

```
https://github.com/openbezal/rhema/releases/download/nightly/Rhema-windows-x64-setup.exe
```

The release is a prerelease tagged `nightly`, and each build replaces the last one. I went with that instead of tagging versions because the version in `tauri.conf.json` almost never changes — if we only released on version bumps, most merges would produce nothing.

**A few things about the build:**

- It skips merges that only touch docs or the `web/` site, so a README fix doesn't trigger a 40-minute Rust build.
- Whisper compiles from C++ source, which needs libclang and CMake. Both usually come with the runner, so there's a step that only installs them if they're missing.
- Rust build output is cached. Without it every merge recompiles whisper.cpp and ONNX Runtime from scratch.
- Building runs `tsc -b` first, so a type error fails the build — the same thing that broke #90.

**The second commit** fixes a lockfile problem. `package.json` asks for `@tauri-apps/api ^2.11.1` but `bun.lock` on `main` still had `^2.10.1`. I confirmed it by cloning `main` fresh: `bun install --frozen-lockfile` fails with "lockfile had changes, but lockfile is frozen". Without this fix the new workflow would go red on its first run.

## Things worth knowing about the installer

**It doesn't include the Bible database or the AI models.** Those add up to well over a gigabyte, and the Bible data comes from a Google Drive link with a daily download limit — not something to hang a release pipeline on. The app still starts fine without them; every place that loads them checks first and logs a warning. The release notes tell people to run `bun run setup:all` from source.

**Semantic verse detection won't work in this build, or any build we distribute.** `src-tauri/src/lib.rs:99` and `:113-115` build the model and embedding paths from `CARGO_MANIFEST_DIR`, which bakes in the path of whatever machine compiled it — in this case a GitHub runner that no longer exists. The Bible database at `:73-82` already does this right with a `resource_dir()` fallback; the model paths need the same treatment. That's a pre-existing bug, not something this PR causes, but it does need fixing before shipping models is worth doing. Happy to open a separate issue.

**The installer isn't signed**, so Windows will show a SmartScreen warning the first time someone runs it. That's expected and needs no keys today. The release notes say so.

**One small edge case:** the workflow deletes the old release before creating the new one. If a run gets cancelled in the couple of seconds between those two steps, there'd be no `nightly` release until the next merge. Low odds, and it fixes itself.

## Type of change

- [x] Build / CI

## Areas affected

Nothing in the app itself — this only adds a workflow file and syncs the lockfile.

## Checklist

- [ ] I have tested this change locally — can't be tested locally; a workflow only runs on GitHub. Everything I could check offline, I did: the YAML parses, the PowerShell here-string terminator lands where it needs to, and the lockfile failure was reproduced against a clean clone of `main`.
- [x] `bun run typecheck` passes — unchanged, no source files touched
- [x] `cargo clippy` passes without warnings — unchanged, no Rust files touched
- [x] `bun run test` passes (if applicable) — n/a
- [x] I have added tests for new functionality (if applicable) — n/a
- [x] UI changes include a screenshot or recording below — n/a

## Tested on

The first merge to `main` is the real test. The most likely thing to break is libclang not being where the workflow expects it; if that happens the build fails inside `whisper-rs-sys` and the fix is a one-line path change.

## Screenshots / recordings

n/a
