### PR TITLE
fix(ci): give the Pages deployment longer before aborting

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -66,3 +66,12 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          # A Pages deployment is keyed by commit SHA, and on timeout this
+          # action cancels the deployment it created. That combination is
+          # unrecoverable: once a SHA's deployment is cancelled, re-running the
+          # job recreates the same id, reads back the cancelled state, and fails
+          # instantly — only a new commit can deploy. A queue stall on
+          # 2026-08-06 burned a SHA that way, so give the queue more room than
+          # the 10-minute default before aborting.
+          timeout: 1800000


### PR DESCRIPTION
## Description

The site deploy for #94 failed, and openrhema.com is still serving a build from May — the Download button there still points at `/releases/latest`, the URL #94 replaced.

**What happened.** A GitHub Pages deployment is identified by the commit SHA. When `actions/deploy-pages` hits its timeout, it cancels the deployment it created. Those two facts combine badly: once a SHA's deployment is cancelled, that SHA can never deploy again. Re-running the job creates a deployment with the same id, reads back the cancelled state, and fails in about nine seconds.

That's exactly what happened here. The deployment sat in `deployment_queued` for the full ten minutes, the action gave up and cancelled it, and every retry since has failed instantly. There was no GitHub incident, the `github-pages` environment allows `main`, and the build itself succeeded and uploaded its artifact fine — the queue was just slow.

**The fix** raises the timeout from the ten-minute default to thirty minutes, so a slow queue no longer burns a commit.

**Merging this also unsticks the site.** `deploy-web.yml` is in its own `paths` filter, so merging a change to it triggers a deploy — and it does so from a fresh SHA, which is the only thing that can deploy now. So this PR fixes the fragility and ships #94's changes in one go.

## What to watch after merging

If the deploy stalls again but finishes within thirty minutes, this worked. If it runs the full thirty and aborts, the queue problem is real rather than transient and worth raising with GitHub support — the last successful Pages deployment on this repo was 2026-05-05.

## Type of change

- [x] Bug fix
- [x] Build / CI

## Areas affected

CI only. No application or site code.

## Checklist

- [x] I have tested this change locally — a workflow can't run locally; the YAML parses and `timeout` is a documented input on `actions/deploy-pages`
- [x] `bun run typecheck` passes — nothing touched
- [x] `cargo clippy` passes without warnings — nothing touched
- [x] `bun run test` passes (if applicable) — n/a
- [x] I have added tests for new functionality (if applicable) — n/a
- [x] UI changes include a screenshot or recording below — n/a

## Tested on

n/a — CI configuration.

## Screenshots / recordings

n/a
