### PR TITLE
feat(search): FTS-first — embedding assets optional, opt-in via --with-embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ run `bun run setup:all`. All releases are listed at
 - [Bun](https://bun.sh/) (runtime for scripts + package manager)
 - [Rust](https://rustup.rs/) toolchain (stable, 1.77.2+)
 - [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/) (platform-specific system dependencies)
-- [Python 3](https://www.python.org/) (for downloading copyrighted translations and embedding model export)
+- [Python 3](https://www.python.org/) (only for the optional `--with-embedding` setup and downloading copyrighted translations)
 - CMake + LLVM/libclang (required for local Whisper STT) — see [Platform-specific setup](#platform-specific-setup) below
 - [Deepgram API key](https://deepgram.com/) (optional, for cloud speech-to-text instead of Whisper)
 
@@ -128,7 +128,7 @@ bun install
 
 ### Quick Setup (recommended)
 
-One command sets up everything — Python virtual environment, Bible data, database, ONNX model, precomputed embeddings, and the local Whisper model:
+One command sets up everything you need — Bible data, database, and the local Whisper model. It finishes in minutes and needs no Python:
 
 > **Windows:** run `bun run setup:windows` *before* `setup:all` and restart your terminal. See [Platform-specific setup](#platform-specific-setup) above.
 
@@ -136,15 +136,27 @@ One command sets up everything — Python virtual environment, Bible data, datab
 bun run setup:all
 ```
 
-This runs 7 idempotent phases in sequence, skipping any whose output artifacts already exist (pass `--force` to re-run all):
+This runs the required phases idempotently, skipping any whose output artifacts already exist (pass `--force` to re-run all):
 
-1. Python environment (`.venv` + pip deps: `optimum-onnx[onnxruntime]`, `sentence-transformers`, `accelerate`, `tokenizers`, `numpy`, `torch`, `meaningless`)
+1. ~~Python environment~~ — skipped by default (only needed for `--with-embedding` below)
 2. Download Bible source data — single bundled archive containing all 10 translations plus the openbible.info cross-references zip
 3. Build SQLite Bible database (`data/rhema.db` with FTS5 + cross-references)
-4. Download & export ONNX model (`Qwen3-Embedding-0.6B`) + INT8 quantization for ARM64
-5. Export KJV verses to JSON for embedding precomputation
-6. Precompute verse embeddings (GPU sentence-transformers when available, ONNX CPU fallback otherwise)
+4. –6. ~~ONNX model + verse embeddings~~ — skipped by default (see below)
 7. Download Whisper model (`ggml-large-v3-turbo-q8_0.bin`) into `models/whisper/`
+
+#### Optional: embedding re-ranking (`--with-embedding`)
+
+Everything above gives you the full search experience: live verse detection, exact/partial quote search, and typed references ("John 3:16") — benchmarked at recall@1 **0.836** across 152 queries. The embedding model adds semantic *paraphrase* matching in the Context search tab on top of that.
+
+```bash
+bun run setup:all --with-embedding
+```
+
+**What you gain:** better paraphrase queries in Context search — e.g. "God will never abandon you" finds Hebrews 13:5. Benchmark: paraphrase recall@5 goes from 0.800 to **1.000**; results gain Semantic badges with a real similarity %. Nothing else changes — exact quotes, verse fragments, typed references, and live detection are identical with or without it (overall recall@1 is 0.836 without vs 0.829 with).
+
+**What it costs:** a one-time ~2.5 hour build (Hugging Face model export, INT8 quantization, embedding all 31k verses with the same ONNX model the app runs), ~3.3 GB of disk (`models/` + `embeddings/`), the Python toolchain, and roughly 600–900 MB of extra memory while the app is running.
+
+You can opt in at any time later — the app detects the assets on next launch. Without them it logs a single info line and runs keyword + reference search at full quality.
 
 ### Environment
 
@@ -181,10 +193,12 @@ Each phase can also be run independently:
 ```bash
 bun run download:bible-data          # Bundled translations + cross-refs
 bun run build:bible                  # Build SQLite database
+bun run download:whisper             # Whisper STT model
+
+# Embedding re-ranking assets (optional — see above):
 bun run download:model               # Download & export ONNX model
 bun run export:verses                # Export verses to JSON
-bun run precompute:embeddings        # Rust ONNX (recommended); see also -onnx and -py variants
-bun run download:whisper             # Whisper STT model
+bun run precompute:embeddings        # Rust ONNX precompute (writes the provenance sidecar — always use this one)
 ```
 
 ### Run in development

--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ bun run setup:all --with-embedding
 
 You can opt in at any time later — the app detects the assets on next launch. Without them it logs a single info line and runs keyword + reference search at full quality.
 
+**Fixing a provenance mismatch.** The app verifies at startup that the embedding index was built with the same ONNX model it loaded (`embeddings/*.meta.json` sidecar). If it warns about a mismatch — typically after the model was re-downloaded or updated while an old index stayed on disk — delete the stale index and rebuild:
+
+```bash
+rm -f embeddings/kjv-qwen3-0.6b*        # Windows: delete embeddings\kjv-qwen3-0.6b* files
+bun run setup:all --with-embedding
+```
+
+The delete matters: setup skips any artifact that already exists, so a stale index looks "done" until it's removed. A mismatched index silently wrecks semantic accuracy (this exact bug shipped once — correct matches scored ~0.65 cosine instead of ~1.0), which is why the app checks.
+
 ### Environment
 
 #### Speech-to-Text Options

--- a/data/ci-build.ts
+++ b/data/ci-build.ts
@@ -18,16 +18,10 @@
 
 import { join } from "node:path"
 import { existsSync } from "node:fs"
-import { ensurePythonEnv, getVenvBin, PROJECT_ROOT } from "./lib/python-env"
+import { ensurePythonEnv, PROJECT_ROOT } from "./lib/python-env"
 
 // ── Paths ────────────────────────────────────────────────────────────
 const DATA_DIR = join(PROJECT_ROOT, "data")
-const MODELS_DIR = join(PROJECT_ROOT, "models", "qwen3-embedding-0.6b")
-const MODELS_DIR_INT8 = join(
-  PROJECT_ROOT,
-  "models",
-  "qwen3-embedding-0.6b-int8"
-)
 
 const KJV_SOURCE = join(DATA_DIR, "sources", "KJV.json")
 const NIV_SOURCE = join(DATA_DIR, "sources", "NIV.json")
@@ -35,16 +29,6 @@ const ESV_SOURCE = join(DATA_DIR, "sources", "ESV.json")
 const CROSS_REFS = join(DATA_DIR, "cross-refs", "cross_references.txt")
 const DB_PATH = join(DATA_DIR, "rhema.db")
 const VERSES_JSON = join(DATA_DIR, "verses-for-embedding.json")
-const EMB_BIN = join(PROJECT_ROOT, "embeddings", "kjv-qwen3-0.6b.bin")
-const IDS_BIN = join(PROJECT_ROOT, "embeddings", "kjv-qwen3-0.6b-ids.bin")
-const WHISPER_MODEL = join(
-  PROJECT_ROOT,
-  "models",
-  "whisper",
-  "ggml-large-v3-turbo-q8_0.bin"
-)
-const MODEL_ONNX = join(MODELS_DIR, "model.onnx")
-const MODEL_INT8 = join(MODELS_DIR_INT8, "model_quantized.onnx")
 
 const force = process.argv.includes("--force")
 
@@ -114,58 +98,13 @@ async function main() {
     await run(["bun", "run", join(DATA_DIR, "build-bible-db.ts")])
   }
 
-//   // ── Phase 4: ONNX model download + quantize ────────────────────
-//   console.log("\n━━━ Phase 4/4: ONNX model download & quantize ━━━")
-//   if (!shouldSkip("ONNX models", MODEL_ONNX, MODEL_INT8)) {
-//     const optimumCli = getVenvBin("optimum-cli")
+  // Embedding re-ranking assets (ONNX model + verse embeddings) are
+  // deliberately NOT built for release bundles: they are optional, cost
+  // ~2.5h of compute, and the app degrades to full-quality FTS + reference
+  // search without them. Users opt in locally with
+  // `bun run setup:all --with-embedding`.
 
-//     // Export FP32
-//     if (force || !existsSync(MODEL_ONNX)) {
-//       console.log(
-//         "\n  🧠 Exporting Qwen3-Embedding-0.6B to ONNX (feature-extraction)..."
-//       )
-//       console.log("     This may take a few minutes on first run.\n")
-//       await run([
-//         optimumCli,
-//         "export",
-//         "onnx",
-//         "--model",
-//         "Qwen/Qwen3-Embedding-0.6B",
-//         "--task",
-//         "feature-extraction",
-//         MODELS_DIR,
-//         "--library-name",
-//         "transformers",
-//       ])
-//       console.log(`  ✓ Model exported to ${MODELS_DIR}`)
-//     }
-
-//     // Quantize to INT8
-//     if (force || !existsSync(MODEL_INT8)) {
-//       console.log("\n  ⚡ Quantizing to INT8 (ARM64)...")
-//       try {
-//         await run([
-//           optimumCli,
-//           "onnxruntime",
-//           "quantize",
-//           "--onnx_model",
-//           MODELS_DIR,
-//           "--arm64",
-//           "-o",
-//           MODELS_DIR_INT8,
-//           "--library-name",
-//           "transformers",
-//         ])
-//         console.log(`  ✓ INT8 model saved to ${MODELS_DIR_INT8}`)
-//       } catch {
-//         console.error(
-//           "  ⚠️  Quantization failed. The FP32 model is still usable."
-//         )
-//       }
-//     }
-//   }
-
-  // ── Phase 5: Export verses to JSON ─────────────────────────────
+  // ── Phase 4: Export verses to JSON ─────────────────────────────
   console.log("\n━━━ Phase 4/4: Export verses to JSON ━━━")
   if (!shouldSkip("verses JSON", VERSES_JSON)) {
     if (!existsSync(DB_PATH)) {
@@ -176,26 +115,6 @@ async function main() {
     }
     await run(["bun", "run", join(DATA_DIR, "compute-embeddings.ts")])
   }
-
-//   // ── Phase 6: Pre-compute embeddings ────────────────────────────
-//   console.log("\n━━━ Phase 6/4: Pre-compute verse embeddings ━━━")
-//   if (!shouldSkip("precomputed embeddings", EMB_BIN, IDS_BIN)) {
-//     const venvPython = getVenvBin(
-//       process.platform === "win32" ? "python" : "python3"
-//     )
-//     // Use sentence-transformers + MPS GPU (much faster than ONNX CPU)
-//     await run(
-//       [venvPython, join(DATA_DIR, "precompute-embeddings.py")],
-//       undefined,
-//       { PYTHONUTF8: "1" }
-//     )
-//   }
-
-//   // ── Phase 7: Whisper model ────────────────────────────────────
-//   console.log("\n━━━ Phase 7/4: Download Whisper model ━━━")
-//   if (!shouldSkip("Whisper model", WHISPER_MODEL)) {
-//     await run(["bun", "run", join(DATA_DIR, "download-whisper-model.ts")])
-//   }
 
   // ── Done ───────────────────────────────────────────────────────
   console.log("\n╔══════════════════════════════════════════════╗")

--- a/data/prepare-embeddings.ts
+++ b/data/prepare-embeddings.ts
@@ -48,6 +48,12 @@ const MODEL_INT8 = join(MODELS_DIR_INT8, "model_quantized.onnx")
 
 const force = process.argv.includes("--force")
 
+// Embedding re-ranking assets (ONNX model + verse embeddings) are OPTIONAL
+// and expensive to build (~2.5h compute, ~3.3GB disk, Python toolchain).
+// Keyword + reference search works fully without them, so their phases only
+// run when explicitly requested.
+const withEmbedding = process.argv.includes("--with-embedding")
+
 // ── Helpers ──────────────────────────────────────────────────────────
 function shouldSkip(label: string, ...artifacts: string[]): boolean {
   if (force) return false
@@ -81,18 +87,32 @@ async function main() {
   console.log("║   Rhema – Full Setup Pipeline                ║")
   console.log("╚══════════════════════════════════════════════╝")
   if (force) console.log("  (--force: re-running all phases)\n")
+  if (!withEmbedding) {
+    console.log(
+      "  Embedding re-ranking assets will be SKIPPED (optional, ~2.5h to build)."
+    )
+    console.log(
+      "  Keyword + reference search works fully without them. To opt in:"
+    )
+    console.log("    bun run setup:all --with-embedding\n")
+  }
 
   // ── Phase 1: Python environment ────────────────────────────────
+  // Only the embedding phases (4-6) consume the Python toolchain.
   console.log("\n━━━ Phase 1/7: Python environment ━━━")
-  await ensurePythonEnv([
-    "optimum-onnx[onnxruntime]",
-    "sentence-transformers<5.0.0",
-    "accelerate",
-    "tokenizers",
-    "numpy",
-    "torch",
-    "meaningless",
-  ])
+  if (withEmbedding) {
+    await ensurePythonEnv([
+      "optimum-onnx[onnxruntime]",
+      "sentence-transformers<5.0.0",
+      "accelerate",
+      "tokenizers",
+      "numpy",
+      "torch",
+      "meaningless",
+    ])
+  } else {
+    console.log("  ⏭ Skip: only needed for --with-embedding")
+  }
 
   // ── Phase 2: Bible source data (pre-built zip + cross-refs) ────
   console.log("\n━━━ Phase 2/7: Download Bible source data ━━━")
@@ -116,7 +136,9 @@ async function main() {
 
   // ── Phase 4: ONNX model download + quantize ────────────────────
   console.log("\n━━━ Phase 4/7: ONNX model download & quantize ━━━")
-  if (!shouldSkip("ONNX models", MODEL_ONNX, MODEL_INT8)) {
+  if (!withEmbedding) {
+    console.log("  ⏭ Skip: embedding assets are opt-in (--with-embedding)")
+  } else if (!shouldSkip("ONNX models", MODEL_ONNX, MODEL_INT8)) {
     const optimumCli = getVenvBin("optimum-cli")
 
     // Export FP32
@@ -167,7 +189,9 @@ async function main() {
 
   // ── Phase 5: Export verses to JSON ─────────────────────────────
   console.log("\n━━━ Phase 5/7: Export verses to JSON ━━━")
-  if (!shouldSkip("verses JSON", VERSES_JSON)) {
+  if (!withEmbedding) {
+    console.log("  ⏭ Skip: embedding assets are opt-in (--with-embedding)")
+  } else if (!shouldSkip("verses JSON", VERSES_JSON)) {
     if (!existsSync(DB_PATH)) {
       console.error(
         "  ❌ rhema.db not found. Run phases 2-3 first (or remove --force skip)."
@@ -179,16 +203,15 @@ async function main() {
 
   // ── Phase 6: Pre-compute embeddings ────────────────────────────
   console.log("\n━━━ Phase 6/7: Pre-compute verse embeddings ━━━")
-  if (!shouldSkip("precomputed embeddings", EMB_BIN, IDS_BIN)) {
-    const venvPython = getVenvBin(
-      process.platform === "win32" ? "python" : "python3"
-    )
-    // Use sentence-transformers + MPS GPU (much faster than ONNX CPU)
-    await run(
-      [venvPython, join(DATA_DIR, "precompute-embeddings.py")],
-      undefined,
-      { PYTHONUTF8: "1" }
-    )
+  if (!withEmbedding) {
+    console.log("  ⏭ Skip: embedding assets are opt-in (--with-embedding)")
+  } else if (!shouldSkip("precomputed embeddings", EMB_BIN, IDS_BIN)) {
+    // Use the Rust precompute binary — it embeds with the SAME ONNX model
+    // and pooling the app uses at runtime and writes the provenance sidecar.
+    // (The old sentence-transformers path produced vectors that did not
+    // match the runtime embedder — that mismatch crippled vector search
+    // until the 2026-08 regeneration.)
+    await run(["bun", "run", "precompute:embeddings"])
   }
 
   // ── Phase 7: Whisper model ────────────────────────────────────
@@ -200,7 +223,21 @@ async function main() {
   // ── Done ───────────────────────────────────────────────────────
   console.log("\n╔══════════════════════════════════════════════╗")
   console.log("║   ✅ Setup complete!                          ║")
-  console.log("╚══════════════════════════════════════════════╝\n")
+  console.log("╚══════════════════════════════════════════════╝")
+  if (!withEmbedding) {
+    console.log(
+      "  Note: embedding re-ranking assets were skipped (optional)."
+    )
+    console.log(
+      "  Gain: better paraphrase search in the Context tab. Cost: ~2.5h build,"
+    )
+    console.log(
+      "  ~3.3GB disk, ~600-900MB RAM at runtime. Opt in anytime with:"
+    )
+    console.log("    bun run setup:all --with-embedding\n")
+  } else {
+    console.log("")
+  }
 }
 
 main().catch((err) => {

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -117,12 +117,21 @@ pub fn ui_mark(label: String, epoch_ms: f64) {
 /// Check if semantic search is available
 #[tauri::command]
 pub fn detection_status(
+    state: State<'_, Mutex<AppState>>,
     pipeline_state: State<'_, Mutex<DetectionPipeline>>,
 ) -> Result<DetectionStatusResult, String> {
-    let pipeline = pipeline_state.lock().map_err(|e| e.to_string())?;
+    let has_semantic = {
+        let pipeline = pipeline_state.lock().map_err(|e| e.to_string())?;
+        pipeline.has_semantic()
+    };
+    let embedding_warning = {
+        let app_state = state.lock().map_err(|e| e.to_string())?;
+        app_state.embedding_warning.clone()
+    };
     Ok(DetectionStatusResult {
         has_direct: true,
-        has_semantic: pipeline.has_semantic(),
+        has_semantic,
+        embedding_warning,
     })
 }
 
@@ -130,6 +139,9 @@ pub fn detection_status(
 pub struct DetectionStatusResult {
     pub has_direct: bool,
     pub has_semantic: bool,
+    /// Set when the embedding index provably mismatches the loaded model —
+    /// the UI shows this as a warning banner.
+    pub embedding_warning: Option<String>,
 }
 
 #[derive(Clone, Serialize)]

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -165,12 +165,13 @@ pub fn semantic_search(
     // overlap to surface.
     let depth = (3 * k).max(30);
 
-    // Lock pipeline for vector search (may be slow if ONNX runs)
+    // Lock pipeline for vector search (may be slow if ONNX runs). The
+    // embedding model is OPTIONAL: without it the detector is a stub that
+    // returns no vector hits, and the search below degrades to FTS5 with
+    // phrase-priority ordering — full-quality keyword + reference search
+    // with zero model assets installed.
     let vector_results = {
         let mut pipeline = pipeline_state.lock().map_err(|e| e.to_string())?;
-        if !pipeline.has_semantic() {
-            return Err("Semantic search not available — model or embeddings not loaded".into());
-        }
         pipeline.semantic_search(&query, depth)
     }; // Pipeline lock dropped
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -215,7 +215,10 @@ fn check_embedding_provenance(embeddings_path: &std::path::Path, model_path: &st
     } else {
         log::warn!(
             "Embeddings index was built with model {index_model:?} but the runtime loaded \
-             {loaded_model:?} — vector search accuracy will suffer. Regenerate the index."
+             {loaded_model:?} — vector search accuracy will suffer. Fix: delete the stale \
+             index and rebuild it with the current model: \
+             `rm -f embeddings/kjv-qwen3-0.6b*` then `bun run setup:all --with-embedding` \
+             (the delete matters — setup skips artifacts that already exist)."
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,7 +147,14 @@ pub fn run() {
                             match rhema_detection::HnswVectorIndex::load(&embeddings_path, &ids_path, dim) {
                                 Ok(index) => {
                                     log::info!("Verse embeddings loaded ({} vectors)", index.len());
-                                    check_embedding_provenance(&embeddings_path, &model_path);
+                                    if let Some(warning) =
+                                        check_embedding_provenance(&embeddings_path, &model_path)
+                                    {
+                                        // Surface in the UI (warning banner via detection_status).
+                                        let managed_state = app.state::<Mutex<state::AppState>>();
+                                        managed_state.lock().unwrap().embedding_warning =
+                                            Some(warning);
+                                    }
                                     pipeline.set_semantic(
                                         rhema_detection::SemanticDetector::new(
                                             Box::new(embedder),
@@ -188,7 +195,13 @@ pub fn run() {
 /// wrecks vector-search accuracy — the shipped pre-2025 index scored
 /// cosine ~0.65 against its own verses because it was built with a
 /// different model/prefix than the runtime.
-fn check_embedding_provenance(embeddings_path: &std::path::Path, model_path: &std::path::Path) {
+///
+/// Returns a user-facing warning message when the index provably mismatches
+/// the loaded model (surfaced as a UI banner); `None` otherwise.
+fn check_embedding_provenance(
+    embeddings_path: &std::path::Path,
+    model_path: &std::path::Path,
+) -> Option<String> {
     let meta_path = embeddings_path.with_extension("meta.json");
     // Missing/unreadable sidecar is informational only (e.g. assets built
     // before the sidecar existed). The loud warning is reserved for the one
@@ -199,11 +212,11 @@ fn check_embedding_provenance(embeddings_path: &std::path::Path, model_path: &st
              Regenerating refreshes it: 'bun run setup:all --with-embedding'.",
             meta_path.display()
         );
-        return;
+        return None;
     };
     let Ok(meta) = serde_json::from_str::<serde_json::Value>(&raw) else {
         log::info!("Unreadable embeddings provenance sidecar at {}", meta_path.display());
-        return;
+        return None;
     };
     let index_model = meta.get("model_file").and_then(|v| v.as_str()).unwrap_or("");
     let loaded_model = model_path
@@ -212,13 +225,15 @@ fn check_embedding_provenance(embeddings_path: &std::path::Path, model_path: &st
         .unwrap_or_default();
     if index_model == loaded_model {
         log::info!("Embeddings provenance OK (model: {loaded_model})");
+        None
     } else {
-        log::warn!(
-            "Embeddings index was built with model {index_model:?} but the runtime loaded \
-             {loaded_model:?} — vector search accuracy will suffer. Fix: delete the stale \
-             index and rebuild it with the current model: \
-             `rm -f embeddings/kjv-qwen3-0.6b*` then `bun run setup:all --with-embedding` \
-             (the delete matters — setup skips artifacts that already exist)."
+        let warning = format!(
+            "Semantic search index mismatch: the verse embeddings were built with \
+             \"{index_model}\" but the app loaded \"{loaded_model}\", so semantic results \
+             will be unreliable. Fix: delete embeddings/kjv-qwen3-0.6b* and run \
+             `bun run setup:all --with-embedding`."
         );
+        log::warn!("{warning}");
+        Some(warning)
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,9 +151,7 @@ pub fn run() {
                                         check_embedding_provenance(&embeddings_path, &model_path)
                                     {
                                         // Surface in the UI (warning banner via detection_status).
-                                        let managed_state = app.state::<Mutex<state::AppState>>();
-                                        managed_state.lock().unwrap().embedding_warning =
-                                            Some(warning);
+                                        set_embedding_warning(app.handle(), warning);
                                     }
                                     pipeline.set_semantic(
                                         rhema_detection::SemanticDetector::new(
@@ -161,6 +159,13 @@ pub fn run() {
                                             Box::new(index),
                                         ),
                                     );
+                                    drop(pipeline);
+                                    // The sidecar can be missing (indexes built before it
+                                    // existed) or wrong — verify EMPIRICALLY in the
+                                    // background: a matched index finds a verse's own text
+                                    // at ~1.0 similarity; the historical mismatched index
+                                    // scored ~0.65. One ONNX embed, off the startup path.
+                                    spawn_embedding_self_check(app.handle().clone());
                                 }
                                 Err(e) => {
                                     log::warn!("Failed to load verse embeddings: {e}");
@@ -188,6 +193,75 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// Store an embedding warning in `AppState` (read by `detection_status`)
+/// and push it to the webview so the banner appears without a reload.
+fn set_embedding_warning(app: &tauri::AppHandle, warning: String) {
+    use tauri::{Emitter, Manager};
+    let managed_state = app.state::<Mutex<state::AppState>>();
+    managed_state.lock().unwrap().embedding_warning = Some(warning.clone());
+    let _ = app.emit("embedding_warning", warning);
+}
+
+/// Empirical index verification, run in the background after startup.
+///
+/// Embeds one known verse's exact KJV text and asks the index for its
+/// nearest neighbour. A healthy index returns that same verse at ~1.0
+/// cosine; the historical mismatched index (built with a different
+/// model/pooling) scored ~0.65. This needs no provenance sidecar, so it
+/// catches the most common broken state in the wild: an old index with no
+/// `meta.json` at all.
+fn spawn_embedding_self_check(app: tauri::AppHandle) {
+    use tauri::Manager;
+    tauri::async_runtime::spawn(async move {
+        let _ = tokio::task::spawn_blocking(move || {
+            // John 3:16 KJV — present in every index build.
+            let (verse_id, verse_text) = {
+                let managed_state = app.state::<Mutex<state::AppState>>();
+                let app_state = managed_state.lock().unwrap();
+                let Some(db) = app_state.bible_db.as_ref() else { return };
+                match db.get_verse(1, 43, 3, 16) {
+                    Ok(Some(v)) => (v.id, v.text),
+                    _ => return,
+                }
+            };
+
+            let top_hit = {
+                let managed_pipeline =
+                    app.state::<Mutex<rhema_detection::DetectionPipeline>>();
+                let mut pipeline = managed_pipeline.lock().unwrap();
+                if !pipeline.has_semantic() {
+                    return;
+                }
+                pipeline.semantic_search(&verse_text, 1).into_iter().next()
+            };
+
+            match top_hit {
+                Some((id, similarity)) if id == verse_id && similarity >= 0.98 => {
+                    log::info!(
+                        "Embedding index self-check OK (self-similarity {similarity:.4})"
+                    );
+                }
+                other => {
+                    let observed = other.map_or_else(
+                        || "no result".to_string(),
+                        |(id, sim)| format!("verse_id {id} at {sim:.2}"),
+                    );
+                    let warning = format!(
+                        "Semantic search index failed verification: a test verse should \
+                         match its own embedding at ~1.0 similarity but returned {observed}. \
+                         The index was built with a different model than the app is running, \
+                         so semantic results will be unreliable. Fix: delete \
+                         embeddings/kjv-qwen3-0.6b* and run `bun run setup:all --with-embedding`."
+                    );
+                    log::warn!("{warning}");
+                    set_embedding_warning(&app, warning);
+                }
+            }
+        })
+        .await;
+    });
 }
 
 /// Compare the embeddings' provenance sidecar (written by the precompute

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,7 +160,10 @@ pub fn run() {
                                 }
                             }
                         } else {
-                            log::info!("No pre-computed verse embeddings found. Run 'bun run export:verses' then the precompute binary.");
+                            log::info!(
+                                "Embedding re-ranking not installed (optional) — keyword + reference \
+                                 search fully functional. Opt in with 'bun run setup:all --with-embedding'."
+                            );
                         }
                     }
                     Err(e) => {
@@ -168,7 +171,10 @@ pub fn run() {
                     }
                 }
             } else {
-                log::info!("ONNX model not found. Semantic search disabled. Run 'bun run download:model' to download.");
+                log::info!(
+                    "Embedding re-ranking not installed (optional) — keyword + reference \
+                     search fully functional. Opt in with 'bun run setup:all --with-embedding'."
+                );
             }
 
             Ok(())
@@ -184,16 +190,19 @@ pub fn run() {
 /// different model/prefix than the runtime.
 fn check_embedding_provenance(embeddings_path: &std::path::Path, model_path: &std::path::Path) {
     let meta_path = embeddings_path.with_extension("meta.json");
+    // Missing/unreadable sidecar is informational only (e.g. assets built
+    // before the sidecar existed). The loud warning is reserved for the one
+    // real hazard: an index provably built with a DIFFERENT model.
     let Ok(raw) = std::fs::read_to_string(&meta_path) else {
-        log::warn!(
+        log::info!(
             "No embeddings provenance sidecar at {} — cannot verify the index matches the model. \
-             Regenerate with 'bun run export:verses && bun run precompute:embeddings'.",
+             Regenerating refreshes it: 'bun run setup:all --with-embedding'.",
             meta_path.display()
         );
         return;
     };
     let Ok(meta) = serde_json::from_str::<serde_json::Value>(&raw) else {
-        log::warn!("Unreadable embeddings provenance sidecar at {}", meta_path.display());
+        log::info!("Unreadable embeddings provenance sidecar at {}", meta_path.display());
         return;
     };
     let index_model = meta.get("model_file").and_then(|v| v.as_str()).unwrap_or("");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -11,6 +11,10 @@ pub struct AppState {
     pub audio_test_active: Arc<AtomicBool>,
     #[expect(dead_code, reason = "reserved for future Deepgram key injection")]
     pub deepgram_api_key: Option<String>,
+    /// Set at startup when the embedding index provably mismatches the
+    /// loaded ONNX model — surfaced as a UI warning banner via
+    /// `detection_status`.
+    pub embedding_warning: Option<String>,
 }
 
 impl AppState {
@@ -22,6 +26,7 @@ impl AppState {
             stt_active: Arc::new(AtomicBool::new(false)),
             audio_test_active: Arc::new(AtomicBool::new(false)),
             deepgram_api_key: None,
+            embedding_warning: None,
         }
     }
 }

--- a/src/components/layout/dashboard.tsx
+++ b/src/components/layout/dashboard.tsx
@@ -5,6 +5,7 @@ import { LiveOutputPanel } from "@/components/panels/live-output-panel"
 import { QueuePanel } from "@/components/panels/queue-panel"
 import { SearchPanel } from "@/components/panels/search-panel"
 import { DetectionsPanel } from "@/components/panels/detections-panel"
+import { EmbeddingWarningBanner } from "@/components/ui/embedding-warning-banner"
 
 export function Dashboard() {
   return (
@@ -13,7 +14,9 @@ export function Dashboard() {
         position: "fixed",
         inset: "0px",
         display: "grid",
-        gridTemplateRows: "56px minmax(0, 2fr) minmax(0, 3fr)",
+        // The `auto` row hosts the warning banner and collapses to 0 when
+        // there is nothing to warn about.
+        gridTemplateRows: "56px auto minmax(0, 2fr) minmax(0, 3fr)",
         overflow: "hidden",
       }}
       className="bg-background"
@@ -22,6 +25,9 @@ export function Dashboard() {
       <div className="col-span-4">
         <TransportBar />
       </div>
+
+      {/* Row 2: warning banner (collapses when healthy) */}
+      <EmbeddingWarningBanner />
 
       {/* Row 2: 4 panels */}
       <div

--- a/src/components/ui/embedding-warning-banner.tsx
+++ b/src/components/ui/embedding-warning-banner.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react"
+import { invoke } from "@tauri-apps/api/core"
+import { AlertTriangleIcon, XIcon } from "lucide-react"
+import type { DetectionStatus } from "@/types"
+
+/**
+ * Amber warning strip shown when the backend reports that the semantic
+ * embedding index was built with a different ONNX model than the one the
+ * app loaded (semantic results would be unreliable). Renders nothing in the
+ * healthy cases: no embeddings installed, or index and model match.
+ */
+export function EmbeddingWarningBanner() {
+  const [warning, setWarning] = useState<string | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    invoke<DetectionStatus>("detection_status")
+      .then((status) => {
+        if (status.embedding_warning) setWarning(status.embedding_warning)
+      })
+      .catch(() => {})
+  }, [])
+
+  // Always occupy the grid row — the parent grid's `auto` row collapses to
+  // zero height when this is empty, and other rows keep their slots.
+  if (!warning || dismissed) return <div className="col-span-4" />
+
+  return (
+    <div
+      role="alert"
+      className="col-span-4 flex items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-500"
+    >
+      <AlertTriangleIcon className="size-4 shrink-0" />
+      <span className="min-w-0 flex-1">{warning}</span>
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss warning"
+        className="shrink-0 rounded p-1 transition-colors hover:bg-amber-500/20"
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/ui/embedding-warning-banner.tsx
+++ b/src/components/ui/embedding-warning-banner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { invoke } from "@tauri-apps/api/core"
 import { AlertTriangleIcon, XIcon } from "lucide-react"
+import { useTauriEvent } from "@/hooks/use-tauri-event"
 import type { DetectionStatus } from "@/types"
 
 /**
@@ -8,6 +9,10 @@ import type { DetectionStatus } from "@/types"
  * embedding index was built with a different ONNX model than the one the
  * app loaded (semantic results would be unreliable). Renders nothing in the
  * healthy cases: no embeddings installed, or index and model match.
+ *
+ * Two sources: the initial detection_status fetch (sidecar check at
+ * startup) and the "embedding_warning" event pushed when the background
+ * self-check — which needs no sidecar — finishes a few seconds later.
  */
 export function EmbeddingWarningBanner() {
   const [warning, setWarning] = useState<string | null>(null)
@@ -20,6 +25,10 @@ export function EmbeddingWarningBanner() {
       })
       .catch(() => {})
   }, [])
+
+  useTauriEvent<string>("embedding_warning", (message) => {
+    setWarning(message)
+  })
 
   // Always occupy the grid row — the parent grid's `auto` row collapses to
   // zero height when this is empty, and other rows keep their slots.

--- a/src/types/detection.ts
+++ b/src/types/detection.ts
@@ -26,6 +26,8 @@ export interface ReadingAdvance {
 export interface DetectionStatus {
   has_direct: boolean
   has_semantic: boolean
+  /** Set when the embedding index mismatches the loaded model — shown as a warning banner. */
+  embedding_warning?: string | null
 }
 
 export interface SemanticSearchResult {


### PR DESCRIPTION
**Do not merge until confirmed live** (standing rule).

## Why

The benchmark says FTS + phrase-priority + typed references match the vector hybrid everywhere that matters (overall R@1 **0.836** FTS-only vs 0.829 hybrid); vectors only add paraphrase R@5 (0.800 → **1.000**). Meanwhile the embedding apparatus costs ~2.5h build, ~3.3GB disk, Python, and 600–900MB RAM — and production installs never had the assets anyway, with `semantic_search` **erroring** without them and dumping users to the Fuse.js fuzzy fallback.

## What changes

1. **`semantic_search` degrades gracefully**: no model → no vector hits → FTS5 with phrase-priority ordering, `sources: ["keyword"]` badges. Production installs get the full-quality search today with zero downloads.
2. **`setup:all` skips the embedding phases by default** — fresh-clone setup finishes in minutes with no Python. Opt in: `bun run setup:all --with-embedding`.
3. **Opt-in path is now correct**: Phase 6 runs the Rust precompute binary (same ONNX model + pooling as the runtime, writes the provenance sidecar) instead of the sentence-transformers script that caused the original mismatched-index bug.
4. **No scary logs without embeddings**: one calm info line; provenance sidecar missing/unreadable is info, not warn — the loud warning remains only for a truly mismatched index.
5. **README**: honest gain-vs-cost section so users know exactly what `--with-embedding` buys.
6. `ci-build.ts`: dead commented phases deleted with a note that release bundles exclude these assets on purpose.

## How to verify

- **With your assets (as-is)**: Context search unchanged — hybrid results, Semantic badges. `bun run setup:all` finishes in seconds, all embedding phases print skip notes.
- **Simulating a fresh user**: temporarily rename `models/` → relaunch `bun tauri dev` → startup shows one info line (no warnings), Context search returns Keyword-badged FTS results (not an error, not Fuse), typed "John 3:16" still pins. Rename back.

## Testing
- cargo build + workspace tests + clippy clean (fusion's fts-only/phrase-priority tests cover the empty-vector path)
- vitest 142/142, tsc clean; both setup scripts syntax-checked and the default gating exercised end-to-end