### PR TITLE
fix(detections): new semantic batch replaces the old one instead of accumulating

### DIFF
--- a/src/stores/detection-store.test.ts
+++ b/src/stores/detection-store.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { useDetectionStore } from "./detection-store"
+import type { DetectionResult } from "@/types"
+
+function detection(overrides: Partial<DetectionResult>): DetectionResult {
+  return {
+    verse_ref: "John 3:16",
+    verse_text: "For God so loved the world",
+    book_name: "John",
+    book_number: 43,
+    chapter: 3,
+    verse: 16,
+    confidence: 0.75,
+    source: "semantic",
+    auto_queued: false,
+    transcript_snippet: "",
+    is_chapter_only: false,
+    ...overrides,
+  }
+}
+
+describe("detection store addDetections", () => {
+  beforeEach(() => {
+    useDetectionStore.setState({ detections: [] })
+  })
+
+  it("replaces the previous semantic batch with the new one", () => {
+    const store = useDetectionStore.getState()
+    store.addDetections([
+      detection({ verse_ref: "Hebrews 13:25", confidence: 0.75 }),
+      detection({ verse_ref: "Isaiah 53:5", confidence: 0.71 }),
+    ])
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Romans 3:1", confidence: 0.75 }),
+      detection({ verse_ref: "1 Corinthians 9:20", confidence: 0.71 }),
+    ])
+
+    const semantic = useDetectionStore
+      .getState()
+      .detections.filter((d) => d.source === "semantic")
+    expect(semantic.map((d) => d.verse_ref)).toEqual([
+      "Romans 3:1",
+      "1 Corinthians 9:20",
+    ])
+  })
+
+  it("keeps semantic batch in backend rank order, not confidence-resorted", () => {
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Romans 3:1", confidence: 0.71 }),
+      detection({ verse_ref: "1 Corinthians 9:20", confidence: 0.75 }),
+    ])
+
+    const refs = useDetectionStore.getState().detections.map((d) => d.verse_ref)
+    expect(refs).toEqual(["Romans 3:1", "1 Corinthians 9:20"])
+  })
+
+  it("preserves direct detection history across semantic batches", () => {
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Hebrews 12:14", source: "direct", confidence: 1.0 }),
+    ])
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Romans 3:1", confidence: 0.75 }),
+    ])
+
+    const detections = useDetectionStore.getState().detections
+    expect(detections.some((d) => d.verse_ref === "Hebrews 12:14")).toBe(true)
+    expect(detections.some((d) => d.verse_ref === "Romans 3:1")).toBe(true)
+  })
+
+  it("keeps the previous semantic batch when a direct-only batch arrives", () => {
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Romans 3:1", confidence: 0.75 }),
+    ])
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Hebrews 12:14", source: "direct", confidence: 1.0 }),
+    ])
+
+    const semantic = useDetectionStore
+      .getState()
+      .detections.filter((d) => d.source === "semantic")
+    expect(semantic.map((d) => d.verse_ref)).toEqual(["Romans 3:1"])
+  })
+
+  it("dedups direct detections by reference, newest first", () => {
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Hebrews 12:14", source: "direct", confidence: 0.9 }),
+      detection({ verse_ref: "John 3:16", source: "direct", confidence: 0.95 }),
+    ])
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Hebrews 12:14", source: "direct", confidence: 1.0 }),
+    ])
+
+    const direct = useDetectionStore
+      .getState()
+      .detections.filter((d) => d.source === "direct")
+    expect(direct.map((d) => d.verse_ref)).toEqual(["Hebrews 12:14", "John 3:16"])
+    expect(direct[0].confidence).toBe(1.0)
+  })
+})

--- a/src/stores/detection-store.ts
+++ b/src/stores/detection-store.ts
@@ -38,25 +38,33 @@ export const useDetectionStore = create<DetectionState>((set) => ({
     }),
   addDetections: (incoming) =>
     set((state) => {
-      const map = new Map<string, DetectionResult>()
-      // Incoming first — they take priority for recency/position
-      for (const d of incoming) {
-        const existing = map.get(d.verse_ref)
-        if (!existing || d.confidence > existing.confidence) {
-          map.set(d.verse_ref, d)
+      const incomingSemantic = incoming.filter((d) => d.source === "semantic")
+      const incomingDirect = incoming.filter((d) => d.source !== "semantic")
+
+      // Semantic detections are a fresh ranking for the LATEST utterance —
+      // a new batch replaces the previous one outright, in backend rank
+      // order. Accumulating batches let a stale hit sit above the newest
+      // ranking forever (same synthetic confidences, older entry wins).
+      const semantic =
+        incomingSemantic.length > 0
+          ? incomingSemantic.slice(0, 25)
+          : state.detections.filter((d) => d.source === "semantic")
+
+      // Direct detections are explicit spoken references — keep a recent
+      // history, deduped by reference, newest first.
+      const seen = new Set<string>()
+      const direct: DetectionResult[] = []
+      for (const d of [
+        ...incomingDirect,
+        ...state.detections.filter((x) => x.source !== "semantic"),
+      ]) {
+        if (!seen.has(d.verse_ref)) {
+          seen.add(d.verse_ref)
+          direct.push(d)
         }
       }
-      // Existing detections — keep if no duplicate, or if higher confidence than incoming
-      for (const d of state.detections) {
-        const existing = map.get(d.verse_ref)
-        if (!existing || d.confidence > existing.confidence) {
-          map.set(d.verse_ref, d)
-        }
-      }
-      // Sort by confidence so high-confidence direct detections appear above semantic
-      return { detections: [...map.values()]
-        .sort((a, b) => b.confidence - a.confidence)
-        .slice(0, 50) }
+
+      return { detections: [...direct.slice(0, 25), ...semantic] }
     }),
   setDetections: (detections) => set({ detections }),
   removeDetection: (verseRef) =>


### PR DESCRIPTION
From live testing: the preacher quoted *"Unto the Jew, I became as a Jew"* and the backend correctly ranked **1 Corinthians 9:20** in the fresh batch — but the Semantic column had accumulated 21 old detections, and since batches were merged and confidence-sorted (with synthetic 75/71/67% ladders), stale Hebrews/Isaiah hits from earlier utterances permanently outranked the new ones.

## Fix

- A new **semantic batch replaces the previous semantic list outright**, in backend rank order — the newest ranking is always at the top of the Semantic column.
- **Direct detections keep history** (deduped by reference, newest first) — explicit spoken references are worth keeping around.
- A direct-only batch does **not** clear the semantic list (the STT pipeline emits direct and semantic batches separately).

## Testing

- 5 new store tests (batch replacement, rank-order preservation, direct history, direct-only batches not clearing semantic, direct dedup); 142 vitest total passing
- tsc + eslint clean