### PR TITLE
feat(search): verbatim-first hybrid fusion (RRF) — fixes the wrong-verse ranking

### DIFF
--- a/src-tauri/crates/bible/src/search.rs
+++ b/src-tauri/crates/bible/src/search.rs
@@ -16,6 +16,10 @@ pub struct Bm25Result {
     pub book_name: String,
     pub chapter: i32,
     pub verse: i32,
+    /// True when the verse matched the exact-phrase tier — the query text
+    /// appears verbatim in the verse. Near-certain relevance for quoted
+    /// scripture; fusion gives these hits priority.
+    pub phrase_match: bool,
 }
 
 // ── Stop words ──────────────────────────────────────────────────────
@@ -170,6 +174,7 @@ fn run_fts_query(
                 book_name: row.get(2)?,
                 chapter: row.get(3)?,
                 verse: row.get(4)?,
+                phrase_match: false,
             })
         },
     )?;
@@ -258,6 +263,11 @@ impl BibleDb {
         let phrase = build_phrase_query(query);
         log::info!("[FTS5-BM25] Phrase: {phrase:?}");
         let mut all_results = run_fts_query(&conn, &phrase, fetch_limit)?;
+        for r in &mut all_results {
+            r.phrase_match = true;
+        }
+        // dedup_results keeps the FIRST occurrence per verse, so a verse
+        // found by both tier 1 and a later tier keeps phrase_match = true.
 
         // Tier 2: AND with stop words filtered (~5-20ms)
         if dedup_count(&all_results) < limit {

--- a/src-tauri/crates/detection/src/bin/search_bench.rs
+++ b/src-tauri/crates/detection/src/bin/search_bench.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use rhema_bible::BibleDb;
-use rhema_detection::fusion::{fuse, VerseKey};
+use rhema_detection::fusion::{fuse_rrf, VerseKey};
 use rhema_detection::semantic::embedder::TextEmbedder;
 use rhema_detection::semantic::index::VectorIndex;
 use rhema_detection::{HnswVectorIndex, OnnxEmbedder};
@@ -91,12 +91,17 @@ struct Tally {
     hits_at_1: usize,
     hits_at_5: usize,
     mrr_sum: f64,
+    latency_ms_sum: f64,
+    latency_ms_max: f64,
 }
 
 impl Tally {
-    /// Record one query given the rank (0-based) of the best accepted verse.
-    fn record(&mut self, best_rank: Option<usize>) {
+    /// Record one query given the rank (0-based) of the best accepted verse
+    /// and how long this mode took to produce its ranked list.
+    fn record(&mut self, best_rank: Option<usize>, latency_ms: f64) {
         self.queries += 1;
+        self.latency_ms_sum += latency_ms;
+        self.latency_ms_max = self.latency_ms_max.max(latency_ms);
         if let Some(rank) = best_rank {
             if rank == 0 {
                 self.hits_at_1 += 1;
@@ -113,12 +118,14 @@ impl Tally {
     }
 
     #[expect(clippy::cast_precision_loss, reason = "query counts are small")]
-    fn row(&self) -> (f64, f64, f64) {
+    fn row(&self) -> (f64, f64, f64, f64, f64) {
         let n = self.queries.max(1) as f64;
         (
             self.hits_at_1 as f64 / n,
             self.hits_at_5 as f64 / n,
             self.mrr_sum / n,
+            self.latency_ms_sum / n,
+            self.latency_ms_max,
         )
     }
 }
@@ -223,27 +230,37 @@ fn run_benchmark(
     for q in &golden.queries {
         let accepts: Vec<VerseKey> = q.accept.iter().map(|a| a.key()).collect();
 
+        let t0 = std::time::Instant::now();
         let fts_keys = fts_search(db, &q.query);
+        let fts_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        let t1 = std::time::Instant::now();
         let vector_hits = vector_search(db, embedder, index, &q.query, query_prefix);
-        let fused_keys: Vec<VerseKey> = fuse(&vector_hits, &fts_keys)
+        let vector_ms = t1.elapsed().as_secs_f64() * 1000.0;
+
+        let t2 = std::time::Instant::now();
+        let fused_keys: Vec<VerseKey> = fuse_rrf(&vector_hits, &fts_keys, K)
             .into_iter()
             .map(|h| h.key)
             .collect();
+        let fused_ms = fts_ms + vector_ms + t2.elapsed().as_secs_f64() * 1000.0;
         let vector_keys: Vec<VerseKey> = vector_hits.iter().map(|&(k, _)| k).collect();
 
-        for (mode, keys) in [
-            ("fts", &fts_keys),
-            ("vector", &vector_keys),
-            ("fused", &fused_keys),
+        for (mode, keys, latency_ms) in [
+            ("fts", &fts_keys, fts_ms),
+            ("vector", &vector_keys, vector_ms),
+            ("fused", &fused_keys, fused_ms),
         ] {
             let best = best_rank(keys, &accepts);
-            tallies.entry((q.category.clone(), mode)).or_default().record(best);
-            tallies.entry(("ALL".to_string(), mode)).or_default().record(best);
+            tallies.entry((q.category.clone(), mode)).or_default().record(best, latency_ms);
+            tallies.entry(("ALL".to_string(), mode)).or_default().record(best, latency_ms);
         }
         log::debug!("query {} done", q.id);
     }
 
     print_table(&tallies);
+    println!("\nNote: vector/fused latency is dominated by the one ONNX query embedding;");
+    println!("the live STT detection path never runs it (FTS-only).");
 }
 
 /// Vector-only run used by the query-format probe.
@@ -258,11 +275,13 @@ fn run_benchmark_vector_only(
     let mut tallies: HashMap<(String, &'static str), Tally> = HashMap::new();
     for q in &golden.queries {
         let accepts: Vec<VerseKey> = q.accept.iter().map(|a| a.key()).collect();
+        let t0 = std::time::Instant::now();
         let hits = vector_search(db, embedder, index, &q.query, query_prefix);
+        let latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
         let keys: Vec<VerseKey> = hits.iter().map(|&(k, _)| k).collect();
         let best = best_rank(&keys, &accepts);
-        tallies.entry((q.category.clone(), "vector")).or_default().record(best);
-        tallies.entry(("ALL".to_string(), "vector")).or_default().record(best);
+        tallies.entry((q.category.clone(), "vector")).or_default().record(best, latency_ms);
+        tallies.entry(("ALL".to_string(), "vector")).or_default().record(best, latency_ms);
     }
     println!("(query prefix mode: {mode_name})");
     print_table(&tallies);
@@ -317,16 +336,16 @@ fn print_table(tallies: &HashMap<(String, &'static str), Tally>) {
     categories.push(&all);
 
     println!(
-        "{:<16} {:<8} {:>4} {:>8} {:>8} {:>8}",
-        "category", "mode", "n", "R@1", "R@5", "MRR@10"
+        "{:<16} {:<8} {:>4} {:>8} {:>8} {:>8} {:>9} {:>9}",
+        "category", "mode", "n", "R@1", "R@5", "MRR@10", "avg ms", "max ms"
     );
     for cat in categories {
         for mode in ["fts", "vector", "fused"] {
             if let Some(t) = tallies.get(&(cat.clone(), mode)) {
-                let (r1, r5, mrr) = t.row();
+                let (r1, r5, mrr, avg_ms, max_ms) = t.row();
                 println!(
-                    "{:<16} {:<8} {:>4} {:>8.3} {:>8.3} {:>8.3}",
-                    cat, mode, t.queries, r1, r5, mrr
+                    "{:<16} {:<8} {:>4} {:>8.3} {:>8.3} {:>8.3} {:>9.1} {:>9.1}",
+                    cat, mode, t.queries, r1, r5, mrr, avg_ms, max_ms
                 );
             }
         }

--- a/src-tauri/crates/detection/src/bin/search_bench.rs
+++ b/src-tauri/crates/detection/src/bin/search_bench.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use rhema_bible::BibleDb;
-use rhema_detection::fusion::{fuse_rrf, VerseKey};
+use rhema_detection::fusion::{fuse_rrf, FtsCandidate, VerseKey};
 use rhema_detection::semantic::embedder::TextEmbedder;
 use rhema_detection::semantic::index::VectorIndex;
 use rhema_detection::{HnswVectorIndex, OnnxEmbedder};
@@ -231,7 +231,7 @@ fn run_benchmark(
         let accepts: Vec<VerseKey> = q.accept.iter().map(|a| a.key()).collect();
 
         let t0 = std::time::Instant::now();
-        let fts_keys = fts_search(db, &q.query);
+        let fts_candidates = fts_search(db, &q.query);
         let fts_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
         let t1 = std::time::Instant::now();
@@ -239,12 +239,13 @@ fn run_benchmark(
         let vector_ms = t1.elapsed().as_secs_f64() * 1000.0;
 
         let t2 = std::time::Instant::now();
-        let fused_keys: Vec<VerseKey> = fuse_rrf(&vector_hits, &fts_keys, K)
+        let fused_keys: Vec<VerseKey> = fuse_rrf(&vector_hits, &fts_candidates, K)
             .into_iter()
             .map(|h| h.key)
             .collect();
         let fused_ms = fts_ms + vector_ms + t2.elapsed().as_secs_f64() * 1000.0;
         let vector_keys: Vec<VerseKey> = vector_hits.iter().map(|&(k, _)| k).collect();
+        let fts_keys: Vec<VerseKey> = fts_candidates.iter().map(|&(k, _)| k).collect();
 
         for (mode, keys, latency_ms) in [
             ("fts", &fts_keys, fts_ms),
@@ -287,11 +288,16 @@ fn run_benchmark_vector_only(
     print_table(&tallies);
 }
 
-fn fts_search(db: &BibleDb, query: &str) -> Vec<VerseKey> {
+fn fts_search(db: &BibleDb, query: &str) -> Vec<FtsCandidate> {
     db.search_verses_bm25(query, K)
         .unwrap_or_default()
         .iter()
-        .map(|f| VerseKey { book_number: f.book_number, chapter: f.chapter, verse: f.verse })
+        .map(|f| {
+            (
+                VerseKey { book_number: f.book_number, chapter: f.chapter, verse: f.verse },
+                f.phrase_match,
+            )
+        })
         .collect()
 }
 

--- a/src-tauri/crates/detection/src/fusion.rs
+++ b/src-tauri/crates/detection/src/fusion.rs
@@ -55,33 +55,67 @@ pub struct FusedHit {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RrfHit {
     pub key: VerseKey,
-    /// Reciprocal-rank-fusion score — used for ordering only, not display.
+    /// Fusion score — used for ordering only, not display.
     pub score: f64,
     /// Cosine similarity when the vector engine found this verse.
     pub cosine: Option<f64>,
     /// True when the FTS5/BM25 engine found this verse.
     pub from_fts: bool,
+    /// True when the query text appears verbatim in this verse (FTS5
+    /// exact-phrase tier).
+    pub phrase_match: bool,
 }
 
-/// Merge vector hits with BM25-ranked FTS5 verse keys using Reciprocal Rank
-/// Fusion: `score(v) = Σ 1/(RRF_K + rank)` over both ranked lists (1-based
-/// ranks), so a verse found by BOTH engines sums two contributions and
-/// naturally outranks single-engine hits at comparable ranks. Engine scores
-/// participate only through their ranks — cosine similarities and synthetic
-/// BM25 confidences are never compared on one axis (the legacy fusion did,
-/// which let mediocre keyword-only hits bury the verse both engines agreed
-/// on).
+/// One FTS5 candidate for fusion: verse key + whether it matched the
+/// exact-phrase tier.
+pub type FtsCandidate = (VerseKey, bool);
+
+/// Score offset that puts exact-phrase matches above every possible RRF sum
+/// while preserving their BM25 order among themselves.
+const PHRASE_PRIORITY_BASE: f64 = 10.0;
+
+/// Merge vector hits with BM25-ranked FTS5 candidates.
+///
+/// Two rules, in order:
+///
+/// 1. **Verbatim wins.** FTS5 exact-phrase matches contain the query text
+///    word for word — for quoted scripture that is definitionally the right
+///    answer, so they take the top slots in BM25 order. (Measured: without
+///    this rule, rank fusion dropped verbatim-fragment R@1 from 0.97 to
+///    0.2-0.5, because two mediocre "agreement" votes on a wrong verse beat
+///    one correct top-rank vote whenever the weaker engine missed the verse.)
+/// 2. **Everything else fuses by Reciprocal Rank:**
+///    `score(v) = Σ 1/(RRF_K + rank)` over both ranked lists (1-based
+///    ranks), so a verse found by BOTH engines sums two contributions and
+///    outranks single-engine hits at comparable ranks. Engine scores
+///    participate only through their ranks — cosines and BM25 values are
+///    never compared on one axis (the legacy fusion did exactly that, which
+///    let fabricated keyword confidences bury the verse both engines agreed
+///    on).
 ///
 /// Vector candidates below `VECTOR_SIMILARITY_FLOOR` are dropped first.
-/// The result is sorted by fused score descending and truncated to `limit`.
+/// The result is sorted by score descending and truncated to `limit`.
 #[expect(clippy::cast_precision_loss, reason = "rank is small")]
 pub fn fuse_rrf(
     vector_hits: &[(VerseKey, f64)],
-    fts_keys: &[VerseKey],
+    fts_candidates: &[FtsCandidate],
     limit: usize,
 ) -> Vec<RrfHit> {
     let mut combined: Vec<RrfHit> = Vec::new();
     let mut index_of: HashMap<VerseKey, usize> = HashMap::new();
+
+    let mut entry_for = |combined: &mut Vec<RrfHit>, key: VerseKey| -> usize {
+        *index_of.entry(key).or_insert_with(|| {
+            combined.push(RrfHit {
+                key,
+                score: 0.0,
+                cosine: None,
+                from_fts: false,
+                phrase_match: false,
+            });
+            combined.len() - 1
+        })
+    };
 
     for (rank, &(key, cosine)) in vector_hits
         .iter()
@@ -89,27 +123,29 @@ pub fn fuse_rrf(
         .enumerate()
     {
         let contribution = 1.0 / (RRF_K + rank as f64 + 1.0);
-        let entry_index = *index_of.entry(key).or_insert_with(|| {
-            combined.push(RrfHit { key, score: 0.0, cosine: None, from_fts: false });
-            combined.len() - 1
-        });
-        let entry = &mut combined[entry_index];
+        let idx = entry_for(&mut combined, key);
+        let entry = &mut combined[idx];
         entry.score += contribution;
         // Duplicate keys cannot occur within one engine's list in practice;
         // keep the best cosine if they ever do.
         entry.cosine = Some(entry.cosine.map_or(cosine, |c: f64| c.max(cosine)));
     }
 
-    for (rank, &key) in fts_keys.iter().enumerate() {
+    for (rank, &(key, phrase_match)) in fts_candidates.iter().enumerate() {
         let contribution = 1.0 / (RRF_K + rank as f64 + 1.0);
-        let entry_index = *index_of.entry(key).or_insert_with(|| {
-            combined.push(RrfHit { key, score: 0.0, cosine: None, from_fts: false });
-            combined.len() - 1
-        });
-        let entry = &mut combined[entry_index];
+        let idx = entry_for(&mut combined, key);
+        let entry = &mut combined[idx];
         if !entry.from_fts {
             entry.score += contribution;
             entry.from_fts = true;
+        }
+        if phrase_match && !entry.phrase_match {
+            entry.phrase_match = true;
+            // Lift verbatim matches above every possible RRF sum, keeping
+            // their BM25 order among themselves. The per-rank step (0.1)
+            // exceeds the largest possible RRF sum (2/(RRF_K+1) ≈ 0.033),
+            // so vector votes can never reorder phrase matches.
+            entry.score += PHRASE_PRIORITY_BASE - rank as f64 * 0.1;
         }
     }
 
@@ -224,6 +260,14 @@ mod tests {
 
     // ── fuse_rrf ────────────────────────────────────────────────────
 
+    fn fts(k: VerseKey) -> FtsCandidate {
+        (k, false)
+    }
+
+    fn phrase(k: VerseKey) -> FtsCandidate {
+        (k, true)
+    }
+
     #[test]
     fn rrf_both_found_outranks_single_found_at_equal_ranks() {
         let both = key(43, 3, 16);
@@ -232,27 +276,12 @@ mod tests {
         // `both` is rank 2 in each list; the single-engine hits are rank 1.
         let fused = fuse_rrf(
             &[(vector_only, 0.70), (both, 0.65)],
-            &[fts_only, both],
+            &[fts(fts_only), fts(both)],
             10,
         );
         assert_eq!(fused[0].key, both);
         assert!(fused[0].from_fts);
         assert_eq!(fused[0].cosine, Some(0.65));
-    }
-
-    #[test]
-    fn rrf_exact_phrase_fts_top_hit_stays_on_top() {
-        // FTS rank 1 with no vector agreement anywhere: 1/(60+1) beats every
-        // deeper single-engine rank.
-        let fused = fuse_rrf(
-            &[(key(45, 5, 8), 0.72), (key(19, 23, 1), 0.60)],
-            &[key(43, 3, 16), key(1, 1, 1)],
-            10,
-        );
-        // Vector rank 1 ties FTS rank 1; both precede all rank-2 hits.
-        let top_two: Vec<VerseKey> = fused[..2].iter().map(|h| h.key).collect();
-        assert!(top_two.contains(&key(43, 3, 16)));
-        assert!(top_two.contains(&key(45, 5, 8)));
     }
 
     #[test]
@@ -276,7 +305,7 @@ mod tests {
     #[test]
     fn rrf_dedups_two_directionally() {
         let both = key(43, 3, 16);
-        let fused = fuse_rrf(&[(both, 0.65)], &[both], 10);
+        let fused = fuse_rrf(&[(both, 0.65)], &[fts(both)], 10);
         assert_eq!(fused.len(), 1);
         assert!((fused[0].score - 2.0 / 61.0).abs() < 1e-12);
         assert!(fused[0].from_fts);
@@ -285,8 +314,8 @@ mod tests {
 
     #[test]
     fn rrf_truncates_to_limit() {
-        let keys: Vec<VerseKey> = (1..=10).map(|v| key(1, 1, v)).collect();
-        let fused = fuse_rrf(&[], &keys, 3);
+        let candidates: Vec<FtsCandidate> = (1..=10).map(|v| fts(key(1, 1, v))).collect();
+        let fused = fuse_rrf(&[], &candidates, 3);
         assert_eq!(fused.len(), 3);
         assert_eq!(fused[0].key, key(1, 1, 1));
     }
@@ -294,5 +323,48 @@ mod tests {
     #[test]
     fn rrf_empty_inputs() {
         assert!(fuse_rrf(&[], &[], 10).is_empty());
+    }
+
+    #[test]
+    fn phrase_match_outranks_any_agreement() {
+        let verbatim = key(43, 3, 16);
+        let agreed_wrong = key(1, 1, 1);
+        // The wrong verse is rank 1 in the vector list AND rank 1 among
+        // non-phrase FTS hits — maximum possible RRF agreement. The verbatim
+        // match sits at FTS rank 2 with no vector support and must still win.
+        let fused = fuse_rrf(
+            &[(agreed_wrong, 0.80)],
+            &[fts(agreed_wrong), phrase(verbatim)],
+            10,
+        );
+        assert_eq!(fused[0].key, verbatim);
+        assert!(fused[0].phrase_match);
+        assert_eq!(fused[1].key, agreed_wrong);
+    }
+
+    #[test]
+    fn phrase_matches_keep_bm25_order_among_themselves() {
+        let first = key(43, 3, 16);
+        let second = key(45, 5, 8);
+        let third = key(1, 1, 1);
+        let fused = fuse_rrf(
+            // Vector prefers the third phrase match; BM25 order must hold.
+            &[(third, 0.95)],
+            &[phrase(first), phrase(second), phrase(third)],
+            10,
+        );
+        assert_eq!(fused[0].key, first);
+        assert_eq!(fused[1].key, second);
+        assert_eq!(fused[2].key, third);
+    }
+
+    #[test]
+    fn phrase_match_carries_cosine_when_vector_agrees() {
+        let verbatim = key(43, 3, 16);
+        let fused = fuse_rrf(&[(verbatim, 0.97)], &[phrase(verbatim)], 10);
+        assert_eq!(fused.len(), 1);
+        assert!(fused[0].phrase_match);
+        assert!(fused[0].from_fts);
+        assert_eq!(fused[0].cosine, Some(0.97));
     }
 }

--- a/src-tauri/crates/detection/src/fusion.rs
+++ b/src-tauri/crates/detection/src/fusion.rs
@@ -1,11 +1,11 @@
 //! Fusion of vector-similarity and FTS5/BM25 search results.
 //!
 //! Single source of truth for the hybrid-search score constants and the
-//! merge logic used by the `semantic_search` command. The current strategy
-//! assigns FTS5 hits a synthetic rank-derived confidence and sorts them
-//! against raw cosine similarities.
+//! merge logic used by the `semantic_search` command. The search path uses
+//! Reciprocal Rank Fusion ([`fuse_rrf`]); the legacy synthetic-confidence
+//! strategy ([`fuse`]) remains for the live-STT confidence ladder.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Confidence assigned to the best FTS5 BM25 match (rank 0).
 pub const FTS5_RANK0_CONFIDENCE: f64 = 0.75;
@@ -15,6 +15,16 @@ pub const FTS5_CONFIDENCE_DECAY: f64 = 0.04;
 
 /// FTS5 results below this confidence are not included.
 pub const FTS5_MIN_CONFIDENCE: f64 = 0.50;
+
+/// Reciprocal Rank Fusion constant: `score = Σ 1/(RRF_K + rank)` with
+/// 1-based ranks. 60 is the standard value from the original RRF paper and
+/// works well without tuning.
+pub const RRF_K: f64 = 60.0;
+
+/// Vector candidates below this cosine similarity are discarded before
+/// fusion — the brute-force index always returns k results, so the tail is
+/// noise on queries with no real semantic match.
+pub const VECTOR_SIMILARITY_FLOOR: f64 = 0.40;
 
 /// A unique verse reference across translations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -41,8 +51,78 @@ pub struct FusedHit {
     pub origin: FusedOrigin,
 }
 
+/// One entry in the RRF-fused result list.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RrfHit {
+    pub key: VerseKey,
+    /// Reciprocal-rank-fusion score — used for ordering only, not display.
+    pub score: f64,
+    /// Cosine similarity when the vector engine found this verse.
+    pub cosine: Option<f64>,
+    /// True when the FTS5/BM25 engine found this verse.
+    pub from_fts: bool,
+}
+
+/// Merge vector hits with BM25-ranked FTS5 verse keys using Reciprocal Rank
+/// Fusion: `score(v) = Σ 1/(RRF_K + rank)` over both ranked lists (1-based
+/// ranks), so a verse found by BOTH engines sums two contributions and
+/// naturally outranks single-engine hits at comparable ranks. Engine scores
+/// participate only through their ranks — cosine similarities and synthetic
+/// BM25 confidences are never compared on one axis (the legacy fusion did,
+/// which let mediocre keyword-only hits bury the verse both engines agreed
+/// on).
+///
+/// Vector candidates below `VECTOR_SIMILARITY_FLOOR` are dropped first.
+/// The result is sorted by fused score descending and truncated to `limit`.
+#[expect(clippy::cast_precision_loss, reason = "rank is small")]
+pub fn fuse_rrf(
+    vector_hits: &[(VerseKey, f64)],
+    fts_keys: &[VerseKey],
+    limit: usize,
+) -> Vec<RrfHit> {
+    let mut combined: Vec<RrfHit> = Vec::new();
+    let mut index_of: HashMap<VerseKey, usize> = HashMap::new();
+
+    for (rank, &(key, cosine)) in vector_hits
+        .iter()
+        .filter(|&&(_, sim)| sim >= VECTOR_SIMILARITY_FLOOR)
+        .enumerate()
+    {
+        let contribution = 1.0 / (RRF_K + rank as f64 + 1.0);
+        let entry_index = *index_of.entry(key).or_insert_with(|| {
+            combined.push(RrfHit { key, score: 0.0, cosine: None, from_fts: false });
+            combined.len() - 1
+        });
+        let entry = &mut combined[entry_index];
+        entry.score += contribution;
+        // Duplicate keys cannot occur within one engine's list in practice;
+        // keep the best cosine if they ever do.
+        entry.cosine = Some(entry.cosine.map_or(cosine, |c: f64| c.max(cosine)));
+    }
+
+    for (rank, &key) in fts_keys.iter().enumerate() {
+        let contribution = 1.0 / (RRF_K + rank as f64 + 1.0);
+        let entry_index = *index_of.entry(key).or_insert_with(|| {
+            combined.push(RrfHit { key, score: 0.0, cosine: None, from_fts: false });
+            combined.len() - 1
+        });
+        let entry = &mut combined[entry_index];
+        if !entry.from_fts {
+            entry.score += contribution;
+            entry.from_fts = true;
+        }
+    }
+
+    combined.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    combined.truncate(limit);
+    combined
+}
+
 /// Merge vector hits (verse key + cosine similarity) with BM25-ranked FTS5
 /// verse keys.
+///
+/// Legacy strategy: kept because its constants still drive the live-STT
+/// confidence ladder; the search UI path uses [`fuse_rrf`] instead.
 ///
 /// Vector hits keep their cosine similarity. FTS5 hits not already found by
 /// the vector search get a synthetic confidence of
@@ -140,5 +220,79 @@ mod tests {
     #[test]
     fn empty_inputs_produce_empty_output() {
         assert!(fuse(&[], &[]).is_empty());
+    }
+
+    // ── fuse_rrf ────────────────────────────────────────────────────
+
+    #[test]
+    fn rrf_both_found_outranks_single_found_at_equal_ranks() {
+        let both = key(43, 3, 16);
+        let vector_only = key(45, 5, 8);
+        let fts_only = key(1, 1, 1);
+        // `both` is rank 2 in each list; the single-engine hits are rank 1.
+        let fused = fuse_rrf(
+            &[(vector_only, 0.70), (both, 0.65)],
+            &[fts_only, both],
+            10,
+        );
+        assert_eq!(fused[0].key, both);
+        assert!(fused[0].from_fts);
+        assert_eq!(fused[0].cosine, Some(0.65));
+    }
+
+    #[test]
+    fn rrf_exact_phrase_fts_top_hit_stays_on_top() {
+        // FTS rank 1 with no vector agreement anywhere: 1/(60+1) beats every
+        // deeper single-engine rank.
+        let fused = fuse_rrf(
+            &[(key(45, 5, 8), 0.72), (key(19, 23, 1), 0.60)],
+            &[key(43, 3, 16), key(1, 1, 1)],
+            10,
+        );
+        // Vector rank 1 ties FTS rank 1; both precede all rank-2 hits.
+        let top_two: Vec<VerseKey> = fused[..2].iter().map(|h| h.key).collect();
+        assert!(top_two.contains(&key(43, 3, 16)));
+        assert!(top_two.contains(&key(45, 5, 8)));
+    }
+
+    #[test]
+    fn rrf_applies_cosine_floor() {
+        let junk = key(1, 1, 1);
+        let good = key(43, 3, 16);
+        let fused = fuse_rrf(&[(good, 0.62), (junk, 0.30)], &[], 10);
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].key, good);
+    }
+
+    #[test]
+    fn rrf_floor_shifts_later_vector_ranks_up() {
+        // A filtered-out candidate must not consume a rank position.
+        let fused = fuse_rrf(&[(key(1, 1, 1), 0.39), (key(43, 3, 16), 0.62)], &[], 10);
+        assert_eq!(fused.len(), 1);
+        // Rank 1 contribution, not rank 2.
+        assert!((fused[0].score - 1.0 / 61.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rrf_dedups_two_directionally() {
+        let both = key(43, 3, 16);
+        let fused = fuse_rrf(&[(both, 0.65)], &[both], 10);
+        assert_eq!(fused.len(), 1);
+        assert!((fused[0].score - 2.0 / 61.0).abs() < 1e-12);
+        assert!(fused[0].from_fts);
+        assert_eq!(fused[0].cosine, Some(0.65));
+    }
+
+    #[test]
+    fn rrf_truncates_to_limit() {
+        let keys: Vec<VerseKey> = (1..=10).map(|v| key(1, 1, v)).collect();
+        let fused = fuse_rrf(&[], &keys, 3);
+        assert_eq!(fused.len(), 3);
+        assert_eq!(fused[0].key, key(1, 1, 1));
+    }
+
+    #[test]
+    fn rrf_empty_inputs() {
+        assert!(fuse_rrf(&[], &[], 10).is_empty());
     }
 }

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -6,7 +6,8 @@ use serde::Serialize;
 use tauri::State;
 
 use rhema_detection::fusion::{
-    fuse_rrf, VerseKey, FTS5_CONFIDENCE_DECAY, FTS5_MIN_CONFIDENCE, FTS5_RANK0_CONFIDENCE,
+    fuse_rrf, FtsCandidate, VerseKey, FTS5_CONFIDENCE_DECAY, FTS5_MIN_CONFIDENCE,
+    FTS5_RANK0_CONFIDENCE,
 };
 use rhema_detection::{DetectionPipeline, MergedDetection, ReadingMode};
 
@@ -187,19 +188,24 @@ pub fn semantic_search(
         .collect();
 
     // FTS5 BM25 across all English translations
-    let fts_keys: Vec<VerseKey> = app_state
+    let fts_candidates: Vec<FtsCandidate> = app_state
         .bible_db
         .as_ref()
         .and_then(|db| db.search_verses_bm25(&query, depth).ok())
         .unwrap_or_default()
         .iter()
-        .map(|f| VerseKey { book_number: f.book_number, chapter: f.chapter, verse: f.verse })
+        .map(|f| {
+            (
+                VerseKey { book_number: f.book_number, chapter: f.chapter, verse: f.verse },
+                f.phrase_match,
+            )
+        })
         .collect();
 
-    // Rank by reciprocal rank fusion, then resolve each hit to the active
+    // Rank with verbatim-first fusion, then resolve each hit to the active
     // translation's text.
     #[expect(clippy::cast_precision_loss, reason = "rank is small")]
-    let results: Vec<SemanticSearchResult> = fuse_rrf(&vector_hits, &fts_keys, k)
+    let results: Vec<SemanticSearchResult> = fuse_rrf(&vector_hits, &fts_candidates, k)
         .into_iter()
         .enumerate()
         .filter_map(|(fts_rank, hit)| {

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -5,7 +5,9 @@ use std::sync::Mutex;
 use serde::Serialize;
 use tauri::State;
 
-use rhema_detection::fusion::{fuse, FusedOrigin, VerseKey};
+use rhema_detection::fusion::{
+    fuse_rrf, VerseKey, FTS5_CONFIDENCE_DECAY, FTS5_MIN_CONFIDENCE, FTS5_RANK0_CONFIDENCE,
+};
 use rhema_detection::{DetectionPipeline, MergedDetection, ReadingMode};
 
 use crate::state::AppState;
@@ -143,6 +145,8 @@ pub struct SemanticSearchResult {
     pub chapter: i32,
     pub verse: i32,
     pub similarity: f64,
+    /// Which engines found this verse: "semantic", "keyword", or both.
+    pub sources: Vec<String>,
 }
 
 #[tauri::command]
@@ -153,6 +157,10 @@ pub fn semantic_search(
     limit: Option<usize>,
 ) -> Result<Vec<SemanticSearchResult>, String> {
     let k = limit.unwrap_or(10);
+    // Fetch deeper candidate lists than the display limit: RRF rewards
+    // agreement between engines, so both lists need enough depth for the
+    // overlap to surface.
+    let depth = (3 * k).max(30);
 
     // Lock pipeline for vector search (may be slow if ONNX runs)
     let vector_results = {
@@ -160,39 +168,21 @@ pub fn semantic_search(
         if !pipeline.has_semantic() {
             return Err("Semantic search not available — model or embeddings not loaded".into());
         }
-        pipeline.semantic_search(&query, k)
+        pipeline.semantic_search(&query, depth)
     }; // Pipeline lock dropped
 
     // Lock AppState for DB lookups only (fast)
     let app_state = state.lock().map_err(|e| e.to_string())?;
 
-    let resolved_vector: Vec<SemanticSearchResult> = vector_results
+    let vector_hits: Vec<(VerseKey, f64)> = vector_results
         .into_iter()
         .filter_map(|(verse_id, similarity)| {
-            if let Some(ref db) = app_state.bible_db {
-                if let Ok(Some(v)) = db.get_verse_by_id(verse_id) {
-                    return Some(SemanticSearchResult {
-                        verse_ref: format!("{} {}:{}", v.book_name, v.chapter, v.verse),
-                        verse_text: v.text,
-                        book_name: v.book_name,
-                        book_number: v.book_number,
-                        chapter: v.chapter,
-                        verse: v.verse,
-                        similarity,
-                    });
-                }
-            }
-            None
-        })
-        .collect();
-
-    let vector_hits: Vec<(VerseKey, f64)> = resolved_vector
-        .iter()
-        .map(|r| {
-            (
-                VerseKey { book_number: r.book_number, chapter: r.chapter, verse: r.verse },
-                r.similarity,
-            )
+            let db = app_state.bible_db.as_ref()?;
+            let v = db.get_verse_by_id(verse_id).ok().flatten()?;
+            Some((
+                VerseKey { book_number: v.book_number, chapter: v.chapter, verse: v.verse },
+                similarity,
+            ))
         })
         .collect();
 
@@ -200,48 +190,58 @@ pub fn semantic_search(
     let fts_keys: Vec<VerseKey> = app_state
         .bible_db
         .as_ref()
-        .and_then(|db| db.search_verses_bm25(&query, k).ok())
+        .and_then(|db| db.search_verses_bm25(&query, depth).ok())
         .unwrap_or_default()
         .iter()
         .map(|f| VerseKey { book_number: f.book_number, chapter: f.chapter, verse: f.verse })
         .collect();
 
-    // Merge and order both result sets; resolve FTS5-only hits to the active
+    // Rank by reciprocal rank fusion, then resolve each hit to the active
     // translation's text.
-    let mut results: Vec<SemanticSearchResult> = Vec::new();
-    for hit in fuse(&vector_hits, &fts_keys) {
-        match hit.origin {
-            FusedOrigin::Vector => {
-                if let Some(r) = resolved_vector.iter().find(|r| {
-                    r.book_number == hit.key.book_number
-                        && r.chapter == hit.key.chapter
-                        && r.verse == hit.key.verse
-                }) {
-                    results.push(r.clone());
-                }
+    #[expect(clippy::cast_precision_loss, reason = "rank is small")]
+    let results: Vec<SemanticSearchResult> = fuse_rrf(&vector_hits, &fts_keys, k)
+        .into_iter()
+        .enumerate()
+        .filter_map(|(fts_rank, hit)| {
+            let db = app_state.bible_db.as_ref()?;
+            let v = db
+                .get_verse(
+                    app_state.active_translation_id,
+                    hit.key.book_number,
+                    hit.key.chapter,
+                    hit.key.verse,
+                )
+                .ok()
+                .flatten()?;
+
+            let mut sources = Vec::with_capacity(2);
+            if hit.cosine.is_some() {
+                sources.push("semantic".to_string());
             }
-            FusedOrigin::Fts5 => {
-                if let Some(ref db) = app_state.bible_db {
-                    if let Ok(Some(v)) = db.get_verse(
-                        app_state.active_translation_id,
-                        hit.key.book_number,
-                        hit.key.chapter,
-                        hit.key.verse,
-                    ) {
-                        results.push(SemanticSearchResult {
-                            verse_ref: format!("{} {}:{}", v.book_name, v.chapter, v.verse),
-                            verse_text: v.text,
-                            book_name: v.book_name,
-                            book_number: v.book_number,
-                            chapter: v.chapter,
-                            verse: v.verse,
-                            similarity: hit.score,
-                        });
-                    }
-                }
+            if hit.from_fts {
+                sources.push("keyword".to_string());
             }
-        }
-    }
+
+            // Display value only — ordering is the RRF score. Semantic hits
+            // show their real cosine; keyword-only hits keep the legacy
+            // rank-derived confidence until the UI grows source badges.
+            let similarity = hit.cosine.unwrap_or_else(|| {
+                (FTS5_RANK0_CONFIDENCE - fts_rank as f64 * FTS5_CONFIDENCE_DECAY)
+                    .max(FTS5_MIN_CONFIDENCE)
+            });
+
+            Some(SemanticSearchResult {
+                verse_ref: format!("{} {}:{}", v.book_name, v.chapter, v.verse),
+                verse_text: v.text,
+                book_name: v.book_name,
+                book_number: v.book_number,
+                chapter: v.chapter,
+                verse: v.verse,
+                similarity,
+                sources,
+            })
+        })
+        .collect();
 
     Ok(results)
 }

--- a/src/types/detection.ts
+++ b/src/types/detection.ts
@@ -36,6 +36,6 @@ export interface SemanticSearchResult {
   chapter: number
   verse: number
   similarity: number
-  /** Which engines found this verse: "reference", "semantic", or "keyword". */
+  /** Which engines found this verse: "reference", "semantic", and/or "keyword". */
   sources?: string[]
 }


### PR DESCRIPTION
Part of the search-accuracy series. **Stacked on #116** (retarget to main after it merges). This is the PR that fixes the reported "correct verse ranks 3rd/4th" behavior.

## The bug being replaced

The old fusion fabricated confidences for keyword hits (0.75, 0.71, 0.67…) and sorted them against raw cosines. A verse found by BOTH engines kept its lower cosine (~0.65), so wrong keyword-only hits outranked it — the correct verse sank to rank 3-4. Measured: exact-phrase queries scored R@1 1.000 on FTS alone but **0.100** after the shipped fusion.

## New fusion, two rules

1. **Verbatim wins.** FTS5 exact-phrase matches (the query text appears word for word in the verse) take the top slots in BM25 order. `Bm25Result` now carries a `phrase_match` flag from the tier-1 query. For a projection app, literal quoted scripture is definitionally the right answer.
2. **Everything else fuses by Reciprocal Rank** (k=60, 1-based ranks): `score(v) = Σ 1/(60+rank)` across both engines — agreement wins, and engine scores are never compared on one axis. Cosine floor 0.40 drops brute-force tail noise; candidate depth `max(30, 3×limit)` per engine.

Also: results now resolve to the **active translation** (semantic hits previously always displayed KJV text), and each result carries `sources: ["semantic"|"keyword"]` for the badges PR.

## Benchmark (152 queries incl. 102 random-verse fragments, with the regenerated embedding index)

| category | shipped fused R@1 | this PR fused R@1 | FTS-only |
|---|---|---|---|
| exact_phrase | 0.100 | **1.000** | 1.000 |
| frag_start/middle/end | 0.32/0.27/0.12 | **0.971 each** | 0.94-0.97 |
| partial_phrase | 0.400 | **1.000** | 1.000 |
| paraphrase (R@5) | 0.600 | **1.000** | 0.800 |
| **ALL R@1** | **0.474** | **0.829** | 0.836 |
| **ALL R@5** | 0.664 | **0.888** | 0.882 |

Thematic queries (n=10) remain slightly below FTS-only (R@1 0.2 vs 0.3) — the vector engine is weak at topic→verse; documented as the known trade-off for the big paraphrase gains.

## Speed

Fusion is a hashmap over ≤90 candidates — microseconds. The added latency vs FTS-only is the one ONNX query embedding (~170ms) that hybrid search always had; **the live STT detection path is untouched (FTS-only, 1-3ms)**.

## Testing

- 15 fusion unit tests (incl. adversarial: maximum RRF agreement on a wrong verse cannot outrank a verbatim match; vector votes cannot reorder phrase matches — this one caught a real bug during development)
- `cargo test --workspace`: 201 passing
- Full before/after benchmark runs recorded above