### PR TITLE
fix(embeddings): align precompute with the runtime embedder + provenance sidecar

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "quantize:model": "optimum-cli onnxruntime quantize --onnx_model models/qwen3-embedding-0.6b/ --arm64 -o models/qwen3-embedding-0.6b-int8/",
     "precompute:embeddings-onnx": "python3 data/precompute-embeddings-onnx.py",
     "precompute:embeddings-py": "python3 data/precompute-embeddings.py",
-    "precompute:embeddings": "cd src-tauri && cargo run -p rhema-detection --features precompute-bin --release --bin precompute -- --model ../models/qwen3-embedding-0.6b/model.onnx --tokenizer ../models/qwen3-embedding-0.6b/tokenizer.json --verses ../data/verses-for-embedding.json --output-embeddings ../embeddings/kjv-qwen3-0.6b.bin --output-ids ../embeddings/kjv-qwen3-0.6b-ids.bin",
+    "precompute:embeddings": "cd src-tauri && cargo run -p rhema-detection --features precompute-bin --release --bin precompute -- --model ../models/qwen3-embedding-0.6b-int8/model_quantized.onnx --tokenizer ../models/qwen3-embedding-0.6b/tokenizer.json --verses ../data/verses-for-embedding.json --output-embeddings ../embeddings/kjv-qwen3-0.6b.bin --output-ids ../embeddings/kjv-qwen3-0.6b-ids.bin",
     "bench:search": "cd src-tauri && cargo run -p rhema-detection --features bench-bin --release --bin search_bench",
     "download:whisper": "bun run data/download-whisper-model.ts",
     "download:ndi-sdk": "bun run data/download-ndi-sdk.ts",

--- a/src-tauri/crates/detection/src/bin/precompute.rs
+++ b/src-tauri/crates/detection/src/bin/precompute.rs
@@ -39,16 +39,18 @@ fn main() {
         std::fs::create_dir_all(parent).expect("Failed to create output directory");
     }
 
-    // Load the ONNX model with "passage: " prefix for document embedding
     log::info!("Loading ONNX model...");
