### PR TITLE
feat: movable book reference and verse text

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "rhema",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.8",
         "@dnd-kit/react": "^0.3.2",
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
@@ -119,6 +120,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@chenglou/pretext": ["@chenglou/pretext@0.0.8", "", {}, "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "web:lint": "cd web && bun run lint"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.8",
     "@dnd-kit/react": "^0.3.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/inter": "^5.2.8",
@@ -37,11 +38,11 @@
     "@fontsource/geist-mono": "^5.2.7",
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-dialog": "~2",
+    "@tauri-apps/plugin-fs": "~2",
     "@tauri-apps/plugin-global-shortcut": "~2",
     "@tauri-apps/plugin-log": "~2",
     "@tauri-apps/plugin-opener": "^2.5.3",
-    "@tauri-apps/plugin-dialog": "~2",
-    "@tauri-apps/plugin-fs": "~2",
     "@tauri-apps/plugin-store": "~2",
     "@types/bun": "^1.3.14",
     "class-variance-authority": "^0.7.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1429,6 +1429,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2679,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -3903,6 +3934,7 @@ dependencies = [
  "base64 0.22.1",
  "crossbeam-channel",
  "dotenvy",
+ "fontdb",
  "log",
  "rhema-api",
  "rhema-audio",
@@ -4073,6 +4105,12 @@ dependencies = [
  "nom",
  "time",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rusqlite"
@@ -4559,6 +4597,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ base64 = "0.22"
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+fontdb = "0.24.0"
 
 [features]
 default = ["whisper"]

--- a/src-tauri/src/commands/fonts.rs
+++ b/src-tauri/src/commands/fonts.rs
@@ -1,0 +1,24 @@
+use std::sync::OnceLock;
+
+/// List the family names of all fonts installed on this system, sorted
+/// case-insensitively. Enumeration is expensive (~100ms+), so the result is
+/// computed once and cached for the lifetime of the process.
+#[tauri::command]
+pub fn list_system_fonts() -> Vec<String> {
+    static FONTS: OnceLock<Vec<String>> = OnceLock::new();
+    FONTS.get_or_init(enumerate_system_fonts).clone()
+}
+
+fn enumerate_system_fonts() -> Vec<String> {
+    let mut db = fontdb::Database::new();
+    db.load_system_fonts();
+
+    let mut families: Vec<String> = db
+        .faces()
+        .flat_map(|face| face.families.iter())
+        .map(|(name, _language)| name.clone())
+        .collect();
+    families.sort_unstable_by_key(|name| name.to_lowercase());
+    families.dedup();
+    families
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod audio;
 pub mod bible;
 pub mod broadcast;
 pub mod detection;
+pub mod fonts;
 pub mod remote;
 pub mod stt;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
             commands::broadcast::stop_ndi,
             commands::broadcast::get_ndi_status,
             commands::broadcast::push_ndi_frame,
+            commands::fonts::list_system_fonts,
             commands::remote::start_osc,
             commands::remote::stop_osc,
             commands::remote::get_osc_status,

--- a/src/broadcast-fonts.css
+++ b/src/broadcast-fonts.css
@@ -1,0 +1,8 @@
+/* Bundled webfonts for the broadcast output window. This webview does not load
+   index.css (which would pull in all of Tailwind), so the fontsource faces are
+   imported here separately — without this, themes using bundled fonts silently
+   fall back to system serif/sans in the projected output. */
+@import "@fontsource-variable/geist";
+@import "@fontsource-variable/source-serif-4";
+@import "@fontsource/geist-mono";
+@import "@fontsource-variable/inter";

--- a/src/broadcast-output.tsx
+++ b/src/broadcast-output.tsx
@@ -2,7 +2,9 @@ import { createRoot } from "react-dom/client"
 import { useRef, useEffect, useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow"
-import { renderVerse } from "@/lib/verse-renderer"
+import { onThemeFontsLoaded, renderVerse } from "@/lib/verse-renderer"
+import { normalizeTheme } from "@/lib/theme-migrations"
+import "./broadcast-fonts.css"
 import type { BroadcastTheme, VerseRenderData } from "@/types/broadcast"
 import type { NdiConfigEventPayload, NdiFrameRequest } from "@/types"
 
@@ -173,7 +175,10 @@ function BroadcastCanvas() {
     const currentWindow = getCurrentWebviewWindow()
     logDebug("Listener registration started", { label: currentWindow.label })
     const unlisten = currentWindow.listen<BroadcastPayload>("broadcast:verse-update", (event) => {
-      latestData.current = event.payload
+      latestData.current = {
+        ...event.payload,
+        theme: normalizeTheme(event.payload.theme),
+      }
       preloadBackgroundImage(event.payload.theme)
       logDebug("Received broadcast:verse-update", {
         hasVerse: Boolean(event.payload.verse),
@@ -208,6 +213,13 @@ function BroadcastCanvas() {
         // Command may not exist yet
       })
 
+    // Redraw whenever a theme webfont finishes loading (the renderer requests
+    // them on demand) so frames drawn against fallback metrics are replaced.
+    const unsubscribeFonts = onThemeFontsLoaded(() => {
+      draw()
+      pushNdiBurst()
+    })
+
     void currentWindow.emitTo("main", "broadcast:output-ready").then(() => {
       logDebug("Sent broadcast:output-ready")
     }).catch(() => {
@@ -215,6 +227,7 @@ function BroadcastCanvas() {
     })
 
     return () => {
+      unsubscribeFonts()
       unlisten.then((fn) => fn())
       unlistenNdiConfig.then((fn) => fn())
     }

--- a/src/components/broadcast/design-canvas.tsx
+++ b/src/components/broadcast/design-canvas.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState, useCallback } from "react"
 import * as fabric from "fabric"
 import { useBroadcastStore } from "@/stores"
-import { renderVerse } from "@/lib/verse-renderer"
+import {
+  onThemeFontsLoaded,
+  renderVerse,
+  type VerseLayoutMetrics,
+} from "@/lib/verse-renderer"
+import { seedFreeBoxesFromMetrics, SAMPLE_VERSE } from "@/lib/theme-migrations"
 import { Button } from "@/components/ui/button"
 import {
   SearchIcon,
@@ -11,14 +16,10 @@ import {
   Grid3X3Icon,
   MaximizeIcon,
 } from "lucide-react"
-import type { BroadcastTheme, VerseRenderData } from "@/types"
+import type { BroadcastTheme } from "@/types"
 
 const WS_WIDTH = 1920
 const WS_HEIGHT = 1080
-const DESIGNER_SAMPLE_VERSE: VerseRenderData = {
-  reference: "Genesis 1:1 (KJV)",
-  segments: [{ verseNumber: 1, text: "In the beginning God created the heaven and the earth." }],
-}
 
 export function DesignCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -33,6 +34,8 @@ export function DesignCanvas() {
     referenceRegion: fabric.Rect | null
     verseRegion: fabric.Rect | null
   }>({ workspace: null, referenceRegion: null, verseRegion: null })
+  const draggingRef = useRef<"reference" | "verse" | null>(null)
+  const latestMetricsRef = useRef<VerseLayoutMetrics | null>(null)
 
   const draftTheme = useBroadcastStore((s) => s.draftTheme)
   const editingThemeId = useBroadcastStore((s) => s.editingThemeId)
@@ -48,7 +51,10 @@ export function DesignCanvas() {
       objectsRef,
       canvas,
       imageCacheRef.current,
-      imageRequestsRef.current
+      imageRequestsRef.current,
+      undefined,
+      latestMetricsRef,
+      draggingRef.current
     )
   }, [])
 
@@ -126,8 +132,8 @@ export function DesignCanvas() {
       hasBorders: true,
       borderColor: "#f59e0b",
       borderDashArray: [6, 3],
-      lockMovementX: true,
-      lockMovementY: true,
+      lockMovementX: false,
+      lockMovementY: false,
       evented: true,
       objectCaching: false,
     })
@@ -147,8 +153,8 @@ export function DesignCanvas() {
       hasBorders: true,
       borderColor: "#f59e0b",
       borderDashArray: [6, 3],
-      lockMovementX: true,
-      lockMovementY: true,
+      lockMovementX: false,
+      lockMovementY: false,
       evented: true,
       objectCaching: false,
     })
@@ -176,6 +182,65 @@ export function DesignCanvas() {
       useBroadcastStore.getState().setSelectedElement(null)
     })
 
+    // Drag-to-position: moving a region writes its box back to the draft
+    // theme. Dragging while in stacked mode detaches into free mode first,
+    // seeding boxes from the current stacked layout so nothing jumps.
+    const regionForObject = (obj: fabric.Object | undefined) =>
+      obj === objectsRef.current.referenceRegion
+        ? ("reference" as const)
+        : obj === objectsRef.current.verseRegion
+          ? ("verse" as const)
+          : null
+
+    canvas.on("object:moving", (e) => {
+      const region = regionForObject(e.target)
+      if (!region) return
+      draggingRef.current = region
+
+      const store = useBroadcastStore.getState()
+      let theme = store.draftTheme
+      if (!theme) return
+      if (
+        theme.layout.mode !== "free" ||
+        !theme.layout.referenceBox ||
+        !theme.layout.verseBox
+      ) {
+        const metrics = latestMetricsRef.current
+        const seeded = metrics
+          ? seedFreeBoxesFromMetrics(metrics, theme.resolution)
+          : null
+        if (!seeded) return
+        store.updateDraft({ layout: { ...theme.layout, mode: "free", ...seeded } })
+        theme = useBroadcastStore.getState().draftTheme
+        if (!theme) return
+      }
+
+      const ws = objectsRef.current.workspace
+      const obj = e.target
+      if (!ws || !obj) return
+      const wsTopLeft = ws.getPointByOrigin("left", "top")
+      const key = region === "reference" ? "referenceBox" : "verseBox"
+      const box = theme.layout[key]
+      if (!box) return
+      const widthPx = (box.width / 100) * WS_WIDTH
+      const heightPx = (box.height / 100) * WS_HEIGHT
+      const localX = clamp(obj.left - wsTopLeft.x, 0, Math.max(0, WS_WIDTH - widthPx))
+      const localY = clamp(obj.top - wsTopLeft.y, 0, Math.max(0, WS_HEIGHT - heightPx))
+      store.updateDraftNested(`layout.${key}`, {
+        ...box,
+        x: Math.round((localX / WS_WIDTH) * 10000) / 100,
+        y: Math.round((localY / WS_HEIGHT) * 10000) / 100,
+      })
+    })
+
+    const endDrag = () => {
+      if (!draggingRef.current) return
+      draggingRef.current = null
+      resyncLatestTheme()
+    }
+    canvas.on("object:modified", endDrag)
+    canvas.on("mouse:up", endDrag)
+
     fabricRef.current = canvas
 
     // Auto-zoom after a tick (canvas needs to be in DOM)
@@ -187,7 +252,12 @@ export function DesignCanvas() {
     const observer = new ResizeObserver(() => autoZoom())
     observer.observe(containerRef.current)
 
+    // Re-render once theme webfonts load — text measured against fallback
+    // fonts before that would leave the bitmap and hit rects off.
+    const unsubscribeFonts = onThemeFontsLoaded(() => resyncLatestTheme())
+
     return () => {
+      unsubscribeFonts()
       observer.disconnect()
       if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current)
       rafIdRef.current = null
@@ -195,7 +265,7 @@ export function DesignCanvas() {
       fabricRef.current = null
       objectsRef.current = { workspace: null, referenceRegion: null, verseRegion: null }
     }
-  }, [editingThemeId, autoZoom])
+  }, [editingThemeId, autoZoom, resyncLatestTheme])
 
   // Sync draft theme to the existing Fabric objects (throttled to 1 per frame)
   useEffect(() => {
@@ -224,9 +294,14 @@ export function DesignCanvas() {
             objectsRef,
             currentCanvas,
             imageCacheRef.current,
-            imageRequestsRef.current
+            imageRequestsRef.current,
+            undefined,
+            latestMetricsRef,
+            draggingRef.current
           )
-        }
+        },
+        latestMetricsRef,
+        draggingRef.current
       )
     })
   }, [draftTheme])
