### PR TITLE
fix(dev): keep the vite watcher out of multi-GB non-frontend dirs

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,20 @@ export default defineConfig({
   server: {
     port: 3000,
     strictPort: true,
+    watch: {
+      // Keep the watcher out of multi-GB non-frontend dirs (Rust build
+      // artifacts, ONNX models, NDI SDK). Crawling them blocks the dev
+      // server's event loop for minutes on Windows, so the app windows
+      // load before Vite can respond and stay white.
+      ignored: [
+        "**/src-tauri/**",
+        "**/models/**",
+        "**/embeddings/**",
+        "**/sdk/**",
+        "**/data/**",
+        "**/build/**",
+      ],
+    },
   },
   build: {
     outDir: "build",


### PR DESCRIPTION
## Problem

`vite.config.ts` has no `server.watch.ignored`, so the dev server watches the entire repo root — including **20+ GB** of `src-tauri` build artifacts, **3.6 GB** of ONNX models, embeddings, the NDI SDK, and the build output. On Windows the initial watcher crawl blocks the node event loop for **minutes** (measured: 549 CPU-seconds burned, port-3000 connections stuck in `CloseWait`, requests timing out). The Tauri app windows load during that outage, get no response from the dev server, and stay **white** — the long-standing white-window-on-startup symptom reported in #77, and a big part of why Windows dev appeared broken while "it works on MacBooks" (FSEvents makes the crawl cheap on macOS).

## Fix

Add watcher ignores for the non-frontend directories, as the official Tauri + Vite template does for `src-tauri`:

```ts
watch: { ignored: ["**/src-tauri/**", "**/models/**", "**/embeddings/**", "**/sdk/**", "**/data/**", "**/build/**"] }
```

## Verification (measured on Windows 11)

- Before: after `bun run tauri dev`, HTTP probes to `localhost:3000` timed out for minutes; both app windows white on first load; node at 549 CPU-seconds.
- After: dev server answers within seconds of "VITE ready", and the app window renders the full UI on first load (screenshot-verified).
- `bun run typecheck` passes; config-only change, no effect on production builds (`build.rollupOptions` untouched).