### PR TITLE
feat(logging): persistent log file and broadcast diagnostics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@tauri-apps/plugin-dialog": "~2",
         "@tauri-apps/plugin-fs": "~2",
         "@tauri-apps/plugin-global-shortcut": "~2",
-        "@tauri-apps/plugin-log": "~2",
+        "@tauri-apps/plugin-log": "^2.9.0",
         "@tauri-apps/plugin-opener": "^2.5.3",
         "@tauri-apps/plugin-store": "~2",
         "@types/bun": "^1.3.14",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@tauri-apps/plugin-dialog": "~2",
     "@tauri-apps/plugin-fs": "~2",
     "@tauri-apps/plugin-global-shortcut": "~2",
-    "@tauri-apps/plugin-log": "~2",
+    "@tauri-apps/plugin-log": "^2.9.0",
     "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-store": "~2",
     "@types/bun": "^1.3.14",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "store:default",
     "dialog:default",
     "fs:default",
-    "fs:allow-write-text-file"
+    "fs:allow-write-text-file",
+    "log:default"
   ]
 }

--- a/src-tauri/crates/broadcast/src/ndi.rs
+++ b/src-tauri/crates/broadcast/src/ndi.rs
@@ -281,6 +281,10 @@ impl ActiveNdiSession {
         let create_ptr = std::ptr::from_ref(&create);
         let sender = unsafe { send_create_fn(create_ptr) };
         if sender.is_null() {
+            let os_err = std::io::Error::last_os_error();
+            log::error!(
+                "NDI: NDIlib_send_create returned null for '{source_name}' (last OS error: {os_err})"
+            );
             // SAFETY: NDI was initialized successfully above, so ndi_destroy is safe to call
             unsafe { ndi_destroy_fn() };
             return Err(NdiError::SenderCreateFailed);

--- a/src-tauri/src/commands/broadcast.rs
+++ b/src-tauri/src/commands/broadcast.rs
@@ -39,7 +39,11 @@ pub struct NdiFrameRequest {
 
 #[tauri::command]
 pub fn list_monitors(app: tauri::AppHandle) -> Result<Vec<MonitorInfo>, String> {
-    let monitors = app.available_monitors().map_err(|e| e.to_string())?;
+    let monitors = app.available_monitors().map_err(|e| {
+        log::error!("list_monitors: available_monitors failed: {e}");
+        e.to_string()
+    })?;
+    log::info!("list_monitors: {} monitor(s) detected", monitors.len());
     Ok(monitors
         .iter()
         .map(|m| {
@@ -87,14 +91,31 @@ pub async fn open_broadcast_window(
     output_id: String,
     monitor_index: usize,
 ) -> Result<(), String> {
+    log::info!("open_broadcast_window: output={output_id}, monitor_index={monitor_index}");
     let label = window_label(&output_id);
-    let monitors = app.available_monitors().map_err(|e| e.to_string())?;
-    let monitor = monitors
-        .get(monitor_index)
-        .ok_or_else(|| format!("Monitor index {monitor_index} out of range"))?;
+    let monitors = app.available_monitors().map_err(|e| {
+        log::error!("open_broadcast_window: available_monitors failed: {e}");
+        e.to_string()
+    })?;
+    let monitor = monitors.get(monitor_index).ok_or_else(|| {
+        let msg = format!(
+            "Monitor index {monitor_index} out of range ({} available)",
+            monitors.len()
+        );
+        log::error!("open_broadcast_window: {msg}");
+        msg
+    })?;
 
     let pos = monitor.position();
     let size = monitor.size();
+    log::info!(
+        "open_broadcast_window: target monitor pos=({},{}) size={}x{} scale={}",
+        pos.x,
+        pos.y,
+        size.width,
+        size.height,
+        monitor.scale_factor()
+    );
 
     // Reuse the window if it already exists (e.g. hidden for NDI), otherwise
     // create it hidden and without geometry: the builder's position/inner_size
@@ -103,8 +124,10 @@ pub async fn open_broadcast_window(
     // runs 125-150%), pushing the window off the target monitor. Physical
     // setters after the fact are unambiguous on both paths.
     let window = if let Some(window) = app.get_webview_window(label) {
+        log::info!("open_broadcast_window: reusing existing window '{label}'");
         window
     } else {
+        log::info!("open_broadcast_window: creating window '{label}'");
         let title = if output_id == "alt" {
             "Projector - Alt"
         } else {
@@ -122,7 +145,10 @@ pub async fn open_broadcast_window(
         .skip_taskbar(false)
         .focused(false)
         .build()
-        .map_err(|e| e.to_string())?
+        .map_err(|e| {
+            log::error!("open_broadcast_window: window build failed: {e}");
+            e.to_string()
+        })?
     };
 
     window
@@ -130,18 +156,28 @@ pub async fn open_broadcast_window(
             x: pos.x,
             y: pos.y,
         }))
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            log::error!("open_broadcast_window: set_position failed: {e}");
+            e.to_string()
+        })?;
     window
         .set_size(tauri::Size::Physical(tauri::PhysicalSize {
             width: size.width,
             height: size.height,
         }))
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            log::error!("open_broadcast_window: set_size failed: {e}");
+            e.to_string()
+        })?;
     // A window created hidden for NDI has skip_taskbar(true); make sure the
     // visible projector is reachable from the taskbar either way.
     let _ = window.set_skip_taskbar(false);
-    window.show().map_err(|e| e.to_string())?;
+    window.show().map_err(|e| {
+        log::error!("open_broadcast_window: show failed: {e}");
+        e.to_string()
+    })?;
     let _ = window.set_focus();
+    log::info!("open_broadcast_window: '{label}' shown at ({},{}) {}x{}", pos.x, pos.y, size.width, size.height);
 
     Ok(())
 }
@@ -161,10 +197,20 @@ pub async fn close_broadcast_window(
             .map_err(|e| e.to_string())?
             .is_active(&output_id);
         if ndi_active {
-            window.hide().map_err(|e| e.to_string())?;
+            log::info!("close_broadcast_window: NDI active for '{output_id}', hiding window instead of closing");
+            window.hide().map_err(|e| {
+                log::error!("close_broadcast_window: hide failed: {e}");
+                e.to_string()
+            })?;
         } else {
-            window.close().map_err(|e| e.to_string())?;
+            log::info!("close_broadcast_window: closing '{output_id}' window");
+            window.close().map_err(|e| {
+                log::error!("close_broadcast_window: close failed: {e}");
+                e.to_string()
+            })?;
         }
+    } else {
+        log::info!("close_broadcast_window: no '{output_id}' window to close");
     }
     Ok(())
 }
@@ -176,9 +222,10 @@ pub fn start_ndi(
     request: NdiStartRequest,
 ) -> Result<NdiSessionInfo, String> {
     let mut runtime = runtime.lock().map_err(|e| e.to_string())?;
-    runtime
-        .start(output_id, request)
-        .map_err(|e| e.to_string())
+    runtime.start(output_id, request).map_err(|e| {
+        log::error!("start_ndi failed: {e}");
+        e.to_string()
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,13 @@ pub fn run() {
         .plugin(
             tauri_plugin_log::Builder::new()
                 .level(tauri_plugin_log::log::LevelFilter::Info)
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
+                        file_name: Some("rhema".into()),
+                    }),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
+                ])
                 .build(),
         )
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())

--- a/src/components/broadcast/broadcast-settings.tsx
+++ b/src/components/broadcast/broadcast-settings.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react"
 import { toast } from "sonner"
+import { info as logInfo, error as logError } from "@tauri-apps/plugin-log"
 import { invoke } from "@tauri-apps/api/core"
 import { emitTo, listen } from "@tauri-apps/api/event"
 import { availableMonitors, getAllWindows, type Monitor } from '@tauri-apps/api/window'
@@ -146,12 +147,18 @@ export function BroadcastSettings({
     setRefreshing(true)
     try {
       const result = await availableMonitors()
+      void logInfo(
+        `[broadcast-ui] availableMonitors -> ${result.length}: ${result
+          .map((m) => `${m.name ?? "?"} ${m.size.width}x${m.size.height}`)
+          .join(", ")}`,
+      )
       setMonitors(result)
       if (result.length > 0 && selectedMonitor === "0") {
         setSelectedMonitor("0")
       }
-    } catch {
-      // Tauri command may not exist yet — use placeholder
+    } catch (error) {
+      void logError(`[broadcast-ui] availableMonitors FAILED: ${String(error)}`)
+      toast.error("Could not list monitors", { description: String(error) })
       setMonitors([])
     } finally {
       setRefreshing(false)
@@ -222,6 +229,9 @@ export function BroadcastSettings({
   }
 
   const handleTogglePreview = async () => {
+    void logInfo(
+      `[broadcast-ui] Open/Close Preview clicked: isPreviewOpen=${isPreviewOpen}, monitor=${selectedMonitor}, monitors=${monitors.length}`,
+    )
     try {
       if (isPreviewOpen) {
         await invoke("close_broadcast_window", { outputId: "main" })
@@ -232,6 +242,7 @@ export function BroadcastSettings({
           monitorIndex: Number(selectedMonitor),
         })
         const opened = await reconcilePreviewState("main")
+        void logInfo(`[broadcast-ui] open_broadcast_window ok, visible=${opened}`)
         setIsPreviewOpen(opened)
         if (!opened) return
         useBroadcastStore.getState().syncBroadcastOutputFor("main")
@@ -241,12 +252,14 @@ export function BroadcastSettings({
         }, 150)
       }
     } catch (error) {
+      void logError(`[broadcast-ui] toggle preview FAILED: ${String(error)}`)
       console.error("Failed to toggle preview window", error)
       toast.error("Could not toggle preview window", { description: String(error) })
     }
   }
 
   const handleToggleNdi = async () => {
+    void logInfo(`[broadcast-ui] Start/Stop NDI clicked: ndiActive=${ndiActive}, source=${ndiSourceName}`)
     try {
       if (ndiActive) {
         await invoke("stop_ndi", { outputId: "main" })
@@ -264,6 +277,9 @@ export function BroadcastSettings({
           alphaMode: ndiAlphaMode,
         }
         const session = await invoke<NdiSessionInfo>("start_ndi", { outputId: "main", request })
+        void logInfo(
+          `[broadcast-ui] start_ndi ok: ${session.sourceName} ${session.width}x${session.height}@${session.fps}`,
+        )
         setNdiActive(true)
         useBroadcastStore.getState().syncBroadcastOutputFor("main")
         void emitTo("broadcast", "broadcast:ndi-config", {
@@ -278,6 +294,7 @@ export function BroadcastSettings({
         }, 300)
       }
     } catch (error) {
+      void logError(`[broadcast-ui] toggle NDI FAILED: ${String(error)}`)
       console.error("Failed to toggle NDI", error)
       toast.error(ndiActive ? "Could not stop NDI" : "Could not start NDI", {
         description: String(error),


### PR DESCRIPTION
## What

- **Persistent log file**: adds a `LogDir` target so the app writes `rhema.log` under the app log dir (`%LOCALAPPDATA%\com.openbezal.rhema\logs` on Windows), alongside stdout and the webview console. Failures now survive restarts.
- **Broadcast path fully logged, both sides of IPC**:
  - frontend (`@tauri-apps/plugin-log`, new `log:default` capability): monitor enumeration results, every preview/NDI button click with its state, invoke outcomes; monitor-listing failures also get a toast instead of being silently swallowed
  - backend: `open_broadcast_window` logs target-monitor geometry/scale, create-vs-reuse, and each failing stage; `close_broadcast_window` logs hide-vs-close decisions; `start_ndi` failures are logged; `NDIlib_send_create` failures capture `GetLastError` (the call reports nothing itself)

## Why

This logging is how the Windows sync-command deadlock behind #123 was found — the file trace ended at `creating window 'broadcast'` with no error and no return, which no amount of UI-side observation could show. It also already caught a transient NDI sender-creation failure in the field. Cheap to keep: info-level, no hot-path logging (`push_ndi_frame` untouched).

## Verification

- `cargo check` clean on the branch; `tsc --noEmit` exit 0; content field-tested during the #123 debugging session on Windows 11 (log lines in this PR are the ones that pinned the deadlock).