### PR TITLE
fix(layout): 50/50 split between book search and detections panels

### DIFF
--- a/src/components/layout/dashboard.tsx
+++ b/src/components/layout/dashboard.tsx
@@ -41,8 +41,9 @@ export function Dashboard() {
         <LiveOutputPanel />
         <QueuePanel />
       </div>
-      {/* Row 3: Search + Detections (own grid, independent of top row columns) */}
-      <div className="col-span-4 grid min-h-0 grid-cols-[2fr_1fr] gap-3 px-3 pb-3">
+      {/* Row 3: Search + Detections, split 50/50 so the two-column
+          detections panel has room to breathe */}
+      <div className="col-span-4 grid min-h-0 grid-cols-2 gap-3 px-3 pb-3">
         <SearchPanel />
         <DetectionsPanel />
       </div>


### PR DESCRIPTION
The Recent Detections panel gained two columns (Direct / Semantic) in #118 and was cramped at 1/3 of the bottom row. The bottom row is now an even 50/50 split between the search panel and the detections panel.

One-line grid change: `grid-cols-[2fr_1fr]` → `grid-cols-2`.