### PR TITLE
chore(ci): update actions to latest and drop the clamped Pages timeout

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -27,14 +27,14 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Cache Next.js build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/bun.lock') }}-${{ hashFiles('web/**/*.ts', 'web/**/*.tsx') }}
@@ -64,14 +64,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Do not try to raise `timeout` here: the action clamps it to 600000 ms
+      # and logs "timeout value is greater than the allowed maximum". Waiting
+      # longer is not an option this workflow controls.
+      #
+      # A Pages deployment is also keyed by commit SHA, and on timeout the
+      # action cancels the deployment it created — so a timed-out SHA can never
+      # deploy again. Re-running the job recreates the same id, reads back the
+      # cancelled state, and fails in seconds. Only a new commit can deploy.
       - id: deployment
         uses: actions/deploy-pages@v5
-        with:
-          # A Pages deployment is keyed by commit SHA, and on timeout this
-          # action cancels the deployment it created. That combination is
-          # unrecoverable: once a SHA's deployment is cancelled, re-running the
-          # job recreates the same id, reads back the cancelled state, and fails
-          # instantly — only a new commit can deploy. A queue stall on
-          # 2026-08-06 burned a SHA that way, so give the queue more room than
-          # the 10-minute default before aborting.
-          timeout: 1800000

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Description

Two things: undo the timeout change from #95, which turned out to do nothing, and move every action to its newest major.

**#95 didn't work, and its reasoning was wrong.** `actions/deploy-pages` caps `timeout` at 600000 ms. The 30-minute value I set was silently clamped back to ten minutes, and the log said so:

```
Warning: timeout value is greater than the allowed maximum - timeout set to the maximum of 600000 milliseconds.
```

The comment I left there also blamed a slow queue. That was wrong — see below. Leaving a setting that advertises 30 minutes, silently becomes 10, and explains itself with a disproved theory is worse than not having it, so it's gone. In its place is a comment recording that the cap exists and can't be raised, so nobody spends time trying again.

**Action versions**, all now on the newest major:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v6 | **v7** (both workflows) |
| `actions/cache` | v5 | **v6** |
| `actions/upload-pages-artifact` | v5 | v5 — already newest |
| `actions/deploy-pages` | v5 | v5 — already newest |
| `oven-sh/setup-bun` | v2 | v2 — already newest |
| `actions/upload-artifact` | v7 | v7 — already newest |
| `Swatinem/rust-cache` | v2 | v2 — already newest |

`checkout` v6 to v7 is a major bump, but both call sites are a bare `- uses:` with no inputs, so there's no surface for a breaking change to land on.

## This does not fix the Pages deploy

Being straight about it: the site deploy is broken on GitHub's side, and no change in this repository fixes it.

The evidence is the May 5 run. Same workflow, same site, same Next version — its deploy step took **10 seconds**. Today the identical operation runs past 600 and gets killed.

Everything repo-side has been ruled out:

- **Site size** — 276 files, 30 MB. Trivial for Pages.
- **Artifact content** — no symlinks, no zero-byte files, nothing nested deeply. The `!` and `$` characters in Next's RSC prefetch filenames were also present in May.
- **Next version** — 16.2.4 then, 16.2.4 now.
- **A wedged deployment holding the environment's concurrency lock** — the usual suspect. Every deployment is in a terminal state; nothing is stuck pending.
- **Branch policy** — the `github-pages` environment allows `main`.
- **A GitHub incident** — status page clean.
- **The legacy `pages-build-deployment` builder** — doesn't exist on this repo, so May's success genuinely came from this workflow.

Three deployments today were accepted and then hung: the first in `deployment_queued`, the next two in `deployment_in_progress`. All three were killed by the ten-minute cap.

This is a support ticket. Worth including in it: the repo, the three run URLs, that the same workflow deployed the same site in 10 seconds on 2026-05-05, and that deployments now hang in `deployment_in_progress` until the action's cap kills them.

If support stalls, the fallback is to stop using `actions/deploy-pages` — build `web/out`, push it to a `gh-pages` branch, and point Pages at that branch. That's entirely different machinery. It needs a settings change on a live custom domain, though, and if GitHub's publishing backend for this site is what's wedged it may hang too, so it's a fallback rather than a plan.

## Type of change

- [x] Build / CI

## Areas affected

CI only.

## Checklist

- [x] I have tested this change locally — both workflow files parse; action versions checked against each repository's latest release
- [x] `bun run typecheck` passes — nothing touched
- [x] `cargo clippy` passes without warnings — nothing touched
- [x] `bun run test` passes (if applicable) — n/a
- [x] I have added tests for new functionality (if applicable) — n/a
- [x] UI changes include a screenshot or recording below — n/a

## Tested on

n/a — CI configuration.

## Screenshots / recordings

n/a