@@ -335,7 +410,9 @@ async function syncThemeToCanvas(
   canvas: fabric.Canvas,
   imageCache: Map<string, HTMLImageElement>,
   imageRequests: Map<string, Promise<HTMLImageElement>>,
-  onImageReady?: () => void
+  onImageReady?: () => void,
+  metricsRef?: React.MutableRefObject<VerseLayoutMetrics | null>,
+  dragging?: "reference" | "verse" | null
 ) {
   const ws = objectsRef.current.workspace
   const refRegion = objectsRef.current.referenceRegion
@@ -363,38 +440,55 @@ async function syncThemeToCanvas(
   })
 
   if (!metrics) return
+  if (metricsRef) metricsRef.current = metrics
   const referenceRect = metrics.referenceRect
   const verseRect = metrics.verseRect
   if (!referenceRect || !verseRect) return
 
   ws.setCoords()
   const wsTopLeft = ws.getPointByOrigin("left", "top")
-  const tightenedRects = tightenTextHitRects(referenceRect, verseRect, theme)
-  const mappedReferenceRect = mapLocalRectToWorkspaceRect(tightenedRects.referenceRect, wsTopLeft)
-  const mappedVerseRect = mapLocalRectToWorkspaceRect(tightenedRects.verseRect, wsTopLeft)
+  // In free mode the regions ARE the layout boxes, so map them 1:1 for an
+  // exact drag round-trip. In stacked mode the renderer's element rects
+  // already wrap the drawn text.
+  const freeMode =
+    theme.layout.mode === "free" &&
+    metrics.referenceBoxRect &&
+    metrics.verseBoxRect
+  const hitRects = freeMode
+    ? {
+        referenceRect: metrics.referenceBoxRect!,
+        verseRect: metrics.verseBoxRect!,
+      }
+    : { referenceRect, verseRect }
+  const mappedReferenceRect = mapLocalRectToWorkspaceRect(hitRects.referenceRect, wsTopLeft)
+  const mappedVerseRect = mapLocalRectToWorkspaceRect(hitRects.verseRect, wsTopLeft)
 
-  refRegion.set({
-    originX: "left",
-    originY: "top",
-    width: Math.max(24, mappedReferenceRect.width),
-    height: Math.max(20, mappedReferenceRect.height),
-  })
-  refRegion.setPositionByOrigin(
-    new fabric.Point(mappedReferenceRect.x, mappedReferenceRect.y),
-    "left",
-    "top"
-  )
-  verseRegion.set({
-    originX: "left",
-    originY: "top",
-    width: Math.max(24, mappedVerseRect.width),
-    height: Math.max(24, mappedVerseRect.height),
-  })
-  verseRegion.setPositionByOrigin(
-    new fabric.Point(mappedVerseRect.x, mappedVerseRect.y),
-    "left",
-    "top"
-  )
+  if (dragging !== "reference") {
+    refRegion.set({
+      originX: "left",
+      originY: "top",
+      width: Math.max(24, mappedReferenceRect.width),
+      height: Math.max(20, mappedReferenceRect.height),
+    })
+    refRegion.setPositionByOrigin(
+      new fabric.Point(mappedReferenceRect.x, mappedReferenceRect.y),
+      "left",
+      "top"
+    )
+  }
+  if (dragging !== "verse") {
+    verseRegion.set({
+      originX: "left",
+      originY: "top",
+      width: Math.max(24, mappedVerseRect.width),
+      height: Math.max(24, mappedVerseRect.height),
+    })
+    verseRegion.setPositionByOrigin(
+      new fabric.Point(mappedVerseRect.x, mappedVerseRect.y),
+      "left",
+      "top"
+    )
+  }
   canvas.bringObjectToFront(verseRegion)
   canvas.bringObjectToFront(refRegion)
 
@@ -421,47 +515,6 @@ function mapLocalRectToWorkspaceRect(
     y: wsTopLeft.y + localY,
     width: clampedWidth,
     height: clampedHeight,
-  }
-}
-
-function tightenTextHitRects(
-  referenceRect: { x: number; y: number; width: number; height: number },
-  verseRect: { x: number; y: number; width: number; height: number },
-  theme: BroadcastTheme
-) {
-  const refFont = Math.max(1, theme.reference.fontSize)
-  const verseFont = Math.max(1, theme.verseText.fontSize)
-  const verseExtraLeading = Math.max(0, theme.verseText.lineHeight - 1) * verseFont
-  const referenceGap = Math.max(0, theme.layout.referenceGap ?? 0)
-  const refPadX = Math.max(6, refFont * 0.25)
-  const refPadTop = Math.max(2, refFont * 0.2)
-  const refPadBottom = Math.max(0, refFont * 0)
-
-  // Renderer rects include spacing blocks; trim to closer glyph hit areas for designer selection.
-  const referenceTight = {
-    x: referenceRect.x - refPadX,
-    y: referenceRect.y + refFont * 0.22 - refPadTop,
-    width: referenceRect.width + refPadX * 2,
-    height: Math.max(refFont * 1.05, referenceRect.height - refFont * 0.42) + refPadTop + refPadBottom,
-  }
-  const verseTight = {
-    x: verseRect.x,
-    y: verseRect.y + verseFont * 0.12,
-    width: verseRect.width,
-    height: Math.max(verseFont, verseRect.height - verseExtraLeading - verseFont * 0.1),
-  }
-
-  if (theme.reference.position === "above") {
-    const minVerseY = referenceTight.y + referenceTight.height + referenceGap
-    verseTight.y = Math.max(verseTight.y, minVerseY)
-  } else if (theme.reference.position === "below") {
-    const minRefY = verseTight.y + verseTight.height + referenceGap
-    referenceTight.y = Math.max(referenceTight.y, minRefY)
-  }
-
-  return {
-    referenceRect: referenceTight,
-    verseRect: verseTight,
   }
 }
 
@@ -511,6 +564,6 @@ function renderThemeBitmap(
   const ctx = offscreen.getContext("2d")
   if (!ctx) return { bitmap: offscreen, metrics: null }
 
-  const metrics = renderVerse(ctx, theme, DESIGNER_SAMPLE_VERSE, { imageCache })
+  const metrics = renderVerse(ctx, theme, SAMPLE_VERSE, { imageCache })
   return { bitmap: offscreen, metrics }
 }

