### PR TITLE
search follow-ups: bound CTE materialization + partial-quote benchmark mode

### DIFF
--- a/src-tauri/crates/bible/src/search.rs
+++ b/src-tauri/crates/bible/src/search.rs
@@ -106,6 +106,11 @@ fn build_or_query(input: &str) -> String {
 
 // ── SQL runner ──────────────────────────────────────────────────────
 
+/// Upper bound on how many rows a single verse can occupy in the FTS index
+/// (one per English translation, currently 7, with headroom). Used to size
+/// the inner materialization limit in `run_fts_query`.
+const TRANSLATION_FANOUT: usize = 10;
+
 /// Execute a BM25-ranked FTS5 query across all English translations.
 ///
 /// Grouped by verse reference so the LIMIT applies to UNIQUE verses: without
@@ -118,6 +123,12 @@ fn build_or_query(input: &str) -> String {
 /// run in an aggregate context, and without materialization SQLite flattens
 /// the subquery into the outer aggregate ("unable to use function bm25 in
 /// the requested context").
+///
+/// The inner `LIMIT` bounds materialization on broad queries (an OR of
+/// common words can match most of the corpus) while staying exact: with at
+/// most `TRANSLATION_FANOUT` rows per verse, the best row of each of the
+/// top `limit` unique verses always sits within the top
+/// `limit × TRANSLATION_FANOUT` ranked rows.
 #[expect(
     clippy::cast_possible_wrap,
     reason = "limit is a small page-size value that fits in i64"
@@ -137,6 +148,8 @@ fn run_fts_query(
              JOIN verses v ON v.rowid = fts.rowid \
              JOIN translations t ON v.translation_id = t.id \
              WHERE fts.text MATCH ?1 AND t.language = 'en' \
+             ORDER BY rank \
+             LIMIT ?3 \
          ) \
          SELECT MIN(rank) as rank, book_number, book_name, chapter, verse \
          FROM ranked \
@@ -145,7 +158,11 @@ fn run_fts_query(
          LIMIT ?2",
     )?;
     let rows = stmt.query_map(
-        rusqlite::params![fts_query, limit as i64],
+        rusqlite::params![
+            fts_query,
+            limit as i64,
+            (limit * TRANSLATION_FANOUT) as i64
+        ],
         |row: &rusqlite::Row| {
             Ok(Bm25Result {
                 rank: row.get(0)?,

--- a/src-tauri/crates/detection/src/bin/search_bench.rs
+++ b/src-tauri/crates/detection/src/bin/search_bench.rs
@@ -15,6 +15,14 @@
 //! Pass `--probe-prefix` to also run the embedding-convention probes that
 //! gate the embedding regeneration work: a provenance probe (was the shipped
 //! index built with a "passage: " prefix?) and a query-format comparison.
+//!
+//! Pass `--fragments N` to additionally benchmark partial quoting the way a
+//! minister actually quotes: N random KJV verses are sampled (deterministic
+//! seed, any of the ~31k verses) and each contributes three queries — the
+//! first, middle, and last 8 words of the verse — reported as the
+//! frag_start / frag_middle / frag_end categories. Any verse containing the
+//! exact fragment counts as a correct answer, so common phrases that appear
+//! in several verses are scored fairly.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -27,6 +35,16 @@ use rhema_detection::{HnswVectorIndex, OnnxEmbedder};
 
 const K: usize = 15;
 const MRR_DEPTH: usize = 10;
+
+/// Words per generated verse fragment (--fragments mode).
+const FRAGMENT_WORDS: usize = 8;
+
+/// Minimum verse length (words) to be eligible for fragment sampling, so the
+/// start/middle/end windows are meaningfully distinct.
+const FRAGMENT_MIN_WORDS: usize = 12;
+
+/// Fixed seed for fragment sampling — results must be reproducible run-to-run.
+const FRAGMENT_SEED: u64 = 0x5EED_0F_B1B1E;
 
 /// Query formats compared by the `--probe-prefix` query-format probe.
 /// "passage: " is the E5-style prefix used by the precompute binary; the
@@ -143,13 +161,26 @@ fn main() {
         );
     }
 
-    let golden: GoldenFile = serde_json::from_str(
+    let mut golden: GoldenFile = serde_json::from_str(
         &std::fs::read_to_string(&golden_path).expect("read golden set"),
     )
     .expect("parse golden set");
     log::info!("Loaded {} golden queries", golden.queries.len());
 
     let db = BibleDb::open(Path::new(&db_path)).expect("open bible db");
+
+    let fragments: usize = get_arg(&args, "--fragments")
+        .map(|n| n.parse().expect("--fragments takes a number"))
+        .unwrap_or(0);
+    if fragments > 0 {
+        let generated = generate_fragment_queries(&db, fragments);
+        log::info!(
+            "Generated {} fragment queries from {fragments} random KJV verses",
+            generated.len()
+        );
+        golden.queries.extend(generated);
+    }
+    let golden = golden;
 
     log::info!("Loading ONNX model from {model_path}...");
     let mut embedder =
@@ -368,6 +399,84 @@ fn run_provenance_probe(embedder: &mut OnnxEmbedder, index: &HnswVectorIndex, db
 
 fn dot(a: &[f32], b: &[f32]) -> f64 {
     a.iter().zip(b.iter()).map(|(&x, &y)| f64::from(x) * f64::from(y)).sum()
+}
+
+/// Sample `count` random KJV verses (deterministic seed) and build three
+/// queries per verse: the first, middle, and last `FRAGMENT_WORDS` words.
+///
+/// Acceptance for each fragment is every KJV verse whose whitespace-normalized
+/// text contains the fragment — common phrases legitimately live in several
+/// verses and any of them is a correct search result.
+fn generate_fragment_queries(db: &BibleDb, count: usize) -> Vec<GoldenQuery> {
+    let verses = db
+        .load_translation_verses_for_search(1)
+        .expect("load KJV verses for fragment sampling");
+
+    // Normalized text per verse, shared by fragment slicing and acceptance.
+    let normalized: Vec<(VerseKey, String)> = verses
+        .iter()
+        .map(|v| {
+            (
+                VerseKey { book_number: v.book_number, chapter: v.chapter, verse: v.verse },
+                v.text.split_whitespace().collect::<Vec<_>>().join(" "),
+            )
+        })
+        .collect();
+
+    let mut eligible: Vec<usize> = normalized
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, text))| text.split_whitespace().count() >= FRAGMENT_MIN_WORDS)
+        .map(|(i, _)| i)
+        .collect();
+
+    // Fisher-Yates with a fixed-seed xorshift so every run samples the same
+    // verses without pulling in a rand dependency.
+    let mut state = FRAGMENT_SEED;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let n = eligible.len();
+    for i in (1..n).rev() {
+        #[expect(clippy::cast_possible_truncation, reason = "index fits in usize")]
+        let j = (next() % (i as u64 + 1)) as usize;
+        eligible.swap(i, j);
+    }
+    eligible.truncate(count.min(n));
+
+    let mut queries = Vec::with_capacity(eligible.len() * 3);
+    for (sample_no, &vi) in eligible.iter().enumerate() {
+        let (_, text) = &normalized[vi];
+        let words: Vec<&str> = text.split_whitespace().collect();
+        let mid_start = (words.len() - FRAGMENT_WORDS) / 2;
+        let windows = [
+            ("frag_start", 0),
+            ("frag_middle", mid_start),
+            ("frag_end", words.len() - FRAGMENT_WORDS),
+        ];
+        for (category, start) in windows {
+            let fragment = words[start..start + FRAGMENT_WORDS].join(" ");
+            let accept: Vec<AcceptKey> = normalized
+                .iter()
+                .filter(|(_, t)| t.contains(&fragment))
+                .map(|(k, _)| AcceptKey {
+                    book_number: k.book_number,
+                    chapter: k.chapter,
+                    verse: k.verse,
+                })
+                .collect();
+            queries.push(GoldenQuery {
+                id: format!("{category}-{sample_no}"),
+                category: category.to_string(),
+                query: fragment,
+                accept,
+            });
+        }
+    }
+    queries
 }
 
 fn get_arg(args: &[String], flag: &str) -> Option<String> {


### PR DESCRIPTION
Two commits that raced the fast merges of #114/#115 (pushed moments after — thank you for the quick reviews!):

## perf: exact inner top-K bound on the FTS CTE (follow-up to #115)

An OR of very common words can match most of the corpus; materializing every row cost ~146ms worst-case vs ~92ms before #115. The CTE is now limited to the top `limit × TRANSLATION_FANOUT` ranked rows — still exact (with at most N translations per verse, the best row of each of the top-K unique verses sits within the top K×N rows), worst case back to ~104ms. **The hot tiers (phrase/AND — everything the live STT detection path uses) are unchanged at 1–3ms warm.**

| query | pre-#115 | #115 | this PR |
|---|---|---|---|
| phrase (live path tier 1) | 2.9 ms | 2.9 ms | 2.9 ms |
| AND (tier 2) | 1.1 ms | 1.1 ms | 1.1 ms |
| OR of 10 most-common words (tier 3 worst case) | 92 ms | 146 ms | 104 ms |

## bench: --fragments N mode (follow-up to #114)

Samples N random KJV verses (fixed seed, reproducible — any of the ~31k verses, not just famous ones) and generates three queries per verse: the **first, middle, and last 8 words**, matching how ministers actually quote mid-verse. Any verse containing the exact fragment counts as correct, so common phrases shared by several verses score fairly.

Baseline with `--fragments 34` (102 generated queries): FTS finds verbatim fragments at any position almost perfectly (R@1 0.94–0.97 for start/middle/end); vector search barely finds them (0.00–0.24); the current legacy fusion drags perfect FTS results down to 0.12–0.53 — more evidence for the RRF PR that follows.