-    let mut embedder = rhema_detection::OnnxEmbedder::load(
+    let embedder = rhema_detection::OnnxEmbedder::load(
         &PathBuf::from(&model_path),
         &PathBuf::from(&tokenizer_path),
     )
     .expect("Failed to load ONNX model");
 
-    // Use "passage: " prefix for verse embedding (Qwen3 uses asymmetric prefixes)
-    embedder.set_prompt_prefix("passage: ".to_string());
+    // No prompt prefix: verse and query embeddings must live in the same
+    // space, and the runtime embedder (semantic search + detection) embeds
+    // queries with no prefix. The previous "passage: " prefix (an E5-style
+    // convention that Qwen3-Embedding does not use) put documents and
+    // queries in mismatched spaces.
 
     log::info!(
         "Model loaded. Embedding dimension: {}",
@@ -84,7 +86,37 @@ fn main() {
     )
     .expect("Pre-computation failed");
 
+    write_meta_sidecar(&output_embeddings, &model_path, &verses.len());
+
     log::info!("=== Done! ===");
+}
+
+/// Write a provenance sidecar next to the embeddings so the app (and future
+/// regenerations) can tell how the index was built. The previous index
+/// shipped with no provenance and turned out not to match the runtime
+/// embedder at all (self-similarity 0.65 instead of ~1.0).
+fn write_meta_sidecar(output_embeddings: &str, model_path: &str, count: &usize) {
+    let meta_path = PathBuf::from(output_embeddings).with_extension("meta.json");
+    let model_file = PathBuf::from(model_path)
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let generated_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default();
+    let meta = serde_json::json!({
+        "model_file": model_file,
+        "prompt_prefix": "",
+        "pooling": "runtime OnnxEmbedder (sentence_embedding output, else masked mean)",
+        "verse_count": count,
+        "generated_at_unix": generated_at,
+        "generated_by": "cargo precompute bin",
+    });
+    match std::fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap_or_default()) {
+        Ok(()) => log::info!("Wrote provenance sidecar {}", meta_path.display()),
+        Err(e) => log::warn!("Failed to write provenance sidecar: {e}"),
+    }
 }
 
 fn get_arg(args: &[String], flag: &str) -> Option<String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,6 +132,7 @@ pub fn run() {
                             match rhema_detection::HnswVectorIndex::load(&embeddings_path, &ids_path, dim) {
                                 Ok(index) => {
                                     log::info!("Verse embeddings loaded ({} vectors)", index.len());
+                                    check_embedding_provenance(&embeddings_path, &model_path);
                                     pipeline.set_semantic(
                                         rhema_detection::SemanticDetector::new(
                                             Box::new(embedder),
@@ -159,4 +160,38 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// Compare the embeddings' provenance sidecar (written by the precompute
+/// bin) against the ONNX model actually loaded. A mismatched index silently
+/// wrecks vector-search accuracy — the shipped pre-2025 index scored
+/// cosine ~0.65 against its own verses because it was built with a
+/// different model/prefix than the runtime.
+fn check_embedding_provenance(embeddings_path: &std::path::Path, model_path: &std::path::Path) {
+    let meta_path = embeddings_path.with_extension("meta.json");
+    let Ok(raw) = std::fs::read_to_string(&meta_path) else {
+        log::warn!(
+            "No embeddings provenance sidecar at {} — cannot verify the index matches the model. \
+             Regenerate with 'bun run export:verses && bun run precompute:embeddings'.",
+            meta_path.display()
+        );
+        return;
+    };
+    let Ok(meta) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        log::warn!("Unreadable embeddings provenance sidecar at {}", meta_path.display());
+        return;
+    };
+    let index_model = meta.get("model_file").and_then(|v| v.as_str()).unwrap_or("");
+    let loaded_model = model_path
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    if index_model == loaded_model {
+        log::info!("Embeddings provenance OK (model: {loaded_model})");
+    } else {
+        log::warn!(
+            "Embeddings index was built with model {index_model:?} but the runtime loaded \
+             {loaded_model:?} — vector search accuracy will suffer. Regenerate the index."
+        );
+    }
 }


### PR DESCRIPTION
Part of the search-accuracy series. **The shipped verse-embedding index provably did not match the runtime embedder** — re-embedding a verse's own exact KJV text scored cosine 0.65–0.73 against its stored vector (should be ≈1.0) under every model/prefix combination. This is why vector search underperformed everywhere and why 60–65% similarity was (wrongly) considered normal for correct matches.

## Changes

- **precompute no longer prepends `"passage: "`** — an E5-style convention Qwen3-Embedding doesn't use. The runtime embeds queries with no prefix; documents and queries must share one space.
- **`precompute:embeddings` now uses the INT8 quantized model** — the same file the runtime prefers — so document and query vectors come from the identical model.
- **Provenance sidecar** (`embeddings/*.meta.json`: model file, prefix, pooling, count, timestamp) written by precompute and **checked by the app at startup**, which warns loudly when the index was built with a different model than the one loaded — exactly the silent failure that shipped last time.

## Action needed after merge (local, one time)

The `.bin` files are gitignored and generated locally. Anyone running the app should regenerate:

```
bun run export:verses && bun run precompute:embeddings
```

(~1.5–2.5h on CPU, one-off.) I've already regenerated on this machine and verified.

## Verification

Provenance probe (from #114's `search_bench --probe-prefix`), old vs regenerated index — cosine of a verse's own re-embedded text vs its stored vector:

| | old index | regenerated |
|---|---|---|
| mean self-similarity | 0.652 | **1.0000** |

Vector search quality (152-query benchmark): R@1 0.13 → **0.40** overall, 0.50 → **0.90** on exact phrases, and paraphrase fused R@5 reaches 1.000 in combination with #119.

If any release pipeline ever bundles `embeddings/*.bin`, that artifact must be regenerated too (currently generation is local-only; `ci-build.ts` Phase 6 is commented out).