--- a/src/components/broadcast/layout-properties.tsx
+++ b/src/components/broadcast/layout-properties.tsx
@@ -8,31 +8,136 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { seedFreeBoxesForTheme } from "@/lib/theme-migrations"
+import type { BroadcastTheme, ElementBox } from "@/types/broadcast"
+
+function ElementBoxControls({
+  label,
+  boxKey,
+}: {
+  label: string
+  boxKey: "referenceBox" | "verseBox"
+}) {
+  const draftTheme = useBroadcastStore((s) => s.draftTheme)
+  const update = useBroadcastStore((s) => s.updateDraftNested)
+
+  if (!draftTheme) return null
+  const box = draftTheme.layout[boxKey]
+  if (!box) return null
+  const resolution = draftTheme.resolution
+
+  const fields: {
+    key: keyof ElementBox
+    label: string
+    axis: "width" | "height"
+  }[] = [
+    { key: "x", label: "X", axis: "width" },
+    { key: "y", label: "Y", axis: "height" },
+    { key: "width", label: "Width", axis: "width" },
+    { key: "height", label: "Height", axis: "height" },
+  ]
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h5 className="text-xs font-medium text-muted-foreground">{label}</h5>
+      <div className="grid grid-cols-2 gap-2">
+        {fields.map((field) => {
+          const value = box[field.key]
+          const px = Math.round(
+            (value / 100) *
+              (field.axis === "width" ? resolution.width : resolution.height)
+          )
+          return (
+            <div key={field.key} className="flex flex-col gap-1">
+              <div className="flex items-center justify-between">
+                <label className="text-xs font-medium text-muted-foreground">{field.label}</label>
+                <span className="text-[10px] tabular-nums text-muted-foreground">{px}px</span>
+              </div>
+              <Input
+                type="number"
+                min={0}
+                max={100}
+                step={0.5}
+                value={value}
+                onChange={(e) => {
+                  const v = Number(e.target.value)
+                  if (Number.isFinite(v) && v >= 0 && v <= 100) {
+                    update(`layout.${boxKey}.${field.key}`, v)
+                  }
+                }}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
 
 export function LayoutProperties() {
   const draftTheme = useBroadcastStore((s) => s.draftTheme)
   const update = useBroadcastStore((s) => s.updateDraftNested)
+  const updateDraft = useBroadcastStore((s) => s.updateDraft)
 
   if (!draftTheme) return null
 
   const layout = draftTheme.layout
   const resolution = draftTheme.resolution
   const referenceGap = layout.referenceGap ?? Math.max(16, Math.round(draftTheme.reference.fontSize * 0.5))
+  const freeMode = layout.mode === "free"
 
   const bgWidthPx = Math.round((layout.backgroundWidth / 100) * resolution.width)
   const bgHeightPx = Math.round((layout.backgroundHeight / 100) * resolution.height)
   const textWidthPx = Math.round((layout.textAreaWidth / 100) * resolution.width)
   const textHeightPx = Math.round((layout.textAreaHeight / 100) * resolution.height)
 
-  const verseNumbers = draftTheme.verseNumbers
-  const superscriptSizePct = Math.round(
-    (verseNumbers.fontSize / draftTheme.verseText.fontSize) * 100
-  )
+  const toggleFreeMode = (enabled: boolean) => {
+    if (!enabled) {
+      update("layout.mode", "stacked")
+      return
+    }
+    const patch: Partial<BroadcastTheme["layout"]> = { mode: "free" }
+    if (!layout.referenceBox || !layout.verseBox) {
+      const seeded = seedFreeBoxesForTheme(draftTheme)
+      if (!seeded) return
+      patch.referenceBox = seeded.referenceBox
+      patch.verseBox = seeded.verseBox
+    }
+    updateDraft({ layout: { ...layout, ...patch } })
+  }
 
   return (
     <div className="flex flex-col gap-3">
-      {/* Background Dimensions */}
+      {/* Positioning */}
       <div className="flex flex-col gap-0.5 pb-1">
+        <h4 className="text-xs font-semibold">Positioning</h4>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-muted-foreground">
+          Free positioning (detach reference)
+        </label>
+        <input
+          type="checkbox"
+          checked={freeMode}
+          onChange={(e) => toggleFreeMode(e.target.checked)}
+          className="h-4 w-4 rounded border-input accent-primary"
+        />
+      </div>
+
+      {freeMode && (
+        <div className="flex flex-col gap-3">
+          <p className="text-[11px] text-muted-foreground">
+            Drag the reference or verse frame on the canvas, or set the boxes
+            here (% of output size).
+          </p>
+          <ElementBoxControls label="Reference Block" boxKey="referenceBox" />
+          <ElementBoxControls label="Verse Block" boxKey="verseBox" />
+        </div>
+      )}
+
+      {/* Background Dimensions */}
+      <div className="flex flex-col gap-0.5 border-t pt-3 pb-1">
         <h4 className="text-xs font-semibold">Background Dimensions</h4>
       </div>
 
@@ -153,77 +258,50 @@ export function LayoutProperties() {
         </div>
       </div>
 
-      {/* Element Spacing */}
-      <div className="flex flex-col gap-0.5 border-t pt-3 pb-1">
-        <h4 className="text-xs font-semibold">Element Spacing</h4>
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <div className="flex items-center justify-between">
-          <label className="text-xs font-medium text-muted-foreground">Verse / Reference</label>
-          <span className="text-xs tabular-nums text-muted-foreground">{referenceGap}px</span>
-        </div>
-        <Slider
-          min={0}
-          max={200}
-          step={1}
-          value={[referenceGap]}
-          onValueChange={([v]) => update("layout.referenceGap", v)}
-        />
-      </div>
-
-      {/* Display Options */}
-      <div className="flex flex-col gap-0.5 border-t pt-3 pb-1">
-        <h4 className="text-xs font-semibold">Display Options</h4>
-      </div>
-
-      {/* Reference Position */}
-      <div className="flex flex-col gap-1.5">
-        <label className="text-xs font-medium text-muted-foreground">Reference Position</label>
-        <Select
-          value={draftTheme.reference.position}
-          onValueChange={(v) => update("reference.position", v)}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="above">Above Verse</SelectItem>
-            <SelectItem value="below">Below Verse</SelectItem>
-            <SelectItem value="inline">Inline</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      {/* Verse Number Superscript */}
-      <div className="flex items-center justify-between">
-        <label className="text-xs font-medium text-muted-foreground">Verse Number Superscript</label>
-        <input
-          type="checkbox"
-          checked={verseNumbers.superscript}
-          onChange={(e) => update("verseNumbers.superscript", e.target.checked)}
-          className="h-4 w-4 rounded border-input accent-primary"
-        />
-      </div>
-
-      {/* Superscript Size */}
-      {verseNumbers.superscript && (
-        <div className="flex flex-col gap-1.5">
-          <div className="flex items-center justify-between">
-            <label className="text-xs font-medium text-muted-foreground">Superscript Size</label>
-            <span className="text-xs tabular-nums text-muted-foreground">{superscriptSizePct}%</span>
+      {/* Element Spacing + Reference Position (stacked mode only) */}
+      {!freeMode && (
+        <>
+          <div className="flex flex-col gap-0.5 border-t pt-3 pb-1">
+            <h4 className="text-xs font-semibold">Element Spacing</h4>
           </div>
-          <Slider
-            min={20}
-            max={100}
-            step={1}
-            value={[superscriptSizePct]}
-            onValueChange={([v]) => {
-              const newFontSize = Math.round((v / 100) * draftTheme.verseText.fontSize)
-              update("verseNumbers.fontSize", newFontSize)
-            }}
-          />
-        </div>
+
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <label className="text-xs font-medium text-muted-foreground">Verse / Reference</label>
+              <span className="text-xs tabular-nums text-muted-foreground">{referenceGap}px</span>
+            </div>
+            <Slider
+              min={0}
+              max={200}
+              step={1}
+              value={[referenceGap]}
+              onValueChange={([v]) => update("layout.referenceGap", v)}
+            />
+          </div>
+
+          {/* Display Options */}
+          <div className="flex flex-col gap-0.5 border-t pt-3 pb-1">
+            <h4 className="text-xs font-semibold">Display Options</h4>
+          </div>
+
+          {/* Reference Position */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Reference Position</label>
+            <Select
+              value={draftTheme.reference.position}
+              onValueChange={(v) => update("reference.position", v)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="above">Above Verse</SelectItem>
+                <SelectItem value="below">Below Verse</SelectItem>
+                <SelectItem value="inline">Inline</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </>
       )}
     </div>
   )

--- a/src/components/broadcast/text-properties.tsx
+++ b/src/components/broadcast/text-properties.tsx
@@ -1,6 +1,11 @@
+import { useEffect, useState } from "react"
+import { ChevronsUpDownIcon, CheckIcon } from "lucide-react"
 import { useBroadcastStore } from "@/stores/broadcast-store"
 import { Slider } from "@/components/ui/slider"
 import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { parseColorOpacity, buildColorWithOpacity } from "@/lib/color-utils"
+import { listAllFonts } from "@/lib/fonts"
 import {
   Select,
   SelectContent,
@@ -8,16 +13,96 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 
-const FONT_FAMILIES = [
-  "Geist Variable",
-  "Source Serif 4 Variable",
-  "Georgia",
-  "Arial",
-  "Helvetica",
-  "Times New Roman",
-  "Courier New",
-]
+function FontFamilyPicker({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (font: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [fonts, setFonts] = useState<{ bundled: string[]; system: string[] }>({
+    bundled: [],
+    system: [],
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    void listAllFonts().then((result) => {
+      if (!cancelled) setFonts(result)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const renderItem = (font: string) => (
+    <CommandItem
+      key={font}
+      value={font}
+      onSelect={() => {
+        onChange(font)
+        setOpen(false)
+      }}
+    >
+      <CheckIcon
+        className={`size-3.5 ${font === value ? "opacity-100" : "opacity-0"}`}
+      />
+      <span style={{ fontFamily: `"${font}"` }}>{font}</span>
+    </CommandItem>
+  )
+
+  return (
+    // modal: the designer lives in a Radix Dialog whose scroll lock swallows
+    // wheel events in portaled popover content — modal popovers manage their
+    // own lock, restoring wheel scrolling in the font list.
+    <Popover open={open} onOpenChange={setOpen} modal={true}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          <span className="truncate" style={{ fontFamily: `"${value}"` }}>
+            {value}
+          </span>
+          <ChevronsUpDownIcon className="size-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[260px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search fonts…" />
+          <CommandList className="max-h-64">
+            <CommandEmpty>No font found.</CommandEmpty>
+            <CommandGroup heading="Bundled">
+              {fonts.bundled.map(renderItem)}
+            </CommandGroup>
+            {fonts.system.length > 0 && (
+              <CommandGroup heading="System">
+                {fonts.system.map(renderItem)}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
 
 const FONT_WEIGHTS = [
   { value: "100", label: "100 - Thin" },
@@ -57,26 +142,6 @@ const TEXT_DECORATION_OPTIONS = [
   { value: "line-through", label: "Line Through" },
 ] as const
 
-function parseColorOpacity(color: string): { hex: string; opacity: number } {
-  if (color.length === 9 && color.startsWith("#")) {
-    const alphaHex = color.slice(7, 9)
-    const alpha = parseInt(alphaHex, 16) / 255
-    return { hex: color.slice(0, 7), opacity: Math.round(alpha * 100) }
-  }
-  if (color.length === 7 && color.startsWith("#")) {
-    return { hex: color, opacity: 100 }
-  }
-  return { hex: color || "#ffffff", opacity: 100 }
-}
-
-function buildColorWithOpacity(hex: string, opacity: number): string {
-  if (opacity >= 100) return hex
-  const alphaHex = Math.round((opacity / 100) * 255)
-    .toString(16)
-    .padStart(2, "0")
-  return `${hex}${alphaHex}`
-}
-
 function SectionHeader({ title, description }: { title: string; description: string }) {
   return (
     <div className="flex flex-col gap-0.5 pb-1">
@@ -104,21 +169,10 @@ function FontControls({ prefix }: { prefix: "verseText" | "reference" }) {
       {/* Font Family */}
       <div className="flex flex-col gap-1.5">
         <label className="text-xs font-medium text-muted-foreground">Font Family</label>
-        <Select
+        <FontFamilyPicker
           value={data.fontFamily}
-          onValueChange={(v) => update(`${prefix}.fontFamily`, v)}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {FONT_FAMILIES.map((f) => (
-              <SelectItem key={f} value={f}>
-                {f}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={(v) => update(`${prefix}.fontFamily`, v)}
+        />
       </div>
 
       {/* Font Weight */}
@@ -347,23 +401,25 @@ function ReferenceProperties() {
         />
       </div>
 
-      {/* Reference Position */}
-      <div className="flex flex-col gap-1.5">
-        <label className="text-xs font-medium text-muted-foreground">Reference Position</label>
-        <Select
-          value={draftTheme.reference.position}
-          onValueChange={(v) => update("reference.position", v)}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="above">Above Verse</SelectItem>
-            <SelectItem value="below">Below Verse</SelectItem>
-            <SelectItem value="inline">Inline</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+      {/* Reference Position (stacked mode only — free mode positions by box) */}
+      {draftTheme.layout.mode !== "free" && (
+        <div className="flex flex-col gap-1.5">
+          <label className="text-xs font-medium text-muted-foreground">Reference Position</label>
+          <Select
+            value={draftTheme.reference.position}
+            onValueChange={(v) => update("reference.position", v)}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="above">Above Verse</SelectItem>
+              <SelectItem value="below">Below Verse</SelectItem>
+              <SelectItem value="inline">Inline</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
     </div>
   )
 }
@@ -380,10 +436,108 @@ function VerseProperties() {
   const shadowColor = shadow ? parseColorOpacity(shadow.color) : { hex: "#000000", opacity: 100 }
   const outlineColor = outline ? parseColorOpacity(outline.color) : { hex: "#000000", opacity: 100 }
 
+  const verseNumbers = draftTheme.verseNumbers
+  const verseNumberColor = parseColorOpacity(verseNumbers.color)
+  const superscriptSizePct = Math.round(
+    (verseNumbers.fontSize / draftTheme.verseText.fontSize) * 100
+  )
+
   return (
     <div className="flex flex-col gap-3">
       <SectionHeader title="Verse Text" description="Customize how verse text appears" />
       <FontControls prefix="verseText" />
+
+      {/* Verse Numbers */}
+      <div className="flex flex-col gap-3 border-t pt-3">
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-semibold">Verse Numbers</label>
+          <input
+            type="checkbox"
+            checked={verseNumbers.visible}
+            onChange={(e) => update("verseNumbers.visible", e.target.checked)}
+            className="h-4 w-4 rounded border-input accent-primary"
+          />
+        </div>
+
+        {verseNumbers.visible && (
+          <div className="flex flex-col gap-3">
+            {/* Superscript */}
+            <div className="flex items-center justify-between">
+              <label className="text-xs font-medium text-muted-foreground">Superscript</label>
+              <input
+                type="checkbox"
+                checked={verseNumbers.superscript}
+                onChange={(e) => update("verseNumbers.superscript", e.target.checked)}
+                className="h-4 w-4 rounded border-input accent-primary"
+              />
+            </div>
+
+            {/* Superscript Size */}
+            {verseNumbers.superscript && (
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-muted-foreground">Size</label>
+                  <span className="text-xs tabular-nums text-muted-foreground">{superscriptSizePct}%</span>
+                </div>
+                <Slider
+                  min={20}
+                  max={100}
+                  step={1}
+                  value={[superscriptSizePct]}
+                  onValueChange={([v]) => {
+                    const newFontSize = Math.round((v / 100) * draftTheme.verseText.fontSize)
+                    update("verseNumbers.fontSize", newFontSize)
+                  }}
+                />
+              </div>
+            )}
+
+            {/* Number Color */}
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">Number Color</label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={verseNumberColor.hex}
+                  onChange={(e) =>
+                    update(
+                      "verseNumbers.color",
+                      buildColorWithOpacity(e.target.value, verseNumberColor.opacity)
+                    )
+                  }
+                  className="h-7 w-8 cursor-pointer rounded border border-input bg-transparent p-0.5"
+                />
+                <Input
+                  value={verseNumberColor.hex}
+                  onChange={(e) => {
+                    const v = e.target.value
+                    if (/^#[0-9a-fA-F]{6}$/.test(v)) {
+                      update(
+                        "verseNumbers.color",
+                        buildColorWithOpacity(v, verseNumberColor.opacity)
+                      )
+                    }
+                  }}
+                  className="w-20 font-mono"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <label className="text-xs font-medium text-muted-foreground">Opacity</label>
+                <span className="text-xs tabular-nums text-muted-foreground">{verseNumberColor.opacity}%</span>
+              </div>
+              <Slider
+                min={0}
+                max={100}
+                step={1}
+                value={[verseNumberColor.opacity]}
+                onValueChange={([v]) =>
+                  update("verseNumbers.color", buildColorWithOpacity(verseNumberColor.hex, v))
+                }
+              />
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* Text Shadow */}
       <div className="flex flex-col gap-3 border-t pt-3">

--- a/src/components/ui/canvas-verse.tsx
+++ b/src/components/ui/canvas-verse.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, useCallback, memo } from "react"
-import { renderVerse } from "@/lib/verse-renderer"
+import { onThemeFontsLoaded, renderVerse } from "@/lib/verse-renderer"
 import type { BroadcastTheme, VerseRenderData } from "@/types"
 import { cn } from "@/lib/utils"
 
@@ -81,6 +81,10 @@ export const CanvasVerse = memo(function CanvasVerse({
   useEffect(() => {
     draw()
   }, [draw])
+
+  // Redraw once theme webfonts load so early frames drawn against fallback
+  // font metrics are corrected.
+  useEffect(() => onThemeFontsLoaded(() => draw()), [draw])
 
   return (
     <div ref={containerRef} className={cn("w-full", className)}>

--- a/src/lib/builtin-themes.ts
+++ b/src/lib/builtin-themes.ts
@@ -231,8 +231,83 @@ const BROADCAST_OVERLAY: BroadcastTheme = {
   },
 }
 
+// Free-positioning example: reference in a top-left banner, verse block
+// detached below it (the layout requested in issue #100).
+const BANNER_SPLIT: BroadcastTheme = {
+  ...baseTheme,
+  id: "builtin-banner-split",
+  name: "Banner Split",
+  background: {
+    type: "solid",
+    color: "#312e81",
+    gradient: null,
+    image: null,
+  },
+  textBox: {
+    enabled: false,
+    color: "#000000",
+    opacity: 0,
+    borderRadius: 0,
+    padding: 0,
+  },
+  verseText: {
+    fontFamily: "Geist Variable",
+    fontSize: 72,
+    fontWeight: 600,
+    color: "#ffffff",
+    horizontalAlign: "left",
+    verticalAlign: "top",
+    textTransform: "none",
+    textDecoration: "none",
+    lineHeight: 1.4,
+    letterSpacing: 0,
+    shadow: null,
+    outline: null,
+  },
+  verseNumbers: {
+    visible: true,
+    fontSize: 32,
+    color: "#fde047",
+    superscript: true,
+  },
+  reference: {
+    fontFamily: "Geist Variable",
+    fontSize: 40,
+    fontWeight: 600,
+    color: "#ffffff",
+    horizontalAlign: "left",
+    verticalAlign: "middle",
+    textTransform: "none",
+    textDecoration: "none",
+    uppercase: true,
+    letterSpacing: 1,
+    position: "above",
+  },
+  layout: {
+    anchor: "center",
+    offsetX: 0,
+    offsetY: 0,
+    padding: { top: 0, right: 0, bottom: 0, left: 0 },
+    textAlign: "left",
+    backgroundWidth: 100,
+    backgroundHeight: 100,
+    textAreaWidth: 90,
+    textAreaHeight: 80,
+    mode: "free",
+    referenceBox: { x: 5, y: 4, width: 55, height: 9 },
+    verseBox: { x: 5, y: 22, width: 62, height: 55 },
+  },
+  transition: {
+    type: "fade",
+    duration: 400,
+    easing: "ease-in-out",
+    direction: "up",
+  },
+}
+
 export const BUILTIN_THEMES: BroadcastTheme[] = [
   CLASSIC_DARK,
   MODERN_LIGHT,
   BROADCAST_OVERLAY,
+  BANNER_SPLIT,
 ]

--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -1,0 +1,22 @@
+export function parseColorOpacity(color: string): {
+  hex: string
+  opacity: number
+} {
+  if (color.length === 9 && color.startsWith("#")) {
+    const alphaHex = color.slice(7, 9)
+    const alpha = parseInt(alphaHex, 16) / 255
+    return { hex: color.slice(0, 7), opacity: Math.round(alpha * 100) }
+  }
+  if (color.length === 7 && color.startsWith("#")) {
+    return { hex: color, opacity: 100 }
+  }
+  return { hex: color || "#ffffff", opacity: 100 }
+}
+
+export function buildColorWithOpacity(hex: string, opacity: number): string {
+  if (opacity >= 100) return hex
+  const alphaHex = Math.round((opacity / 100) * 255)
+    .toString(16)
+    .padStart(2, "0")
+  return `${hex}${alphaHex}`
+}

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,0 +1,44 @@
+import { invoke } from "@tauri-apps/api/core"
+
+/** Webfonts bundled with the app (fontsource imports in index.css / broadcast-fonts.css). */
+export const BUNDLED_FONTS = [
+  "Geist Variable",
+  "Source Serif 4 Variable",
+  "Inter Variable",
+  "Geist Mono",
+]
+
+/** Web-safe fallbacks shown when system enumeration is unavailable (web build, tests). */
+const FALLBACK_FONTS = [
+  "Georgia",
+  "Arial",
+  "Helvetica",
+  "Times New Roman",
+  "Courier New",
+]
+
+let systemFontsPromise: Promise<string[]> | null = null
+
+/**
+ * Font families installed on this machine, via the `list_system_fonts` Tauri
+ * command. Memoized; resolves to a fallback list outside of Tauri.
+ */
+export function listSystemFonts(): Promise<string[]> {
+  if (!systemFontsPromise) {
+    systemFontsPromise = invoke<string[]>("list_system_fonts").catch(() => {
+      systemFontsPromise = null
+      return FALLBACK_FONTS
+    })
+  }
+  return systemFontsPromise
+}
+
+/** Bundled fonts first, then system fonts (deduplicated, already sorted). */
+export async function listAllFonts(): Promise<{
+  bundled: string[]
+  system: string[]
+}> {
+  const bundledSet = new Set(BUNDLED_FONTS)
+  const system = (await listSystemFonts()).filter((f) => !bundledSet.has(f))
+  return { bundled: BUNDLED_FONTS, system }
+}

--- a/src/lib/theme-designer-files.ts
+++ b/src/lib/theme-designer-files.ts
@@ -1,6 +1,7 @@
 import { open, save } from "@tauri-apps/plugin-dialog"
 import { readFile, writeTextFile } from "@tauri-apps/plugin-fs"
 import type { BroadcastTheme } from "@/types"
+import { normalizeTheme } from "@/lib/theme-migrations"
 
 /**
  * Opens a native file dialog to pick an image, reads it,
@@ -74,11 +75,11 @@ export async function importTheme(): Promise<BroadcastTheme | null> {
     throw new Error("Invalid theme file: missing required fields")
   }
 
-  return {
+  return normalizeTheme({
     ...parsed,
     id: crypto.randomUUID(),
     builtin: false,
     createdAt: Date.now(),
     updatedAt: Date.now(),
-  }
+  })
 }

--- a/src/lib/theme-migrations.test.ts
+++ b/src/lib/theme-migrations.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+import type { BroadcastTheme } from "@/types/broadcast"
+import { BUILTIN_THEMES } from "./builtin-themes"
+import { normalizeTheme, seedFreeBoxesFromMetrics } from "./theme-migrations"
+import type { VerseLayoutMetrics } from "./verse-renderer"
+
+const stackedBase = BUILTIN_THEMES[0]
+
+describe("normalizeTheme", () => {
+  it("defaults layout.mode to stacked for legacy themes", () => {
+    const legacy = {
+      ...stackedBase,
+      layout: { ...stackedBase.layout, mode: undefined },
+    }
+    expect(normalizeTheme(legacy).layout.mode).toBe("stacked")
+  })
+
+  it("keeps free mode when both boxes are valid", () => {
+    const theme: BroadcastTheme = {
+      ...stackedBase,
+      layout: {
+        ...stackedBase.layout,
+        mode: "free",
+        referenceBox: { x: 5, y: 5, width: 50, height: 10 },
+        verseBox: { x: 5, y: 20, width: 60, height: 50 },
+      },
+    }
+    expect(normalizeTheme(theme).layout.mode).toBe("free")
+  })
+
+  it("demotes free mode to stacked when boxes are missing", () => {
+    const theme: BroadcastTheme = {
+      ...stackedBase,
+      layout: { ...stackedBase.layout, mode: "free" },
+    }
+    expect(normalizeTheme(theme).layout.mode).toBe("stacked")
+  })
+
+  it("demotes free mode to stacked when a box has non-finite values", () => {
+    const theme: BroadcastTheme = {
+      ...stackedBase,
+      layout: {
+        ...stackedBase.layout,
+        mode: "free",
+        referenceBox: { x: NaN, y: 0, width: 50, height: 10 },
+        verseBox: { x: 5, y: 20, width: 60, height: 50 },
+      },
+    }
+    expect(normalizeTheme(theme).layout.mode).toBe("stacked")
+  })
+
+  it("fills verse number defaults for themes missing the field", () => {
+    const legacy = {
+      ...stackedBase,
+      verseNumbers: undefined,
+    } as unknown as BroadcastTheme
+    const normalized = normalizeTheme(legacy)
+    expect(normalized.verseNumbers).toEqual({
+      visible: true,
+      fontSize: 18,
+      color: "#ffffff",
+      superscript: true,
+    })
+  })
+
+  it("preserves existing verse number settings", () => {
+    const normalized = normalizeTheme(stackedBase)
+    expect(normalized.verseNumbers).toEqual(stackedBase.verseNumbers)
+  })
+})
+
+describe("seedFreeBoxesFromMetrics", () => {
+  const metrics = {
+    textRect: { x: 192, y: 108, width: 1536, height: 864 },
+    referenceRect: { x: 500, y: 200, width: 400, height: 72 },
+    verseRect: { x: 300, y: 300, width: 900, height: 400 },
+  } as VerseLayoutMetrics
+
+  it("converts element rects to percent boxes that tightly wrap the content", () => {
+    const seeded = seedFreeBoxesFromMetrics(metrics, {
+      width: 1920,
+      height: 1080,
+    })
+    expect(seeded).toEqual({
+      referenceBox: { x: 26.04, y: 18.51, width: 20.84, height: 6.67 },
+      verseBox: { x: 15.62, y: 27.77, width: 46.88, height: 37.04 },
+    })
+  })
+
+  it("never rounds a box smaller than its source rect", () => {
+    const seeded = seedFreeBoxesFromMetrics(metrics, {
+      width: 1920,
+      height: 1080,
+    })!
+    expect((seeded.verseBox.width / 100) * 1920).toBeGreaterThanOrEqual(
+      metrics.verseRect!.width
+    )
+    expect((seeded.verseBox.height / 100) * 1080).toBeGreaterThanOrEqual(
+      metrics.verseRect!.height
+    )
+  })
+
+  it("returns null when an element rect is missing", () => {
+    const withoutRef = { ...metrics, referenceRect: null } as VerseLayoutMetrics
+    expect(
+      seedFreeBoxesFromMetrics(withoutRef, { width: 1920, height: 1080 })
+    ).toBeNull()
+  })
+})

--- a/src/lib/theme-migrations.ts
+++ b/src/lib/theme-migrations.ts
@@ -1,0 +1,112 @@
+import type {
+  BroadcastTheme,
+  ElementBox,
+  VerseRenderData,
+} from "@/types/broadcast"
+import {
+  computeVerseLayoutMetrics,
+  type VerseLayoutMetrics,
+} from "./verse-renderer"
+
+/** Sample verse used wherever a layout must be computed without live data. */
+export const SAMPLE_VERSE: VerseRenderData = {
+  reference: "Genesis 1:1 (KJV)",
+  segments: [
+    {
+      verseNumber: 1,
+      text: "In the beginning God created the heaven and the earth.",
+    },
+  ],
+}
+
+const DEFAULT_VERSE_NUMBERS: BroadcastTheme["verseNumbers"] = {
+  visible: true,
+  fontSize: 18,
+  color: "#ffffff",
+  superscript: true,
+}
+
+function isValidBox(box: ElementBox | undefined): box is ElementBox {
+  return (
+    box !== undefined &&
+    [box.x, box.y, box.width, box.height].every(
+      (v) => typeof v === "number" && Number.isFinite(v)
+    ) &&
+    box.width > 0 &&
+    box.height > 0
+  )
+}
+
+/**
+ * Fill defaults on themes loaded from disk, import, or IPC so older saved
+ * themes (created before free positioning / verse-number styling existed)
+ * keep working unchanged.
+ */
+export function normalizeTheme(theme: BroadcastTheme): BroadcastTheme {
+  const layout = { ...theme.layout }
+  layout.mode = layout.mode === "free" ? "free" : "stacked"
+  if (
+    layout.mode === "free" &&
+    (!isValidBox(layout.referenceBox) || !isValidBox(layout.verseBox))
+  ) {
+    layout.mode = "stacked"
+  }
+  return {
+    ...theme,
+    verseNumbers: { ...DEFAULT_VERSE_NUMBERS, ...theme.verseNumbers },
+    layout,
+  }
+}
+
+// Floor the origin and ceil the size (at 2 decimals) so the percent box is
+// guaranteed to contain the source rect — a width rounded down would reduce
+// the wrap width and re-flow the text on detach.
+const rectToBox = (
+  rect: { x: number; y: number; width: number; height: number },
+  canvasW: number,
+  canvasH: number
+): ElementBox => ({
+  x: Math.floor((rect.x / canvasW) * 10000) / 100,
+  y: Math.floor((rect.y / canvasH) * 10000) / 100,
+  width: Math.ceil((rect.width / canvasW) * 10000) / 100,
+  height: Math.ceil((rect.height / canvasH) * 10000) / 100,
+})
+
+/**
+ * Compute seed boxes for a theme directly (used by the properties panel's
+ * "free positioning" toggle, where no designer metrics are at hand). Lays the
+ * theme out in stacked mode against a sample verse and converts the resulting
+ * rects.
+ */
+export function seedFreeBoxesForTheme(
+  theme: BroadcastTheme,
+  verse: VerseRenderData = SAMPLE_VERSE
+): { referenceBox: ElementBox; verseBox: ElementBox } | null {
+  const ctx = document.createElement("canvas").getContext("2d")
+  if (!ctx) return null
+  const stackedTheme: BroadcastTheme = {
+    ...theme,
+    layout: { ...theme.layout, mode: "stacked" },
+  }
+  const metrics = computeVerseLayoutMetrics(ctx, stackedTheme, verse)
+  return seedFreeBoxesFromMetrics(metrics, theme.resolution)
+}
+
+/**
+ * Seed free-mode element boxes from stacked layout metrics (computed at
+ * scale 1). Each box tightly wraps its rendered content, so on detach the
+ * frame hugs the text and dragging it moves the text 1:1. Line breaks are
+ * preserved: greedy wrap at the widest-line width reproduces the same lines.
+ */
+export function seedFreeBoxesFromMetrics(
+  metrics: VerseLayoutMetrics,
+  resolution: BroadcastTheme["resolution"]
+): { referenceBox: ElementBox; verseBox: ElementBox } | null {
+  const { referenceRect, verseRect } = metrics
+  if (!referenceRect || !verseRect) return null
+  const { width: canvasW, height: canvasH } = resolution
+  return {
+    referenceBox: rectToBox(referenceRect, canvasW, canvasH),
+    verseBox: rectToBox(verseRect, canvasW, canvasH),
+  }
+}

--- a/src/lib/verse-renderer.test.ts
+++ b/src/lib/verse-renderer.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest"
+import type { BroadcastTheme, VerseRenderData } from "@/types/broadcast"
+
+// Deterministic stand-in for pretext: character width is 0.6 × the px size
+// parsed from the item font, lines wrap greedily at maxWidth. Enough for the
+// layout math under test (wrapping monotonicity, rect containment, auto-fit).
+vi.mock("@chenglou/pretext/rich-inline", () => {
+  const parsePx = (font: string) => Number(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? 16)
+  const itemWidth = (item: { text: string; font: string }) =>
+    item.text.trim().length * parsePx(item.font) * 0.6
+
+  const lineWidths = (
+    prepared: { items: { text: string; font: string }[] },
+    maxWidth: number
+  ): number[] => {
+    const widths: number[] = []
+    let current = 0
+    for (const item of prepared.items) {
+      const w = itemWidth(item)
+      if (current > 0 && current + w > maxWidth) {
+        widths.push(current)
+        current = w
+      } else {
+        current += w
+      }
+      while (current > maxWidth) {
+        widths.push(maxWidth)
+        current -= maxWidth
+      }
+    }
+    if (current > 0) widths.push(current)
+    return widths.length ? widths : [0]
+  }
+
+  return {
+    prepareRichInline: (items: { text: string; font: string }[]) => ({ items }),
+    measureRichInlineStats: (
+      prepared: { items: { text: string; font: string }[] },
+      maxWidth: number
+    ) => {
+      const widths = lineWidths(prepared, maxWidth)
+      return { lineCount: widths.length, maxLineWidth: Math.max(...widths) }
+    },
+    walkRichInlineLineRanges: (
+      prepared: { items: { text: string; font: string }[] },
+      maxWidth: number,
+      onLine: (line: unknown) => void
+    ) => {
+      const widths = lineWidths(prepared, maxWidth)
+      for (const width of widths) onLine({ fragments: [], width, end: {} })
+      return widths.length
+    },
+    materializeRichInlineLineRange: (
+      _prepared: unknown,
+      line: { width: number }
+    ) => ({ fragments: [], width: line.width, end: {} }),
+  }
+})
+
+import { computeVerseLayoutMetrics } from "./verse-renderer"
+import { BUILTIN_THEMES } from "./builtin-themes"
+
+function stubCtx(): CanvasRenderingContext2D {
+  let font = "16px test"
+  return {
+    get font() {
+      return font
+    },
+    set font(value: string) {
+      font = value
+    },
+    measureText: (text: string) => {
+      const size = Number(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? 16)
+      return { width: text.length * size * 0.6 } as TextMetrics
+    },
+    save: () => {},
+    restore: () => {},
+  } as unknown as CanvasRenderingContext2D
+}
+
+const VERSE: VerseRenderData = {
+  reference: "Genesis 1:1 (KJV)",
+  segments: [
+    {
+      verseNumber: 1,
+      text: "In the beginning God created the heaven and the earth.",
+    },
+  ],
+}
+
+const within = (
+  inner: { x: number; y: number; width: number; height: number },
+  outer: { x: number; y: number; width: number; height: number }
+) =>
+  inner.x >= outer.x - 0.01 &&
+  inner.y >= outer.y - 0.01 &&
+  inner.x + inner.width <= outer.x + outer.width + 0.01 &&
+  inner.y + inner.height <= outer.y + outer.height + 0.01
+
+function freeTheme(
+  overrides: Partial<BroadcastTheme["layout"]> = {}
+): BroadcastTheme {
+  const base = BUILTIN_THEMES[0]
+  return {
+    ...base,
+    layout: {
+      ...base.layout,
+      mode: "free",
+      referenceBox: { x: 5, y: 5, width: 50, height: 10 },
+      verseBox: { x: 10, y: 25, width: 60, height: 50 },
+      ...overrides,
+    },
+  }
+}
+
+describe("computeVerseLayoutMetrics — free mode", () => {
+  it("places the reference rect inside its box", () => {
+    const metrics = computeVerseLayoutMetrics(stubCtx(), freeTheme(), VERSE)
+    expect(metrics.referenceBoxRect).toEqual({
+      x: 96,
+      y: 54,
+      width: 960,
+      height: 108,
+    })
+    expect(within(metrics.referenceRect!, metrics.referenceBoxRect!)).toBe(true)
+  })
+
+  it("places the verse rect inside its box", () => {
+    const metrics = computeVerseLayoutMetrics(stubCtx(), freeTheme(), VERSE)
+    expect(metrics.verseBoxRect).toEqual({
+      x: 192,
+      y: 270,
+      width: 1152,
+      height: 540,
+    })
+    expect(within(metrics.verseRect!, metrics.verseBoxRect!)).toBe(true)
+  })
+
+  it("uses the verse box as the text box backdrop area", () => {
+    const metrics = computeVerseLayoutMetrics(stubCtx(), freeTheme(), VERSE)
+    expect(metrics.textAreaRect).toEqual(metrics.verseBoxRect)
+  })
+
+  it("auto-fits to a smaller font size when the verse box shrinks", () => {
+    const roomy = computeVerseLayoutMetrics(stubCtx(), freeTheme(), VERSE)
+    const cramped = computeVerseLayoutMetrics(
+      stubCtx(),
+      freeTheme({ verseBox: { x: 10, y: 25, width: 20, height: 12 } }),
+      VERSE
+    )
+    expect(roomy.fittedVerseFontSize).toBeDefined()
+    expect(cramped.fittedVerseFontSize!).toBeLessThan(
+      roomy.fittedVerseFontSize!
+    )
+  })
+
+  it("falls back to stacked layout when boxes are missing", () => {
+    const theme = freeTheme({ referenceBox: undefined, verseBox: undefined })
+    const metrics = computeVerseLayoutMetrics(stubCtx(), theme, VERSE)
+    expect(metrics.referenceBoxRect).toBeNull()
+    expect(metrics.verseBoxRect).toBeNull()
+    expect(metrics.referenceRect).not.toBeNull()
+    expect(metrics.verseRect).not.toBeNull()
+  })
+})
+
+describe("computeVerseLayoutMetrics — stacked mode", () => {
+  it("keeps the reference above the verse for position 'above'", () => {
+    const theme = BUILTIN_THEMES[0] // Classic Dark, position "above"
+    const metrics = computeVerseLayoutMetrics(stubCtx(), theme, VERSE)
+    expect(metrics.referenceRect!.y).toBeLessThan(metrics.verseRect!.y)
+  })
+
+  it("keeps the reference below the verse for position 'below'", () => {
+    const theme = BUILTIN_THEMES[2] // Broadcast Overlay, position "below"
+    const metrics = computeVerseLayoutMetrics(stubCtx(), theme, VERSE)
+    expect(metrics.referenceRect!.y).toBeGreaterThan(metrics.verseRect!.y)
+  })
+
+  it("reports the fitted verse font size", () => {
+    const metrics = computeVerseLayoutMetrics(
+      stubCtx(),
+      BUILTIN_THEMES[0],
+      VERSE
+    )
+    expect(metrics.fittedVerseFontSize).toBeGreaterThan(0)
+    expect(metrics.fittedVerseFontSize).toBeLessThanOrEqual(
+      BUILTIN_THEMES[0].verseText.fontSize
+    )
+  })
+
+  it("returns no element rects without a verse", () => {
+    const metrics = computeVerseLayoutMetrics(stubCtx(), BUILTIN_THEMES[0], null)
+    expect(metrics.referenceRect).toBeNull()
+    expect(metrics.verseRect).toBeNull()
+    expect(metrics.fittedVerseFontSize).toBeUndefined()
+  })
+})

--- a/src/lib/verse-renderer.ts
+++ b/src/lib/verse-renderer.ts
@@ -1,8 +1,86 @@
+import { clearCache } from "@chenglou/pretext"
+import {
+  materializeRichInlineLineRange,
+  measureRichInlineStats,
+  prepareRichInline,
+  walkRichInlineLineRanges,
+  type PreparedRichInline,
+  type RichInlineItem,
+  type RichInlineLine,
+} from "@chenglou/pretext/rich-inline"
 import type {
   BroadcastTheme,
   VerseRenderData,
   RenderOptions,
 } from "@/types/broadcast"
+
+// Pretext lazily creates one internal measurement context, preferring
+// OffscreenCanvas. Force that creation with a DOM canvas instead — older
+// WebKit versions don't expose document webfonts to OffscreenCanvas, and a
+// DOM canvas behaves identically everywhere.
+function primePretextMeasureContext(): void {
+  if (typeof document === "undefined") return
+  const g = globalThis as { OffscreenCanvas?: typeof OffscreenCanvas }
+  const original = g.OffscreenCanvas
+  try {
+    g.OffscreenCanvas = undefined
+    prepareRichInline([{ text: "prime", font: "16px serif" }])
+  } finally {
+    g.OffscreenCanvas = original
+  }
+  // Widths measured before a webfont finished loading came from the fallback
+  // font and are cached per font string — drop them whenever loading settles.
+  // (Consumers redraw on this same event.)
+  document.fonts?.addEventListener("loadingdone", () => clearCache())
+}
+primePretextMeasureContext()
+
+const requestedFontSpecs = new Set<string>()
+const fontListeners = new Set<() => void>()
+
+/**
+ * Subscribe to "a theme font just finished loading" so consumers can redraw.
+ * Driven by the FontFaceSet.load() promise rather than the "loadingdone"
+ * event: WebKit's canvas can still measure the fallback font when the event
+ * fires, but is reliably up to date once the load promise resolves.
+ */
+export function onThemeFontsLoaded(listener: () => void): () => void {
+  fontListeners.add(listener)
+  return () => fontListeners.delete(listener)
+}
+
+/**
+ * Canvas `ctx.font` never triggers a webfont download: a registered
+ * `@font-face` stays unloaded — and canvas silently draws the fallback font —
+ * until DOM text or an explicit `FontFaceSet.load()` requests it. If the font
+ * later loads for an unrelated reason (e.g. a DOM element uses it), drawing
+ * switches to the real font while cached measurements still hold fallback
+ * widths, so text overflows its measured layout box. Request every font a
+ * theme uses up front; when a face actually arrives, invalidate pretext's
+ * cache (redraws ride the resulting "loadingdone" event).
+ */
+function ensureThemeFontsLoaded(theme: BroadcastTheme): void {
+  if (typeof document === "undefined" || !document.fonts?.load) return
+  const specs = [
+    `${theme.verseText.fontWeight} 16px "${theme.verseText.fontFamily}"`,
+    `${theme.reference.fontWeight} 16px "${theme.reference.fontFamily}"`,
+  ]
+  for (const spec of specs) {
+    if (requestedFontSpecs.has(spec)) continue
+    requestedFontSpecs.add(spec)
+    void document.fonts
+      .load(spec)
+      .then((faces) => {
+        if (faces.length > 0) {
+          clearCache()
+          for (const listener of fontListeners) listener()
+        }
+      })
+      .catch(() => {
+        requestedFontSpecs.delete(spec)
+      })
+  }
+}
 
 export interface VerseLayoutRect {
   x: number
@@ -17,6 +95,11 @@ export interface VerseLayoutMetrics {
   textRect: VerseLayoutRect
   referenceRect: VerseLayoutRect | null
   verseRect: VerseLayoutRect | null
+  /** Auto-fitted verse font size (scaled px). Absent when there is no verse. */
+  fittedVerseFontSize?: number
+  /** Free-mode element boxes in canvas px. Only set when layout.mode === "free". */
+  referenceBoxRect?: VerseLayoutRect | null
+  verseBoxRect?: VerseLayoutRect | null
 }
 
 export function wrapText(
@@ -44,6 +127,70 @@ export function wrapText(
     lines.push(currentLine)
   }
 
+  return lines
+}
+
+export interface VerseInlineHandle {
+  prepared: PreparedRichInline
+  /** Per-item kind, indexed by RichInlineFragment.itemIndex. */
+  kinds: ("word" | "verseNum")[]
+  wordFont: string
+  verseNumFont: string
+}
+
+/**
+ * Compile verse segments into a pretext rich-inline flow: verse numbers are
+ * their own atomic items so they wrap, measure, and draw with their own font
+ * size. Numbers scale proportionally with the auto-fitted verse size; when
+ * superscript is off they render at the full verse size (colour still applies).
+ */
+export function prepareVerseInline(
+  theme: BroadcastTheme,
+  verse: VerseRenderData,
+  effectiveFontSize: number
+): VerseInlineHandle | null {
+  const vt = theme.verseText
+  const vn = theme.verseNumbers
+  const transform = resolveTextTransform(vt.textTransform)
+  const ratio = vt.fontSize > 0 ? effectiveFontSize / vt.fontSize : 1
+  const verseNumFontSize = vn.superscript
+    ? Math.max(1, vn.fontSize * ratio)
+    : effectiveFontSize
+  const wordFont = `${vt.fontWeight} ${effectiveFontSize}px "${vt.fontFamily}", serif`
+  const verseNumFont = `${vt.fontWeight} ${verseNumFontSize}px "${vt.fontFamily}", serif`
+  const letterSpacing = vt.letterSpacing > 0 ? vt.letterSpacing : undefined
+
+  const items: RichInlineItem[] = []
+  const kinds: ("word" | "verseNum")[] = []
+  for (const segment of verse.segments) {
+    if (vn.visible && segment.verseNumber !== undefined) {
+      items.push({
+        text: `${segment.verseNumber} `,
+        font: verseNumFont,
+        letterSpacing,
+        break: "never",
+      })
+      kinds.push("verseNum")
+    }
+    const text = applyTextTransform(segment.text, transform).trim()
+    if (text) {
+      items.push({ text: `${text} `, font: wordFont, letterSpacing })
+      kinds.push("word")
+    }
+  }
+  if (!items.length) return null
+
+  return { prepared: prepareRichInline(items), kinds, wordFont, verseNumFont }
+}
+
+function layoutVerseLines(
+  handle: VerseInlineHandle,
+  maxWidth: number
+): RichInlineLine[] {
+  const lines: RichInlineLine[] = []
+  walkRichInlineLineRanges(handle.prepared, Math.max(1, maxWidth), (range) => {
+    lines.push(materializeRichInlineLineRange(handle.prepared, range))
+  })
   return lines
 }
 
@@ -435,10 +582,8 @@ function drawVerseText(
   const lineHeightPx = actualFontSize * vt.lineHeight
 
   ctx.save()
-  ctx.font = `${vt.fontWeight} ${actualFontSize}px "${vt.fontFamily}", serif`
-  ctx.fillStyle = vt.color
   ctx.textBaseline = "top"
-  ctx.textAlign = verseAlign === "justify" ? "left" : verseAlign
+  ctx.textAlign = "left"
 
   if (vt.letterSpacing > 0) {
     try {
@@ -448,36 +593,29 @@ function drawVerseText(
     }
   }
 
-  // Build full text with verse numbers inline
-  let fullText = ""
-  for (const segment of verse.segments) {
-    if (vn.visible && segment.verseNumber !== undefined) {
-      fullText += `${segment.verseNumber} `
-    }
-    fullText += segment.text + " "
+  const handle = prepareVerseInline(theme, verse, actualFontSize)
+  if (!handle) {
+    ctx.restore()
+    return 0
   }
-  fullText = applyTextTransform(
-    fullText.trim(),
-    resolveTextTransform(vt.textTransform)
-  )
+  const lines = layoutVerseLines(handle, textRectWidth)
 
-  const wrappedLines = wrapText(ctx, fullText, textRectWidth)
+  const drawFragment = (
+    text: string,
+    kind: "word" | "verseNum",
+    drawX: number,
+    drawY: number
+  ) => {
+    ctx.font = kind === "verseNum" ? handle.verseNumFont : handle.wordFont
+    ctx.fillStyle = kind === "verseNum" ? vn.color : vt.color
 
-  let currentY = startY
-  const x = alignX(
-    verseAlign === "justify" ? "left" : verseAlign,
-    textRectX,
-    textRectWidth
-  )
-
-  const drawStyledLine = (line: string, drawX: number, drawY: number) => {
     if (vt.shadow) {
       ctx.save()
       ctx.shadowColor = vt.shadow.color
       ctx.shadowBlur = vt.shadow.blur
       ctx.shadowOffsetX = vt.shadow.x
       ctx.shadowOffsetY = vt.shadow.y
-      ctx.fillText(line, drawX, drawY)
+      ctx.fillText(text, drawX, drawY)
       ctx.restore()
     }
 
@@ -485,65 +623,56 @@ function drawVerseText(
       ctx.save()
       ctx.strokeStyle = vt.outline.color
       ctx.lineWidth = vt.outline.width
-      ctx.strokeText(line, drawX, drawY)
+      ctx.strokeText(text, drawX, drawY)
       ctx.restore()
     }
 
     if (!vt.shadow) {
-      ctx.fillText(line, drawX, drawY)
+      ctx.fillText(text, drawX, drawY)
     }
   }
 
-  for (const [index, line] of wrappedLines.entries()) {
+  let currentY = startY
+  for (const [index, line] of lines.entries()) {
     const isJustifiedLine =
       verseAlign === "justify" &&
-      index < wrappedLines.length - 1 &&
-      /\s+/.test(line)
+      index < lines.length - 1 &&
+      line.fragments.length > 1
+
+    let extraGap = 0
+    let lineStartX = textRectX
+    let lineWidth = line.width
     if (isJustifiedLine) {
-      const words = line.trim().split(/\s+/).filter(Boolean)
-      if (words.length > 1) {
-        const wordsWidth = words.reduce(
-          (sum, word) => sum + ctx.measureText(word).width,
-          0
-        )
-        const gap = (textRectWidth - wordsWidth) / (words.length - 1)
-        let cursorX = textRectX
-        for (const word of words) {
-          drawStyledLine(word, cursorX, currentY)
-          cursorX += ctx.measureText(word).width + gap
-        }
-      } else {
-        drawStyledLine(line, textRectX, currentY)
-      }
-      drawTextDecorationLine(
-        ctx,
-        verseDecoration,
-        vt.color,
-        "left",
-        textRectX,
-        currentY,
-        textRectWidth,
-        vt.fontSize,
-        textRectX
-      )
-    } else {
-      drawStyledLine(line, x, currentY)
-      const lineWidth = Math.min(
-        textRectWidth,
-        Math.max(1, ctx.measureText(line).width)
-      )
-      drawTextDecorationLine(
-        ctx,
-        verseDecoration,
-        vt.color,
-        verseAlign,
-        x,
-        currentY,
-        lineWidth,
-        vt.fontSize,
-        textRectX
-      )
+      extraGap = (textRectWidth - line.width) / (line.fragments.length - 1)
+      lineWidth = textRectWidth
+    } else if (verseAlign === "center") {
+      lineStartX = textRectX + (textRectWidth - line.width) / 2
+    } else if (verseAlign === "right") {
+      lineStartX = textRectX + textRectWidth - line.width
     }
+
+    let cursorX = lineStartX
+    for (const [i, fragment] of line.fragments.entries()) {
+      cursorX += fragment.gapBefore + (i > 0 ? extraGap : 0)
+      drawFragment(
+        fragment.text,
+        handle.kinds[fragment.itemIndex],
+        cursorX,
+        currentY
+      )
+      cursorX += fragment.occupiedWidth
+    }
+    drawTextDecorationLine(
+      ctx,
+      verseDecoration,
+      vt.color,
+      "left",
+      lineStartX,
+      currentY,
+      Math.min(textRectWidth, Math.max(1, lineWidth)),
+      actualFontSize,
+      textRectX
+    )
     currentY += lineHeightPx
   }
 
@@ -668,17 +797,8 @@ function calculateScaledFontSize(
   while (low <= high) {
     const mid = Math.floor((low + high) / 2)
 
-    // Simulate a temporary theme with the test font size
-    const testTheme = {
-      ...theme,
-      verseText: {
-        ...theme.verseText,
-        fontSize: mid,
-      },
-    }
-
     // If I use this font size, how tall will the verse be?
-    const metrics = measureVerseHeight(ctx, testTheme, verse, textRectWidth)
+    const metrics = measureVerseHeight(ctx, theme, verse, textRectWidth, mid)
 
     // Check if the rendered verse is still too big to fit
     if (metrics.height <= maxHeight) {
@@ -694,51 +814,48 @@ function calculateScaledFontSize(
   return bestFit
 }
 
-function measureVerseHeight(
-  ctx: CanvasRenderingContext2D,
+// The ctx parameter is kept for call-site symmetry with the draw path, but
+// measurement now happens inside pretext's own canvas context.
+export function measureVerseHeight(
+  _ctx: CanvasRenderingContext2D,
   theme: BroadcastTheme,
   verse: VerseRenderData,
-  textRectWidth: number
+  textRectWidth: number,
+  fontSizeOverride?: number
 ): { height: number; maxLineWidth: number } {
   const vt = theme.verseText
-  const vn = theme.verseNumbers
   const verseAlign = resolveHorizontalAlign(
     vt.horizontalAlign,
     theme.layout.textAlign,
     true
   )
-  const lineHeightPx = vt.fontSize * vt.lineHeight
-  ctx.save()
-  ctx.font = `${vt.fontWeight} ${vt.fontSize}px "${vt.fontFamily}", serif`
-  if (vt.letterSpacing > 0) {
-    try {
-      ctx.letterSpacing = `${vt.letterSpacing}px`
-    } catch {
-      /* unsupported in some WebViews */
-    }
+  const effectiveFontSize = fontSizeOverride ?? vt.fontSize
+  const lineHeightPx = effectiveFontSize * vt.lineHeight
+  const handle = prepareVerseInline(theme, verse, effectiveFontSize)
+  if (!handle) {
+    return { height: lineHeightPx, maxLineWidth: 1 }
   }
-  let fullText = ""
-  for (const segment of verse.segments) {
-    if (vn.visible && segment.verseNumber !== undefined)
-      fullText += `${segment.verseNumber} `
-    fullText += `${segment.text} `
-  }
-  const transformed = applyTextTransform(
-    fullText.trim(),
-    resolveTextTransform(vt.textTransform)
-  )
-  const lines = wrapText(ctx, transformed, textRectWidth)
-  let maxLineWidth = 0
-  for (const [index, line] of lines.entries()) {
-    const isJustifiedLine =
-      verseAlign === "justify" && index < lines.length - 1 && /\s+/.test(line)
-    const width = isJustifiedLine ? textRectWidth : ctx.measureText(line).width
-    if (width > maxLineWidth) maxLineWidth = width
-  }
-  ctx.restore()
+  const stats = measureRichInlineStats(handle.prepared, Math.max(1, textRectWidth))
+  const maxLineWidth =
+    verseAlign === "justify" && stats.lineCount > 1
+      ? textRectWidth
+      : stats.maxLineWidth
   return {
-    height: Math.max(lineHeightPx, lines.length * lineHeightPx),
+    height: Math.max(1, stats.lineCount) * lineHeightPx,
     maxLineWidth: Math.max(1, maxLineWidth),
+  }
+}
+
+function pctBoxToPx(
+  box: { x: number; y: number; width: number; height: number },
+  canvasW: number,
+  canvasH: number
+): VerseLayoutRect {
+  return {
+    x: (box.x / 100) * canvasW,
+    y: (box.y / 100) * canvasH,
+    width: Math.max(1, (box.width / 100) * canvasW),
+    height: Math.max(1, (box.height / 100) * canvasH),
   }
 }
 
@@ -772,6 +889,7 @@ export function computeVerseLayoutMetrics(
   verse: VerseRenderData | null,
   options?: RenderOptions
 ): VerseLayoutMetrics {
+  ensureThemeFontsLoaded(theme)
   const scale = options?.scale ?? 1
   const scaledTheme = buildScaledTheme(theme, scale)
   const canvasW = scaledTheme.resolution.width
@@ -812,13 +930,26 @@ export function computeVerseLayoutMetrics(
     height: textRectH,
   }
 
+  const freeMode =
+    layout.mode === "free" &&
+    layout.referenceBox !== undefined &&
+    layout.verseBox !== undefined
+  const referenceBoxRect: VerseLayoutRect | null = freeMode
+    ? pctBoxToPx(layout.referenceBox!, canvasW, canvasH)
+    : null
+  const verseBoxRect: VerseLayoutRect | null = freeMode
+    ? pctBoxToPx(layout.verseBox!, canvasW, canvasH)
+    : null
+
   if (!verse) {
     return {
       scaledTheme,
-      textAreaRect,
-      textRect,
+      textAreaRect: verseBoxRect ?? textAreaRect,
+      textRect: verseBoxRect ?? textRect,
       referenceRect: null,
       verseRect: null,
+      referenceBoxRect,
+      verseBoxRect,
     }
   }
 
@@ -833,6 +964,90 @@ export function computeVerseLayoutMetrics(
     scaledTheme.layout.textAlign,
     false
   )
+
+  const refText = applyTextTransform(
+    scaledTheme.reference.uppercase
+      ? verse.reference.toUpperCase()
+      : verse.reference,
+    resolveTextTransform(scaledTheme.reference.textTransform)
+  )
+  const measureReferenceWidth = (maxWidth: number) => {
+    ctx.save()
+    ctx.font = `${scaledTheme.reference.fontWeight} ${scaledTheme.reference.fontSize}px "${scaledTheme.reference.fontFamily}", sans-serif`
+    const width = Math.max(
+      1,
+      Math.min(maxWidth, ctx.measureText(refText).width)
+    )
+    ctx.restore()
+    return width
+  }
+
+  if (freeMode && referenceBoxRect && verseBoxRect) {
+    const fittedVerseFontSize = calculateScaledFontSize(
+      ctx,
+      scaledTheme,
+      verse,
+      verseBoxRect.width,
+      verseBoxRect.height
+    )
+    const verseMetrics = measureVerseHeight(
+      ctx,
+      scaledTheme,
+      verse,
+      verseBoxRect.width,
+      fittedVerseFontSize
+    )
+    const verseY = alignY(
+      resolveVerticalAlign(scaledTheme.verseText.verticalAlign),
+      verseBoxRect.y,
+      verseBoxRect.height,
+      verseMetrics.height
+    )
+    const verseRect = rectForAlignedText(
+      verseAlign === "justify" ? "left" : verseAlign,
+      alignX(
+        verseAlign === "justify" ? "left" : verseAlign,
+        verseBoxRect.x,
+        verseBoxRect.width
+      ),
+      verseY,
+      verseMetrics.maxLineWidth,
+      verseMetrics.height,
+      verseBoxRect
+    )
+
+    const referenceWidth = measureReferenceWidth(referenceBoxRect.width)
+    const refY = alignY(
+      resolveVerticalAlign(scaledTheme.reference.verticalAlign),
+      referenceBoxRect.y,
+      referenceBoxRect.height,
+      referenceHeight
+    )
+    const referenceRect = rectForAlignedText(
+      referenceAlign === "justify" ? "left" : referenceAlign,
+      alignX(
+        referenceAlign === "justify" ? "left" : referenceAlign,
+        referenceBoxRect.x,
+        referenceBoxRect.width
+      ),
+      refY,
+      referenceWidth,
+      referenceHeight,
+      referenceBoxRect
+    )
+
+    return {
+      scaledTheme,
+      textAreaRect: verseBoxRect,
+      textRect: verseBoxRect,
+      referenceRect,
+      verseRect,
+      fittedVerseFontSize,
+      referenceBoxRect,
+      verseBoxRect,
+    }
+  }
+
   const blockVerticalAlign = resolveVerticalAlign(
     scaledTheme.reference.position === "above"
       ? (scaledTheme.reference.verticalAlign ??
@@ -844,7 +1059,20 @@ export function computeVerseLayoutMetrics(
     0,
     scaledTheme.layout.referenceGap ?? scaledTheme.reference.fontSize * 0.5
   )
-  const verseMetrics = measureVerseHeight(ctx, scaledTheme, verse, textRectW)
+  const fittedVerseFontSize = calculateScaledFontSize(
+    ctx,
+    scaledTheme,
+    verse,
+    textRectW,
+    calculateMaxAvailableVerseHeight(scaledTheme, textRect, referenceHeight)
+  )
+  const verseMetrics = measureVerseHeight(
+    ctx,
+    scaledTheme,
+    verse,
+    textRectW,
+    fittedVerseFontSize
+  )
   const verseHeight = verseMetrics.height
   const verseDrawX = alignX(
     verseAlign === "justify" ? "left" : verseAlign,
@@ -856,20 +1084,7 @@ export function computeVerseLayoutMetrics(
     textRectX,
     textRectW
   )
-
-  const refText = applyTextTransform(
-    scaledTheme.reference.uppercase
-      ? verse.reference.toUpperCase()
-      : verse.reference,
-    resolveTextTransform(scaledTheme.reference.textTransform)
-  )
-  ctx.save()
-  ctx.font = `${scaledTheme.reference.fontWeight} ${scaledTheme.reference.fontSize}px "${scaledTheme.reference.fontFamily}", sans-serif`
-  const referenceWidth = Math.max(
-    1,
-    Math.min(textRectW, ctx.measureText(refText).width)
-  )
-  ctx.restore()
+  const referenceWidth = measureReferenceWidth(textRectW)
 
   const blockHeight =
     scaledTheme.reference.position === "above"
@@ -945,7 +1160,16 @@ export function computeVerseLayoutMetrics(
     )
   }
 
-  return { scaledTheme, textAreaRect, textRect, referenceRect, verseRect }
+  return {
+    scaledTheme,
+    textAreaRect,
+    textRect,
+    referenceRect,
+    verseRect,
+    fittedVerseFontSize,
+    referenceBoxRect: null,
+    verseBoxRect: null,
+  }
 }
 
 export function renderVerse(
@@ -1006,29 +1230,17 @@ function renderVerseImpl(
 
   const referenceRect = metrics.referenceRect
   const verseRect = metrics.verseRect
+  const verseArea = metrics.verseBoxRect ?? metrics.textRect
+  const referenceArea = metrics.referenceBoxRect ?? metrics.textRect
   if (verseRect) {
-    const maxAvailableVerseHeight = calculateMaxAvailableVerseHeight(
-      scaledTheme,
-      metrics.textRect,
-      referenceRect?.height ?? 0
-    )
-
-    const scaledFontSize = calculateScaledFontSize(
-      ctx,
-      scaledTheme,
-      verse,
-      metrics.textAreaRect.width,
-      maxAvailableVerseHeight
-    )
-
     drawVerseText(
       ctx,
       scaledTheme,
       verse,
-      metrics.textRect.x,
-      metrics.textRect.width,
+      verseArea.x,
+      verseArea.width,
       verseRect.y,
-      scaledFontSize
+      metrics.fittedVerseFontSize
     )
   }
   if (referenceRect) {
@@ -1036,8 +1248,8 @@ function renderVerseImpl(
       ctx,
       scaledTheme,
       verse.reference,
-      metrics.textRect.x,
-      metrics.textRect.width,
+      referenceArea.x,
+      referenceArea.width,
       referenceRect.y
     )
   }

--- a/src/stores/broadcast-store.ts
+++ b/src/stores/broadcast-store.ts
@@ -3,6 +3,7 @@ import { emitTo } from "@tauri-apps/api/event"
 import { load, type Store } from "@tauri-apps/plugin-store"
 import type { BroadcastTheme, VerseRenderData } from "@/types"
 import { BUILTIN_THEMES } from "@/lib/builtin-themes"
+import { normalizeTheme } from "@/lib/theme-migrations"
 
 type SelectedElement = "verse" | "reference" | null
 
@@ -290,7 +291,7 @@ export function hydrateBroadcastThemes(): Promise<void> {
 
       const patch: Partial<BroadcastState> = {}
       if (customThemes && Array.isArray(customThemes) && customThemes.length > 0) {
-        patch.themes = [...BUILTIN_THEMES, ...customThemes]
+        patch.themes = [...BUILTIN_THEMES, ...customThemes.map(normalizeTheme)]
       }
       if (activeId) patch.activeThemeId = activeId
       if (altActiveId) patch.altActiveThemeId = altActiveId

--- a/src/types/broadcast.ts
+++ b/src/types/broadcast.ts
@@ -16,6 +16,14 @@ export interface RenderOptions {
   imageCache?: Map<string, HTMLImageElement>
 }
 
+/** A freely positioned element region, all values in % of canvas size (0-100), x/y = top-left. */
+export interface ElementBox {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 export type TextHorizontalAlign = "left" | "center" | "right" | "justify"
 export type TextVerticalAlign = "top" | "middle" | "bottom"
 export type TextTransform = "none" | "uppercase" | "lowercase" | "capitalize"
@@ -103,6 +111,10 @@ export interface BroadcastTheme {
     textAreaWidth: number
     textAreaHeight: number
     referenceGap?: number
+    /** "stacked" (default): reference + verse flow as one block. "free": each is positioned by its box. */
+    mode?: "stacked" | "free"
+    referenceBox?: ElementBox
+    verseBox?: ElementBox
   }
   transition: {
     type: "fade" | "slide" | "scale" | "none"

--- a/web/content/docs/features/theme-designer.mdx
+++ b/web/content/docs/features/theme-designer.mdx
@@ -22,14 +22,21 @@ NDI exactly as designed.
   letter-spacing, line-height, and alignment.
 - **Effects**: drop shadows, outlines/strokes, fills, and blur.
 - **Layout**: drag elements to position them with pixel precision; the
-  canvas reflects the exact NDI output dimensions.
+  canvas reflects the exact NDI output dimensions. Dragging the reference
+  or verse frame detaches them into **free positioning** mode, where each
+  block has its own X/Y/width/height (also editable as percentages in the
+  Layout tab). Keep them stacked and the classic above/below/inline flow
+  applies instead.
 - **Tokens**: place the verse text, the reference, the translation tag,
   and the verse number as separate elements so they can be styled
   independently.
+- **Verse numbers**: toggle visibility, render as superscript (with an
+  adjustable size relative to the verse text), and give them their own
+  colour — e.g. a yellow number in front of white verse text.
 
 ## Built-in starters
 
-Rhema ships with three opinionated starter themes (`src/lib/builtin-themes.ts`)
+Rhema ships with four opinionated starter themes (`src/lib/builtin-themes.ts`)
 that you can clone and modify:
 
 - **Classic Dark** — a high-contrast dark overlay tuned for typical
@@ -38,6 +45,8 @@ that you can clone and modify:
   palettes.
 - **Broadcast Overlay** — a broadcast-safe layout designed for
   composition over a live camera feed.
+- **Banner Split** — a free-positioning example with the reference in a
+  top-left banner and the verse block detached below it.
 
 Each starter is a regular project file you can save, version, and
 re-export.


### PR DESCRIPTION
## Description

Closes #100.

Splits the book reference and verse text into independently positionable elements, and fills the gaps that made the requested design impossible:

- **Detached reference** — themes gain a `mode` of `"stacked"` (existing behaviour, still the default) or `"free"`. In free mode the reference and verse each have their own `ElementBox` (`x`/`y`/`width`/`height` as % of canvas), so they can be moved, resized and styled separately in the Theme Designer.
- **System fonts** — new `list_system_fonts` Tauri command (via `fontdb`, enumerated once and cached) exposed through `src/lib/fonts.ts`, so the font picker offers installed fonts alongside the bundled ones. Falls back to web-safe families outside Tauri.
- **Verse numbers** — superscript now actually renders, with a size control relative to the verse text, plus colour and opacity (`src/lib/color-utils.ts`).

Existing themes are normalised forward by `src/lib/theme-migrations.ts`, so saved themes keep rendering as they did before.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

- [x] Frontend (React / TypeScript)
- [x] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [x] Broadcast / NDI
- [x] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [ ] I have tested this change locally
- [ ] `bun run typecheck` passes
- [ ] `cargo clippy` passes without warnings
- [ ] `bun run test` passes (if applicable)
- [x] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

<!-- Check the platforms you tested on: -->

- [ ] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

<!-- If this PR includes UI changes, add screenshots or recordings here. -->
