### PR TITLE
fix(broadcast): stop AI detection overriding the manually selected live verse

### DIFF
--- a/src/components/panels/live-output-panel.tsx
+++ b/src/components/panels/live-output-panel.tsx
@@ -4,31 +4,53 @@ import { CanvasVerse } from "@/components/ui/canvas-verse"
 import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
 import { useBroadcastStore, useBibleStore } from "@/stores"
-import { deriveLiveVerse } from "@/hooks/use-broadcast"
+import { presentVerse, toVerseRenderData } from "@/hooks/use-broadcast"
+import { bibleActions } from "@/hooks/use-bible"
 
 export function LiveOutputPanel() {
   const isLive = useBroadcastStore((s) => s.isLive)
+  const autoLive = useBroadcastStore((s) => s.autoLive)
+  const liveVerse = useBroadcastStore((s) => s.liveVerse)
   const themes = useBroadcastStore((s) => s.themes)
   const activeThemeId = useBroadcastStore((s) => s.activeThemeId)
-
-  // Read the same data source as the preview panel
-  const selectedVerse = useBibleStore((s) => s.selectedVerse)
-  const translations = useBibleStore((s) => s.translations)
   const activeTranslationId = useBibleStore((s) => s.activeTranslationId)
 
   const activeTheme = themes.find((t) => t.id === activeThemeId) ?? themes[0]
-  const translation =
-    translations.find((t) => t.id === activeTranslationId)?.abbreviation ?? "KJV"
 
-  const verseData = deriveLiveVerse({
-    isLive,
-    selectedVerse,
-    translation,
-  })
+  // The live output renders only what was explicitly presented — it no longer
+  // follows the preview selection, so detections can't override the operator.
+  const verseData = isLive ? liveVerse : null
 
+  // Refetch the live verse when the translation changes so the live output
+  // text follows the new translation. Updates the live output only — the
+  // preview keeps whatever the operator is browsing.
   useEffect(() => {
-    useBroadcastStore.getState().setLiveVerse(verseData)
-  }, [verseData])
+    const source = useBroadcastStore.getState().liveSourceVerse
+    if (!source) return
+    bibleActions
+      .fetchVerse(source.book_number, source.chapter, source.verse)
+      .then((v) => {
+        if (!v) return
+        const bible = useBibleStore.getState()
+        const abbreviation =
+          bible.translations.find((t) => t.id === bible.activeTranslationId)
+            ?.abbreviation ?? "KJV"
+        useBroadcastStore
+          .getState()
+          .setLiveVerse(toVerseRenderData(v, abbreviation), v)
+      })
+      .catch(() => {})
+  }, [activeTranslationId])
+
+  const handleGoLive = (checked: boolean) => {
+    useBroadcastStore.getState().setLive(checked)
+    // Going live with nothing presented yet: present the current preview
+    // verse so the output isn't blank.
+    if (checked && !useBroadcastStore.getState().liveVerse) {
+      const selected = useBibleStore.getState().selectedVerse
+      if (selected) void presentVerse(selected)
+    }
+  }
 
   return (
     <div
@@ -39,7 +61,26 @@ export function LiveOutputPanel() {
       )}
     >
       <PanelHeader title="Live display">
