### PR TITLE
fix(broadcast): surface backend errors from the broadcast dialog as toasts

### DIFF
--- a/src/components/broadcast/broadcast-settings.tsx
+++ b/src/components/broadcast/broadcast-settings.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react"
+import { toast } from "sonner"
 import { invoke } from "@tauri-apps/api/core"
 import { emitTo, listen } from "@tauri-apps/api/event"
 import { availableMonitors, getAllWindows, type Monitor } from '@tauri-apps/api/window'
@@ -225,8 +226,9 @@ export function BroadcastSettings({
           useBroadcastStore.getState().syncBroadcastOutputFor("main")
         }, 150)
       }
-    } catch {
-      // Command may not exist yet
+    } catch (error) {
+      console.error("Failed to toggle preview window", error)
+      toast.error("Could not toggle preview window", { description: String(error) })
     }
   }
 
@@ -261,8 +263,11 @@ export function BroadcastSettings({
           syncNdiConfigToOutput("main", true, ndiFrameRate, ndiResolution)
         }, 300)
       }
-    } catch {
-      // Command may not exist yet
+    } catch (error) {
+      console.error("Failed to toggle NDI", error)
+      toast.error(ndiActive ? "Could not stop NDI" : "Could not start NDI", {
+        description: String(error),
+      })
     }
   }
 
@@ -316,7 +321,8 @@ export function BroadcastSettings({
         }, 150)
       }
     } catch (error) {
-      console.warn("Failed to toggle alt preview window", error)
+      console.error("Failed to toggle alt preview window", error)
+      toast.error("Could not toggle alt preview window", { description: String(error) })
     }
   }
 
@@ -352,7 +358,10 @@ export function BroadcastSettings({
         }, 300)
       }
     } catch (error) {
-      console.warn("Failed to toggle alt NDI", error)
+      console.error("Failed to toggle alt NDI", error)
+      toast.error(altNdiActive ? "Could not stop alt NDI" : "Could not start alt NDI", {
+        description: String(error),
+      })
     }
   }
 


### PR DESCRIPTION
## Problem

Part of #123 — the silent half. The preview/NDI toggle handlers in the Broadcast dialog swallow every backend error:

- `handleTogglePreview` / `handleToggleNdi`: empty `catch { // Command may not exist yet }` blocks (stale — all four commands exist and are registered).
- `handleAltTogglePreview` / `handleAltToggleNdi`: `console.warn` only.

So a real failure — "Monitor index N out of range", a window-creation error, NDI library not found — produces zero user feedback. The reporter of #123 saw the feature silently do nothing, with no explanation.

## Fix

Report failures with the sonner `toast.error("Title", { description })` pattern the codebase already uses (`use-transcription.ts`, `use-audio-test.ts`; `<Toaster />` is mounted in `App.tsx`), keeping `console.error` for debugging. NDI toasts distinguish start vs stop.

## Verification

- `bun run typecheck` exit 0; `bun run test` 142/142 passed; eslint on the file shows only the 2 pre-existing baseline errors.
- Manual: in the dev app, trigger a failing command — e.g. select a monitor, unplug it (without refreshing the list), click Open Preview; or from devtools run `window.__TAURI__.core.invoke("open_broadcast_window", { outputId: "main", monitorIndex: 99 })`-equivalent via the UI. Expect a "Could not toggle preview window" toast with the backend message instead of silence.
