### PR TITLE
fix(broadcast): keep preview buttons in sync with the actual windows

### DIFF
--- a/src/components/broadcast/broadcast-settings.tsx
+++ b/src/components/broadcast/broadcast-settings.tsx
@@ -130,8 +130,15 @@ export function BroadcastSettings({
 
   const reconcilePreviewState = useCallback(async (outputId: string = "main") => {
     const label = outputId === "alt" ? "broadcast-alt" : "broadcast"
-    const windows = await getAllWindows()
-    return windows.some((w) => w.label === label)
+    try {
+      const windows = await getAllWindows()
+      const window = windows.find((w) => w.label === label)
+      // A window hidden for NDI still exists — only a visible one counts as
+      // an open preview.
+      return window ? await window.isVisible() : false
+    } catch {
+      return false
+    }
   }, [])
 
   const fetchMonitors = useCallback(async () => {
@@ -189,17 +196,24 @@ export function BroadcastSettings({
     syncNdiConfigToOutput,
   ])
 
+  // Keep the preview buttons in sync with the actual windows: reconcile when
+  // the dialog opens (the window may outlive a dialog close/reopen) and keep
+  // polling so an OS-level close of the projector flips the button back.
   useEffect(() => {
-    if (!open || !isPreviewOpen) return
+    if (!open) return
 
-    const intervalId = setInterval(() => {
-      void reconcilePreviewState()
-    }, 750)
+    const reconcileBoth = () => {
+      void reconcilePreviewState("main").then(setIsPreviewOpen)
+      void reconcilePreviewState("alt").then(setAltIsPreviewOpen)
+    }
+
+    reconcileBoth()
+    const intervalId = setInterval(reconcileBoth, 750)
 
     return () => {
       clearInterval(intervalId)
     }
-  }, [open, isPreviewOpen, reconcilePreviewState])
+  }, [open, reconcilePreviewState])
 
   const handleMainThemeChange = (id: string) => {
     setMainThemeId(id)


### PR DESCRIPTION
## Problem

Part of #123 — the "preview window cannot be closed" half.

The Open/Close Preview buttons track window state in `useState` that is never reconciled with the actual windows:

- `isPreviewOpen`/`altIsPreviewOpen` start `false` and are only written inside the toggle handlers. Close the Broadcast dialog and reopen it while a projector window is alive → the button reads "Open Preview", and clicking it re-invokes `open_broadcast_window` (which just re-shows the window). The close path is unreachable.
- The 750ms poll called `reconcilePreviewState()` but **discarded the result**, so it could never self-heal — and it only ran while the state already said "open".
- The existence check counted windows hidden for a still-running NDI session (`close_broadcast_window` hides instead of closing when NDI is active), which would report a hidden window as an open preview.

## Fix

- `reconcilePreviewState` now finds the window by label and returns `isVisible()` (false on missing window or error) — a hidden NDI window no longer counts as open.
- One effect, active while the dialog is open, reconciles **both** outputs immediately on dialog open and applies the result on every 750ms tick. An OS-level close of the projector window now flips the button back within a tick.

## Verification

- `bun run typecheck` exit 0; `bun run test` 142/142 passed.
- `eslint` on the file: 2 pre-existing errors, identical on baseline (verified via stash comparison) — no new findings.
- Manual (machine that runs local builds):
  1. Open Preview → close the Broadcast dialog → reopen it → button must read "Close Preview" and clicking it must close the projector window.
  2. Open Preview → close the projector via its OS close button → button flips back to "Open Preview" within ~750ms.
  3. Start NDI → Open Preview → Close Preview (window hides, NDI keeps sending) → button shows "Open Preview"; reopening shows the same window again.
  4. Repeat 1–2 for the Alternate Output card.