-        <label className="flex items-center gap-2">
+        <label
+          className="flex items-center gap-2"
+          title="When on, detected verses are presented to the live display automatically. Turn off for manual control."
+        >
+          <span
+            className={cn(
+              "text-[0.625rem] font-medium uppercase tracking-wider transition-colors",
+              autoLive ? "text-foreground" : "text-muted-foreground"
+            )}
+          >
+            Auto
+          </span>
+          <Switch
+            checked={autoLive}
+            onCheckedChange={(checked) =>
+              useBroadcastStore.getState().setAutoLive(checked)
+            }
+          />
+        </label>
+        <label className="ml-2 flex items-center gap-2">
           <span
             className={cn(
               "text-[0.625rem] font-medium uppercase tracking-wider transition-colors",
@@ -50,9 +91,7 @@ export function LiveOutputPanel() {
           </span>
           <Switch
             checked={isLive}
-            onCheckedChange={(checked) =>
-              useBroadcastStore.getState().setLive(checked)
-            }
+            onCheckedChange={handleGoLive}
             className="data-[state=checked]:bg-emerald-500"
           />
         </label>

--- a/src/components/panels/preview-panel.tsx
+++ b/src/components/panels/preview-panel.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
+import { Button } from "@/components/ui/button"
+import { MonitorUpIcon } from "lucide-react"
 import { useBibleStore, useBroadcastStore } from "@/stores"
 import { bibleActions } from "@/hooks/use-bible"
-import { toVerseRenderData } from "@/hooks/use-broadcast"
+import { presentVerse, toVerseRenderData } from "@/hooks/use-broadcast"
 
 export function PreviewPanel() {
   const selectedVerse = useBibleStore((s) => s.selectedVerse)
@@ -35,7 +37,22 @@ export function PreviewPanel() {
       data-slot="preview-panel"
       className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card"
     >
-      <PanelHeader title="Program preview" />
+      <PanelHeader title="Program preview">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-[0.625rem] font-medium uppercase tracking-wider"
+          disabled={!selectedVerse}
+          onClick={() => {
+            const verse = useBibleStore.getState().selectedVerse
+            if (verse) void presentVerse(verse)
+          }}
+          title="Present this verse on the live display"
+        >
+          <MonitorUpIcon className="size-3" />
+          Send to live
+        </Button>
+      </PanelHeader>
       <div className="flex min-h-0 flex-1 items-center justify-center p-3">
         <CanvasVerse theme={activeTheme} verse={verseData} />
       </div>

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -9,11 +9,13 @@ import {
   useDetectionStore,
   useQueueStore,
   useBibleStore,
+  useBroadcastStore,
   useTranscriptStore,
 } from "@/stores"
 import { useTauriEvent } from "@/hooks/use-tauri-event"
 import { useTranscription } from "@/hooks/use-transcription"
 import { bibleActions } from "@/hooks/use-bible"
+import { presentVerse } from "@/hooks/use-broadcast"
 import type { DetectionResult, ReadingAdvance } from "@/types"
 
 /**
@@ -83,8 +85,7 @@ export function TranscriptPanel() {
       (d) => d.source === "direct" && !d.is_chapter_only
     )
     if (directHit && directHit.book_number > 0) {
-      // Select verse immediately so preview/live panels update
-      bibleActions.selectVerse({
+      const detectedVerse = {
         id: 0,
         translation_id: useBibleStore.getState().activeTranslationId,
         book_number: directHit.book_number,
@@ -93,7 +94,15 @@ export function TranscriptPanel() {
         chapter: directHit.chapter,
         verse: directHit.verse,
         text: directHit.verse_text,
-      })
+      }
+      // Detections always update the preview. They only reach the live
+      // display when auto-live is on — otherwise the operator presents
+      // manually (issue #105).
+      if (useBroadcastStore.getState().autoLive) {
+        void presentVerse(detectedVerse)
+      } else {
+        bibleActions.selectVerse(detectedVerse)
+      }
       // Navigate book search panel to this verse
       useBibleStore
         .getState()
@@ -173,7 +182,7 @@ export function TranscriptPanel() {
   // Does NOT add to queue — only direct/semantic feed the queue.
   useTauriEvent<ReadingAdvance>("reading_mode_verse", (advance) => {
     if (advance.book_number > 0) {
-      bibleActions.selectVerse({
+      const advanceVerse = {
         id: 0,
         translation_id: useBibleStore.getState().activeTranslationId,
         book_number: advance.book_number,
@@ -182,7 +191,14 @@ export function TranscriptPanel() {
         chapter: advance.chapter,
         verse: advance.verse,
         text: advance.verse_text,
-      })
+      }
+      // Same auto-live gate as detections: preview always follows, the live
+      // display only when the operator allows it (issue #105).
+      if (useBroadcastStore.getState().autoLive) {
+        void presentVerse(advanceVerse)
+      } else {
+        bibleActions.selectVerse(advanceVerse)
+      }
       useBibleStore.getState().setPendingNavigation({
         bookNumber: advance.book_number,
         chapter: advance.chapter,

--- a/src/hooks/use-broadcast.test.ts
+++ b/src/hooks/use-broadcast.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Verse } from "@/types"
-import { deriveLiveVerse, presentVerse } from "./use-broadcast"
+import { presentVerse } from "./use-broadcast"
 import { useBibleStore } from "@/stores/bible-store"
 import { useBroadcastStore } from "@/stores/broadcast-store"
 
@@ -24,32 +24,6 @@ const sampleVerse: Verse = {
   verse: 2,
   text: "The earth was without form and void.",
 }
-
-describe("deriveLiveVerse", () => {
-  it("returns null when live output is off", () => {
-    const result = deriveLiveVerse({
-      isLive: false,
-      selectedVerse: sampleVerse,
-      translation: "NKJV",
-    })
-
-    expect(result).toBeNull()
-  })
-
-  it("returns verse render data when live output is on", () => {
-    const result = deriveLiveVerse({
-      isLive: true,
-      selectedVerse: sampleVerse,
-      translation: "NKJV",
-    })
-
-    expect(result).toEqual(
-      expect.objectContaining({
-        reference: "Genesis 1:2 (NKJV)",
-      }),
-    )
-  })
-})
 
 describe("presentVerse", () => {
   const staleVerse: Verse = {
@@ -79,7 +53,7 @@ describe("presentVerse", () => {
         },
       ],
     })
-    useBroadcastStore.setState({ liveVerse: null })
+    useBroadcastStore.setState({ liveVerse: null, liveSourceVerse: null })
   })
 
   it("presents the refetched verse text, not the stale queue text", async () => {
@@ -134,6 +108,34 @@ describe("presentVerse", () => {
     expect(useBibleStore.getState().selectedVerse).toEqual(sampleVerse)
     expect(useBroadcastStore.getState().liveVerse?.segments[0].text).toBe(
       sampleVerse.text,
+    )
+  })
+
+  it("records the presented verse as the live source verse", async () => {
+    const fullVerse: Verse = { ...staleVerse, id: 26137, translation_id: 2, text: "For God so loved the world" }
+    mockInvoke.mockResolvedValue(fullVerse)
+
+    await presentVerse(staleVerse)
+
+    expect(useBroadcastStore.getState().liveSourceVerse).toEqual(fullVerse)
+  })
+
+  it("ignores a stale refetch that resolves after a newer present call", async () => {
+    const older: Verse = { ...sampleVerse, verse: 1, text: "In the beginning" }
+    let resolveOlder: (v: Verse) => void = () => {}
+    mockInvoke
+      .mockImplementationOnce(
+        () => new Promise<Verse>((resolve) => (resolveOlder = resolve)),
+      )
+      .mockResolvedValueOnce(sampleVerse)
+
+    const first = presentVerse(older)
+    await presentVerse(sampleVerse)
+    resolveOlder(older)
+    await first
+
+    expect(useBroadcastStore.getState().liveVerse?.reference).toBe(
+      "Genesis 1:2 (NKJV)",
     )
   })
 })

--- a/src/hooks/use-broadcast.ts
+++ b/src/hooks/use-broadcast.ts
@@ -11,14 +11,25 @@ export function toVerseRenderData(verse: Verse, translation: string): VerseRende
   }
 }
 
+// Monotonic ticket so an older present whose refetch resolves late can't
+// overwrite a newer one (detections can present in quick succession).
+let presentSeq = 0
+
 /**
  * Refetch the full verse from the backend and present it to preview + live
  * output. Queue/detection items may carry partial verse objects (empty text,
  * synthetic id 0, stale translation_id), so always look the verse up by
  * book/chapter/verse against the active translation. Falls back to the passed
  * verse if the lookup fails — never blanks the output on error.
+ *
+ * This is the ONLY path that changes the live output verse. Detections and
+ * navigation update the preview (`selectedVerse`); the live output follows
+ * only through an explicit present (or auto-live, which calls this).
  */
 export async function presentVerse(verse: Verse): Promise<void> {
+  presentSeq += 1
+  const ticket = presentSeq
+
   let verseToPresent = verse
   try {
     const fullVerse = await invoke<Verse | null>("get_verse", {
@@ -32,30 +43,19 @@ export async function presentVerse(verse: Verse): Promise<void> {
     console.warn("[broadcast] get_verse refetch failed, using cached verse:", e)
   }
 
+  // A newer present started while we were refetching — let it win.
+  if (ticket !== presentSeq) return
+
   const bibleState = useBibleStore.getState()
   const translation =
     bibleState.translations.find((t) => t.id === bibleState.activeTranslationId)
       ?.abbreviation ?? "KJV"
 
-  // Update selectedVerse too: live-output-panel re-derives the live verse
-  // from selectedVerse, so it must carry the same (refetched) text.
+  // Keep the preview in sync with what was just presented.
   bibleState.selectVerse(verseToPresent)
   useBroadcastStore
     .getState()
-    .setLiveVerse(toVerseRenderData(verseToPresent, translation))
-}
-
-export function deriveLiveVerse({
-  isLive,
-  selectedVerse,
-  translation,
-}: {
-  isLive: boolean
-  selectedVerse: Verse | null
-  translation: string
-}): VerseRenderData | null {
-  if (!isLive || !selectedVerse) return null
-  return toVerseRenderData(selectedVerse, translation)
+    .setLiveVerse(toVerseRenderData(verseToPresent, translation), verseToPresent)
 }
 
 export const broadcastActions = {

--- a/src/stores/broadcast-store.test.ts
+++ b/src/stores/broadcast-store.test.ts
@@ -6,6 +6,11 @@ vi.mock("@tauri-apps/api/event", () => ({
   emitTo: emitToMock,
 }))
 
+const sampleLiveVerse = {
+  reference: "John 3:16",
+  segments: [{ text: "For God so loved the world", verseNumber: 16 }],
+}
+
 describe("broadcast store sync", () => {
   beforeEach(async () => {
     emitToMock.mockReset()
@@ -13,15 +18,13 @@ describe("broadcast store sync", () => {
     vi.resetModules()
   })
 
-  it("syncBroadcastOutput emits current theme and verse to broadcast window", async () => {
+  it("syncBroadcastOutput emits current theme and verse to broadcast window when live", async () => {
     const { useBroadcastStore } = await import("./broadcast-store")
     const theme = useBroadcastStore.getState().themes[0]
     useBroadcastStore.setState({
       activeThemeId: theme.id,
-      liveVerse: {
-      reference: "John 3:16",
-        segments: [{ text: "For God so loved the world", verseNumber: 16 }],
-      },
+      isLive: true,
+      liveVerse: sampleLiveVerse,
     })
 
     emitToMock.mockClear()
@@ -44,5 +47,82 @@ describe("broadcast store sync", () => {
         verse: expect.objectContaining({ reference: "John 3:16" }),
       }),
     )
+  })
+
+  it("syncBroadcastOutput emits null verse when not live, even with a live verse set", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    useBroadcastStore.setState({
+      isLive: false,
+      liveVerse: sampleLiveVerse,
+    })
+
+    emitToMock.mockClear()
+    useBroadcastStore.getState().syncBroadcastOutput()
+
+    expect(emitToMock).toHaveBeenCalledTimes(2)
+    expect(emitToMock).toHaveBeenCalledWith(
+      "broadcast",
+      "broadcast:verse-update",
+      expect.objectContaining({ verse: null }),
+    )
+  })
+
+  it("setLive pushes the persisted live verse to outputs when toggled on", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    useBroadcastStore.setState({ isLive: false, liveVerse: sampleLiveVerse })
+
+    emitToMock.mockClear()
+    useBroadcastStore.getState().setLive(true)
+
+    expect(emitToMock).toHaveBeenCalledWith(
+      "broadcast",
+      "broadcast:verse-update",
+      expect.objectContaining({
+        verse: expect.objectContaining({ reference: "John 3:16" }),
+      }),
+    )
+  })
+
+  it("setLive blanks the outputs when toggled off without clearing the stored verse", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    useBroadcastStore.setState({ isLive: true, liveVerse: sampleLiveVerse })
+
+    emitToMock.mockClear()
+    useBroadcastStore.getState().setLive(false)
+
+    expect(emitToMock).toHaveBeenCalledWith(
+      "broadcast",
+      "broadcast:verse-update",
+      expect.objectContaining({ verse: null }),
+    )
+    expect(useBroadcastStore.getState().liveVerse).toEqual(sampleLiveVerse)
+  })
+
+  it("autoLive defaults to on and can be toggled", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+
+    expect(useBroadcastStore.getState().autoLive).toBe(true)
+
+    useBroadcastStore.getState().setAutoLive(false)
+    expect(useBroadcastStore.getState().autoLive).toBe(false)
+  })
+
+  it("setLiveVerse records the source verse for re-presentation", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    const source = {
+      id: 1,
+      translation_id: 1,
+      book_number: 43,
+      book_name: "John",
+      book_abbreviation: "Jhn",
+      chapter: 3,
+      verse: 16,
+      text: "For God so loved the world",
+    }
+
+    useBroadcastStore.getState().setLiveVerse(sampleLiveVerse, source)
+
+    expect(useBroadcastStore.getState().liveVerse).toEqual(sampleLiveVerse)
+    expect(useBroadcastStore.getState().liveSourceVerse).toEqual(source)
   })
 })

--- a/src/stores/broadcast-store.ts
+++ b/src/stores/broadcast-store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand"
 import { emitTo } from "@tauri-apps/api/event"
 import { load, type Store } from "@tauri-apps/plugin-store"
-import type { BroadcastTheme, VerseRenderData } from "@/types"
+import type { BroadcastTheme, Verse, VerseRenderData } from "@/types"
 import { BUILTIN_THEMES, BROADCAST_OVERLAY, CLASSIC_DARK } from "@/lib/builtin-themes"
 import { normalizeTheme } from "@/lib/theme-migrations"
 
@@ -15,6 +15,13 @@ interface BroadcastState {
   altActiveThemeId: string
   isLive: boolean
   liveVerse: VerseRenderData | null
+  // The Verse the live output was presented from, kept so it can be
+  // re-presented (e.g. after a translation change). Preview selection never
+  // writes this — only an explicit present does.
+  liveSourceVerse: Verse | null
+  // When on, detections auto-present to the live output. When off, the live
+  // output only changes via explicit presents (manual operator control).
+  autoLive: boolean
 
   // Designer state
   isDesignerOpen: boolean
@@ -34,7 +41,8 @@ interface BroadcastState {
   setActiveTheme: (id: string) => void
   setAltActiveTheme: (id: string) => void
   setLive: (live: boolean) => void
-  setLiveVerse: (verse: VerseRenderData | null) => void
+  setLiveVerse: (verse: VerseRenderData | null, source?: Verse | null) => void
+  setAutoLive: (auto: boolean) => void
   syncBroadcastOutput: () => void
   syncBroadcastOutputFor: (outputId: string) => void
 
@@ -83,16 +91,17 @@ function setNestedValue(obj: Record<string, unknown>, path: string, value: unkno
 function emitDraftToBroadcast(state: BroadcastState): void {
   if (!state.draftTheme) return
   const id = state.editingThemeId
+  const verse = state.isLive ? state.liveVerse : null
   if (id === state.activeThemeId) {
     void emitTo("broadcast", "broadcast:verse-update", {
       theme: state.draftTheme,
-      verse: state.liveVerse,
+      verse,
     }).catch(() => {})
   }
   if (id === state.altActiveThemeId) {
     void emitTo("broadcast-alt", "broadcast:verse-update", {
       theme: state.draftTheme,
-      verse: state.liveVerse,
+      verse,
     }).catch(() => {})
   }
 }
@@ -103,6 +112,8 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
   altActiveThemeId: BUILTIN_THEMES[0].id,
   isLive: false,
   liveVerse: null,
+  liveSourceVerse: null,
+  autoLive: true,
   isDesignerOpen: false,
   editingThemeId: null,
   renamingThemeId: null,
@@ -184,7 +195,7 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
 
     void emitTo(label, "broadcast:verse-update", {
       theme,
-      verse: s.liveVerse,
+      verse: s.isLive ? s.liveVerse : null,
     }).catch(() => {})
   },
   syncBroadcastOutput: () => {
@@ -199,11 +210,15 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
     set({ altActiveThemeId })
     get().syncBroadcastOutputFor("alt")
   },
-  setLive: (isLive) => set({ isLive }),
-  setLiveVerse: (liveVerse) => {
-    set({ liveVerse })
+  setLive: (isLive) => {
+    set({ isLive })
     get().syncBroadcastOutput()
   },
+  setLiveVerse: (liveVerse, source = null) => {
+    set({ liveVerse, liveSourceVerse: source })
+    get().syncBroadcastOutput()
+  },
+  setAutoLive: (autoLive) => set({ autoLive }),
 
   // Designer
   setDesignerOpen: (isDesignerOpen) => {
@@ -296,6 +311,7 @@ export function hydrateBroadcastThemes(): Promise<void> {
       const customThemes = (await store.get("customThemes")) as BroadcastTheme[] | undefined
       const activeId = (await store.get("activeThemeId")) as string | undefined
       const altActiveId = (await store.get("altActiveThemeId")) as string | undefined
+      const autoLive = (await store.get("autoLive")) as boolean | undefined
 
       const patch: Partial<BroadcastState> = {}
       if (customThemes && Array.isArray(customThemes) && customThemes.length > 0) {
@@ -303,6 +319,7 @@ export function hydrateBroadcastThemes(): Promise<void> {
       }
       if (activeId) patch.activeThemeId = activeId
       if (altActiveId) patch.altActiveThemeId = altActiveId
+      if (typeof autoLive === "boolean") patch.autoLive = autoLive
 
       if (Object.keys(patch).length > 0) {
         useBroadcastStore.setState(patch)
@@ -313,7 +330,8 @@ export function hydrateBroadcastThemes(): Promise<void> {
         const changed =
           state.themes !== prevState.themes ||
           state.activeThemeId !== prevState.activeThemeId ||
-          state.altActiveThemeId !== prevState.altActiveThemeId
+          state.altActiveThemeId !== prevState.altActiveThemeId ||
+          state.autoLive !== prevState.autoLive
         if (!changed) return
         if (saveTimer) clearTimeout(saveTimer)
         saveTimer = setTimeout(() => {
@@ -341,6 +359,7 @@ async function persistBroadcastThemes(state: BroadcastState): Promise<void> {
     await store.set("customThemes", customThemes)
     await store.set("activeThemeId", state.activeThemeId)
     await store.set("altActiveThemeId", state.altActiveThemeId)
+    await store.set("autoLive", state.autoLive)
     await store.save()
   } catch {
     console.warn("[broadcast] Failed to persist themes")


### PR DESCRIPTION
Closes #105

## Problem

The live output re-derived its verse from the preview selection (`selectedVerse`) on every change. AI detections and reading-mode advances write `selectedVerse` continuously during transcription, so any detection — including a wrong one (e.g. Esther while the preacher reads 1 Corinthians) — instantly replaced whatever the operator had manually presented. Manual navigation lost every time.

## Fix — preview and live are now unlinked

- `liveVerse` in the broadcast store is the single source of truth for the live output. Only an explicit present (`presentVerse`: queue Present, detection-card Present, remote control, or the new **Send to live** button) changes it.
- Detections and reading mode keep driving the **preview** and the queue — the AI keeps working while the operator holds the live display.
- New **Auto** toggle in the Live display header (persisted): when on (default, matches current behavior), detections auto-present to live; turn it off for full manual control while reading multi-verse passages.
- **Send to live** button on the Program preview panel to push the previewed verse manually.
- Stale-present guard: an older present whose verse refetch resolves late can no longer overwrite a newer present.
- Changing translation refetches the live verse in the new translation without disturbing the operator's preview browsing.

## Testing

- `vitest`: 126/126 passing, including new coverage for isLive-gated broadcast emission, autoLive toggling, live source tracking, and the stale-present guard
- `tsc --noEmit` clean; changed files lint clean
- Manual flow to verify: start transcription, turn **Auto** off, present a verse from the queue, let detections fire — live display holds; preview and Recent detections keep updating; **Send to live** pushes the previewed verse.