### PR TITLE
fix(ndi): load the NDI runtime from bundled resources in release builds

### DIFF
--- a/src-tauri/crates/broadcast/src/ndi.rs
+++ b/src-tauri/crates/broadcast/src/ndi.rs
@@ -133,17 +133,27 @@ pub enum NdiError {
 #[derive(Default)]
 pub struct NdiRuntime {
     sessions: std::collections::HashMap<String, ActiveNdiSession>,
+    /// Directories searched (in order) for the NDI runtime library before the
+    /// compile-time dev fallback. In production this is the Tauri resource dir.
+    library_search_dirs: Vec<PathBuf>,
 }
 
 impl std::fmt::Debug for NdiRuntime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NdiRuntime")
             .field("active_sessions", &self.sessions.len())
+            .field("library_search_dirs", &self.library_search_dirs)
             .finish()
     }
 }
 
 impl NdiRuntime {
+    /// Set the directories searched for the NDI runtime library, in order of
+    /// preference. The compile-time dev checkout path stays as a fallback.
+    pub fn set_library_search_dirs(&mut self, dirs: Vec<PathBuf>) {
+        self.library_search_dirs = dirs;
+    }
+
     /// Check if a specific session is active.
     pub fn is_active(&self, session_id: &str) -> bool {
         self.sessions.contains_key(session_id)
@@ -166,7 +176,7 @@ impl NdiRuntime {
         }
 
         log::info!("NDI[{session_id}]: starting session '{}'", request.source_name);
-        let session = ActiveNdiSession::create(request)?;
+        let session = ActiveNdiSession::create(request, &self.library_search_dirs)?;
         let info = session.info.clone();
         log::info!(
             "NDI[{session_id}]: session active — {}x{} @ {}fps",
@@ -231,13 +241,16 @@ unsafe impl Sync for NdiRuntime {}
 
 impl ActiveNdiSession {
     #[expect(clippy::needless_pass_by_value, reason = "request fields are destructured and moved into the session")]
-    fn create(request: NdiStartRequest) -> Result<Self, NdiError> {
+    fn create(request: NdiStartRequest, library_search_dirs: &[PathBuf]) -> Result<Self, NdiError> {
         let source_name = request.source_name.trim().to_string();
         if source_name.is_empty() {
             return Err(NdiError::EmptySourceName);
         }
 
-        let library_path = resolve_library_path()?;
+        let mut search_dirs = library_search_dirs.to_vec();
+        search_dirs.push(dev_fallback_dir());
+        let library_path = resolve_library_path(&search_dirs)?;
+        log::info!("NDI: loading runtime library from {}", library_path.display());
         // SAFETY: library_path was validated to exist by resolve_library_path()
         let library = unsafe { Library::new(&library_path) }
             .map_err(|e| NdiError::LibraryLoad(e.to_string()))?;
@@ -384,31 +397,42 @@ impl Drop for ActiveNdiSession {
     }
 }
 
-fn resolve_library_path() -> Result<PathBuf, NdiError> {
-    let candidates: Vec<&str> = if cfg!(target_os = "macos") {
-        vec!["sdk/ndi/macos/libndi.dylib"]
+/// Relative locations of the NDI runtime library for the current OS. The same
+/// layout is used by the repo checkout (`sdk/…` at the workspace root) and by
+/// the bundled app (`sdk/…` inside the Tauri resource dir).
+fn library_candidates() -> &'static [&'static str] {
+    if cfg!(target_os = "macos") {
+        &["sdk/ndi/macos/libndi.dylib"]
     } else if cfg!(target_os = "windows") {
-        vec!["sdk/ndi/windows/Processing.NDI.Lib.x64.dll"]
+        &["sdk/ndi/windows/Processing.NDI.Lib.x64.dll"]
     } else {
-        vec![
+        &[
             "sdk/ndi/linux/libndi.so",
             "sdk/ndi/linux/x86_64/libndi.so.6",
             "sdk/ndi/linux/libndi.so.6",
         ]
-    };
+    }
+}
 
-    let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
-    for candidate in &candidates {
-        if candidate.is_empty() {
-            continue;
-        }
-        let absolute = base.join(candidate);
-        if absolute.exists() {
-            return Ok(absolute);
+/// Dev fallback: the workspace root of a source checkout. Only meaningful on
+/// the machine the binary was compiled on.
+fn dev_fallback_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..")
+}
+
+fn resolve_library_path(search_dirs: &[PathBuf]) -> Result<PathBuf, NdiError> {
+    let mut attempted = Vec::new();
+    for base in search_dirs {
+        for candidate in library_candidates() {
+            let absolute = base.join(candidate);
+            if absolute.exists() {
+                return Ok(absolute);
+            }
+            attempted.push(absolute.display().to_string());
         }
     }
 
-    Err(NdiError::LibraryNotFound(candidates.join(", ")))
+    Err(NdiError::LibraryNotFound(attempted.join(", ")))
 }
 
 fn load_symbol<'a, T>(
@@ -421,4 +445,64 @@ fn load_symbol<'a, T>(
         symbol: name,
         message: e.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unique per-test scratch dir, removed on drop.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir()
+                .join(format!("rhema-ndi-test-{tag}-{}", std::process::id()));
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn plant_library(base: &Path) -> PathBuf {
+        let path = base.join(library_candidates()[0]);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"stub").unwrap();
+        path
+    }
+
+    #[test]
+    fn resolves_library_from_search_dir() {
+        let dir = TempDir::new("resolve");
+        let planted = plant_library(&dir.0);
+        let resolved = resolve_library_path(std::slice::from_ref(&dir.0)).unwrap();
+        assert_eq!(resolved, planted);
+    }
+
+    #[test]
+    fn earlier_search_dirs_win() {
+        let first = TempDir::new("first");
+        let second = TempDir::new("second");
+        let planted_first = plant_library(&first.0);
+        let _planted_second = plant_library(&second.0);
+        let resolved = resolve_library_path(&[first.0.clone(), second.0.clone()]).unwrap();
+        assert_eq!(resolved, planted_first);
+    }
+
+    #[test]
+    fn missing_library_reports_attempted_paths() {
+        let dir = TempDir::new("missing");
+        let err = resolve_library_path(std::slice::from_ref(&dir.0)).unwrap_err();
+        match err {
+            NdiError::LibraryNotFound(paths) => {
+                assert!(paths.contains(dir.0.to_str().unwrap()), "attempted paths: {paths}");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,6 +72,14 @@ pub fn run() {
 
             memstats::spawn();
 
+            // Point the NDI runtime at the bundled resource dir (production).
+            // The source-checkout path stays as a fallback inside the crate.
+            if let Ok(resource_dir) = app.path().resource_dir() {
+                let managed_ndi = app.state::<Mutex<rhema_broadcast::ndi::NdiRuntime>>();
+                let mut ndi = managed_ndi.lock().unwrap();
+                ndi.set_library_search_dirs(vec![resource_dir]);
+            }
+
             // Try resource dir first (production), then dev fallback
             let db_path = app
                 .path()

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "resources": {
+      "../data/rhema.db": "rhema.db",
+      "../sdk/ndi/linux/libndi.so": "sdk/ndi/linux/libndi.so"
+    }
+  }
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "resources": {
+      "../data/rhema.db": "rhema.db",
+      "../sdk/ndi/macos/libndi.dylib": "sdk/ndi/macos/libndi.dylib"
+    }
+  }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "resources": {
+      "../data/rhema.db": "rhema.db",
+      "../sdk/ndi/windows/Processing.NDI.Lib.x64.dll": "sdk/ndi/windows/Processing.NDI.Lib.x64.dll"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

NDI output can never work in an installed/released build. `resolve_library_path()` in `crates/broadcast/src/ndi.rs` located the runtime library only via `env!("CARGO_MANIFEST_DIR")` — a **compile-time** path pointing at the workspace of the machine that built the binary (e.g. a CI runner). On a user's machine that path doesn't exist, and `tauri.conf.json` bundled only `rhema.db`, so `start_ndi` always failed with `LibraryNotFound`. Only source checkouts worked. Related to the Broadcast/NDI area of #123.

## Fix

Mirrors the resource-dir-first / dev-fallback pattern `lib.rs` already uses for the Bible database:

- `NdiRuntime` gains `library_search_dirs` (+ setter), tried in order before the dev-checkout fallback; app setup points it at `app.path().resource_dir()`.
- New platform-specific Tauri configs (`tauri.windows.conf.json` / `.macos.` / `.linux.`) bundle the matching runtime library under the same `sdk/ndi/...` layout the resolver expects, so each installer ships only its own library (they also restate the `rhema.db` resource so the merge result is correct regardless of merge semantics).
- `LibraryNotFound` now reports every attempted path, and the chosen library path is logged at session start — no more guessing why NDI didn't come up.

## Verification

- New unit tests for the resolver (`cargo test -p rhema-broadcast`, 3/3 pass): finds the library in a search dir, earlier dirs take precedence, and the not-found error lists the attempted paths.
- `cargo check` and clippy clean.
- Dev behavior unchanged: with empty search dirs the dev fallback resolves `sdk/ndi/<os>/...` from the source checkout as before.
- Manual (release): `bun tauri build`, install the bundle, start NDI → the log should show `NDI: loading runtime library from <resource dir>\sdk\ndi\windows\Processing.NDI.Lib.x64.dll` and an NDI receiver (e.g. Studio Monitor) should see the source. Also confirm the installer payload contains `sdk/ndi/windows/Processing.NDI.Lib.x64.dll` and `rhema.db`.