### PR TITLE
debug(latency): unified [LAT] timeline from transcript to painted detection card

### DIFF
--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -105,6 +105,15 @@ pub fn detect_verses(
     Ok(results)
 }
 
+/// Frontend latency mark — logs a webview-side timestamp into the unified
+/// backend log so `[LAT]` timelines can be read from one file. `epoch_ms`
+/// is the webview's `Date.now()`; same machine, same clock as the backend's
+/// marks.
+#[tauri::command]
+pub fn ui_mark(label: String, epoch_ms: f64) {
+    log::info!("[LAT] ui {label} t={epoch_ms:.0}");
+}
+
 /// Check if semantic search is available
 #[tauri::command]
 pub fn detection_status(
@@ -143,6 +152,13 @@ pub fn semantic_search(
     query: String,
     limit: Option<usize>,
 ) -> Result<Vec<SemanticSearchResult>, String> {
+    // ONNX inference pages the whole quantized model into memory — log every
+    // invocation so RSS spikes and CPU stalls can be correlated with a caller.
+    log::info!(
+        "[LAT] semantic_search invoked t={} query_len={}",
+        super::stt::epoch_ms(),
+        query.len()
+    );
     let k = limit.unwrap_or(10);
     // Fetch deeper candidate lists than the display limit: RRF rewards
     // agreement between engines, so both lists need enough depth for the

--- a/src-tauri/src/commands/stt.rs
+++ b/src-tauri/src/commands/stt.rs
@@ -12,6 +12,16 @@ use crate::events::{
 };
 use crate::state::AppState;
 
+/// Epoch milliseconds — the shared clock for `[LAT]` latency marks. The
+/// frontend logs `Date.now()` through the `ui_mark` command, so backend and
+/// webview timestamps interleave comparably in one log.
+pub(crate) fn epoch_ms() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or_default()
+}
+
 /// Truncate a string to at most `max_bytes`, snapping to a valid UTF-8 char boundary.
 fn truncate_safe(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
@@ -346,6 +356,7 @@ pub async fn start_transcription(
         while let Some(transcript) = detect_rx.recv().await {
             let app_clone = det_app.clone();
             let _ = tokio::task::spawn_blocking(move || {
+                log::info!("[LAT] worker start t={} {:?}", epoch_ms(), truncate_safe(&transcript, 40));
                 let direct_found = run_direct_detection(&app_clone, &transcript);
                 check_reading_mode(&app_clone, &transcript, direct_found);
                 if direct_found {
@@ -371,6 +382,7 @@ pub async fn start_transcription(
                 TranscriptEvent::Partial { transcript, .. } => {
                     if !transcript.is_empty() {
                         let t0 = std::time::Instant::now();
+                        log::info!("[LAT] partial t={} {:?}", epoch_ms(), truncate_safe(&transcript, 60));
                         let _ = event_app.emit(
                             EVENT_TRANSCRIPT_PARTIAL,
                             TranscriptPayload {
@@ -394,6 +406,7 @@ pub async fn start_transcription(
                 } => {
                     if !transcript.is_empty() {
                         let t0 = std::time::Instant::now();
+                        log::info!("[LAT] final t={} {:?}", epoch_ms(), truncate_safe(&transcript, 60));
                         // Emit as permanent transcript segment IMMEDIATELY
                         // (never blocked by detection work)
                         let _ = event_app.emit(
@@ -523,6 +536,12 @@ fn run_direct_detection(app: &AppHandle, transcript: &str) -> bool {
         log::info!("[DET-DIRECT] Found: {} ({:.0}%)", r.verse_ref, r.confidence * 100.0);
     }
     drop(app_state);
+    log::info!(
+        "[LAT] emit verse_detections t={} src=direct n={} first={:?}",
+        epoch_ms(),
+        results.len(),
+        results.first().map(|r| r.verse_ref.as_str()).unwrap_or("")
+    );
     let _ = app.emit("verse_detections", &results);
     log::info!("[DET-DIRECT] Detection took {:?} for {:?}", t0.elapsed(), truncate_safe(transcript, 50));
     has_high_confidence
@@ -617,6 +636,12 @@ fn run_semantic_detection(app: &AppHandle, transcript: &str) {
         );
     }
     drop(app_state);
+    log::info!(
+        "[LAT] emit verse_detections t={} src=semantic n={} first={:?}",
+        epoch_ms(),
+        results.len(),
+        results.first().map(|r| r.verse_ref.as_str()).unwrap_or("")
+    );
     let _ = app.emit("verse_detections", &results);
     log::info!("[DET-SEMANTIC] Total: {:?}", t0.elapsed());
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
             commands::bible::set_active_translation,
             commands::detection::detect_verses,
             commands::detection::detection_status,
+            commands::detection::ui_mark,
             commands::detection::semantic_search,
             commands::detection::reading_mode_status,
             commands::detection::stop_reading_mode,

--- a/src/components/panels/detections-panel.tsx
+++ b/src/components/panels/detections-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { ConfidenceDot } from "@/components/ui/confidence-dot"
 import { Button } from "@/components/ui/button"
@@ -8,6 +8,7 @@ import { useDetection, detectionActions } from "@/hooks/use-detection"
 import { bibleActions } from "@/hooks/use-bible"
 import { useQueueStore, useBibleStore } from "@/stores"
 import { presentVerse } from "@/hooks/use-broadcast"
+import { mark } from "@/lib/latency-marks"
 import type { DetectionResult } from "@/types"
 
 const SOURCE_COLORS: Record<string, { text: string; label: string }> = {
@@ -130,6 +131,17 @@ function DetectionColumn({
 
 export function DetectionsPanel() {
   const { detections } = useDetection()
+
+  // Latency debugging: when the list changes, mark the React commit and the
+  // next animation frame (≈ actual pixels on screen).
+  useEffect(() => {
+    if (detections.length === 0) return
+    mark(
+      `detections-commit n=${detections.length} first=${detections[0]?.verse_ref ?? ""} src=${detections[0]?.source ?? "?"}`
+    )
+    const raf = requestAnimationFrame(() => mark("detections-paint"))
+    return () => cancelAnimationFrame(raf)
+  }, [detections])
 
   // Issue #104: direct (spoken references) and semantic (quoted text)
   // detections in separate columns, so a burst of direct hits doesn't push

--- a/src/components/panels/search-panel.tsx
+++ b/src/components/panels/search-panel.tsx
@@ -34,6 +34,7 @@ import { useBibleStore, useQueueStore } from "@/stores"
 import type { Book, Verse, SemanticSearchResult } from "@/types"
 import { Input } from "@/components/ui/input"
 import { searchContextWithFuse } from "@/lib/context-search"
+import { mark } from "@/lib/latency-marks"
 
 type SearchTab = "book" | "context"
 
@@ -206,7 +207,9 @@ export function SearchPanel() {
       applyNavigationSelection(book, navChapter)
 
       // Load chapter explicitly, then select + scroll to the verse.
+      mark(`nav loadChapter start ${bookNumber} ${navChapter}:${navVerse}`)
       bibleActions.loadChapter(bookNumber, navChapter).then((verses) => {
+        mark(`nav loadChapter done ${bookNumber} ${navChapter}:${navVerse} n=${verses.length}`)
         const target = verses.find((v) => v.verse === navVerse)
         if (target) {
           setSelectedVerseId(target.id)

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -16,6 +16,7 @@ import { useTauriEvent } from "@/hooks/use-tauri-event"
 import { useTranscription } from "@/hooks/use-transcription"
 import { bibleActions } from "@/hooks/use-bible"
 import { presentVerse } from "@/hooks/use-broadcast"
+import { mark, observeLongTasks } from "@/lib/latency-marks"
 import type { DetectionResult, ReadingAdvance } from "@/types"
 
 /**
@@ -63,6 +64,9 @@ export function TranscriptPanel() {
   const hasPartial = useTranscriptStore((s) => s.currentPartial.length > 0)
   const scrollRef = useRef<HTMLDivElement>(null)
 
+  // Latency debugging: surface main-thread stalls in the unified [LAT] log.
+  useEffect(() => observeLongTasks(), [])
+
   useTauriEvent<{ rms: number; peak: number }>("audio_level", (payload) => {
     useAudioStore.getState().setLevel(payload)
   })
@@ -78,7 +82,11 @@ export function TranscriptPanel() {
 
   // Listen for detection results from the backend (batch replaces previous detections)
   useTauriEvent<DetectionResult[]>("verse_detections", (detections) => {
+    mark(
+      `verse_detections received src=${detections[0]?.source ?? "?"} n=${detections.length} first=${detections[0]?.verse_ref ?? ""}`
+    )
     useDetectionStore.getState().addDetections(detections)
+    mark(`addDetections done src=${detections[0]?.source ?? "?"}`)
 
     // Auto-navigate book search + select verse for preview/live
     const directHit = detections.find(
@@ -181,6 +189,7 @@ export function TranscriptPanel() {
   // advances to a new verse (chapter commands, verse commands, text matching).
   // Does NOT add to queue — only direct/semantic feed the queue.
   useTauriEvent<ReadingAdvance>("reading_mode_verse", (advance) => {
+    mark(`reading_mode_verse received ${advance.reference ?? ""}`)
     if (advance.book_number > 0) {
       const advanceVerse = {
         id: 0,

--- a/src/hooks/use-broadcast.ts
+++ b/src/hooks/use-broadcast.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core"
+import { mark } from "@/lib/latency-marks"
 import { useBroadcastStore } from "@/stores/broadcast-store"
 import { useBibleStore } from "@/stores/bible-store"
 import type { VerseRenderData } from "@/types"
@@ -29,6 +30,7 @@ let presentSeq = 0
 export async function presentVerse(verse: Verse): Promise<void> {
   presentSeq += 1
   const ticket = presentSeq
+  mark(`presentVerse start ${verse.book_name} ${verse.chapter}:${verse.verse}`)
 
   let verseToPresent = verse
   try {
@@ -42,6 +44,7 @@ export async function presentVerse(verse: Verse): Promise<void> {
   } catch (e) {
     console.warn("[broadcast] get_verse refetch failed, using cached verse:", e)
   }
+  mark(`presentVerse get_verse done ${verse.book_name} ${verse.chapter}:${verse.verse}`)
 
   // A newer present started while we were refetching — let it win.
   if (ticket !== presentSeq) return
@@ -56,6 +59,7 @@ export async function presentVerse(verse: Verse): Promise<void> {
   useBroadcastStore
     .getState()
     .setLiveVerse(toVerseRenderData(verseToPresent, translation), verseToPresent)
+  mark(`presentVerse end ${verseToPresent.book_name} ${verseToPresent.chapter}:${verseToPresent.verse}`)
 }
 
 export const broadcastActions = {

--- a/src/hooks/use-transcription.ts
+++ b/src/hooks/use-transcription.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner"
 import { useAudioStore } from "@/stores/audio-store"
 import { useSettingsStore } from "@/stores/settings-store"
 import { useTranscriptStore } from "@/stores/transcript-store"
+import { mark } from "@/lib/latency-marks"
 import { useTauriEvent } from "./use-tauri-event"
 
 interface TranscriptPartialPayload {
@@ -103,10 +104,12 @@ export function useTranscription(options?: UseTranscriptionOptions) {
   })
 
   useTauriEvent<TranscriptPartialPayload>("transcript_partial", (payload) => {
+    mark(`transcript_partial received "${payload.text.slice(0, 30)}"`)
     useTranscriptStore.getState().setPartial(payload.text)
   })
 
   useTauriEvent<TranscriptPartialPayload>("transcript_final", (payload) => {
+    mark(`transcript_final received "${payload.text.slice(0, 30)}"`)
     useTranscriptStore.getState().addSegment({
       id: crypto.randomUUID(),
       text: payload.text,

--- a/src/lib/latency-marks.ts
+++ b/src/lib/latency-marks.ts
@@ -1,0 +1,46 @@
+import { invoke } from "@tauri-apps/api/core"
+
+/**
+ * Latency instrumentation for the detection → screen pipeline.
+ *
+ * Each mark logs to the webview console AND is forwarded to the backend
+ * (`ui_mark` command), which writes it into the same log stream as the
+ * backend's `[LAT]` marks. Both sides stamp epoch milliseconds from the
+ * same machine clock, so a single log file yields the full timeline:
+ * partial → final → worker → emit → ui receive → store → commit → paint.
+ */
+export function mark(label: string): void {
+  const t = Date.now()
+  console.log(`[LAT] ui ${label} t=${t}`)
+  // Defensive: never let instrumentation break the app (or tests that mock
+  // invoke without covering ui_mark).
+  try {
+    void Promise.resolve(invoke("ui_mark", { label, epochMs: t })).catch(() => {})
+  } catch {
+    // ignore — marks are best-effort
+  }
+}
+
+let longTasksObserved = false
+
+/**
+ * Report main-thread stalls (>50ms long tasks) into the latency log.
+ * Safari/WKWebView may not support the "longtask" entry type — in that
+ * case this is a silent no-op and the receive→paint marks still bound
+ * any render stall.
+ */
+export function observeLongTasks(): void {
+  if (longTasksObserved) return
+  longTasksObserved = true
+  if (typeof PerformanceObserver === "undefined") return
+  try {
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        mark(`longtask dur=${Math.round(entry.duration)}ms name=${entry.name}`)
+      }
+    })
+    observer.observe({ type: "longtask", buffered: false })
+  } catch {
+    // longtask not supported in this webview — receive→paint marks still apply
+  }
+}


### PR DESCRIPTION
**Do not merge yet** — instrumentation for the reported 3–5s delay between speaking a reference and the card appearing in Recent Detections (backend detection itself measures ~2ms, and semantic cards reportedly appear much faster than direct ones — so the delay must be measured, not assumed).

## What it adds

Every hop logs an epoch-ms `[LAT]` mark into **one log stream** (webview marks are forwarded through a new `ui_mark` command; both processes share the machine clock):

- **Backend:** partial/final transcript arrival, detection-worker start, `verse_detections` emit (labeled `src=direct|semantic`), and every `semantic_search` invocation (to correlate the unexplained 120→675MB RSS spikes)
- **Frontend:** event receive (labeled by source), store update, detections-panel React commit, next-frame **paint**, the direct-only cascade (`presentVerse` start/`get_verse`/end, `loadChapter` start/done, `reading_mode_verse`), transcript receive, and `longtask` main-thread stalls >50ms

## How to capture (Phase 2 of the plan)

1. Run `bun tauri dev` from this branch, start transcription
2. Speak **8–10 references in continuous flow** (reference then keep talking — no pause) plus 2–3 with a deliberate pause after
3. Also quote 2–3 verses (so semantic timelines are captured for comparison)
4. Send me the full terminal log — I'll build the per-reference timeline `partial → final → worker → emit → receive → commit → paint` and identify which hop owns the 3–5s

No behavior changes — marks are log lines only, each ≤1 per event, and `mark()` is fail-safe (cannot break the app).

## Testing
- `cargo build` + clippy clean, vitest 142/142, tsc clean