### PR TITLE
fix(detection): validate verse existence and resolve book-less references from context

### DIFF
--- a/src-tauri/crates/detection/src/direct/automaton.rs
+++ b/src-tauri/crates/detection/src/direct/automaton.rs
@@ -91,10 +91,11 @@ impl BookMatcher {
             let start = mat.start();
             let end = mat.end();
 
-            // Check word boundary at start
+            // Check word boundary at start. An apostrophe is word-internal:
+            // without this, "we're" matches the Revelation alias "Re".
             if start > 0 {
                 let prev = text_bytes[start - 1];
-                if prev.is_ascii_alphanumeric() {
+                if prev.is_ascii_alphanumeric() || prev == b'\'' {
                     continue;
                 }
             }

--- a/src-tauri/crates/detection/src/direct/context.rs
+++ b/src-tauri/crates/detection/src/direct/context.rs
@@ -11,8 +11,9 @@ pub struct ReferenceContext {
     last_timestamp: Option<Instant>,
 }
 
-/// How long context remains valid (60 seconds).
-const CONTEXT_TIMEOUT_SECS: u64 = 60;
+/// How long context remains valid (90 seconds — preachers often expound for
+/// a while between citing a book and calling out the next verse number).
+const CONTEXT_TIMEOUT_SECS: u64 = 90;
 
 impl ReferenceContext {
     pub fn new() -> Self {
@@ -66,6 +67,31 @@ impl ReferenceContext {
         }
 
         resolved
+    }
+
+    /// Check if context was updated within the last `within_secs` seconds.
+    /// Used for patterns that need a tighter window than the full timeout
+    /// (e.g. bare "N:M" corrections).
+    pub fn is_fresh(&self, within_secs: u64) -> bool {
+        match self.last_timestamp {
+            Some(ts) => ts.elapsed().as_secs() < within_secs,
+            None => false,
+        }
+    }
+
+    /// The last book heard, if context is still valid.
+    pub fn last_book(&self) -> Option<(i32, &str)> {
+        if !self.is_valid() {
+            return None;
+        }
+        let book = self.last_book?;
+        let name = self.last_book_name.as_deref()?;
+        Some((book, name))
+    }
+
+    /// The last chapter heard, if context is still valid.
+    pub fn last_chapter(&self) -> Option<i32> {
+        if self.is_valid() { self.last_chapter } else { None }
     }
 
     /// Update context with the latest detection.

--- a/src-tauri/crates/detection/src/direct/detector.rs
+++ b/src-tauri/crates/detection/src/direct/detector.rs
@@ -598,10 +598,17 @@ impl DirectDetector {
                             ));
                             self.push_recent(&completed);
                             self.context.update(&completed);
+                            self.incomplete = None;
                         } else {
+                            // The naive completion doesn't exist — the text
+                            // may be a correction ("22 20" after "Revelation
+                            // 20"), so retry it contextually.
                             self.remember_rejected(&completed);
+                            self.incomplete = None;
+                            if let Some(d) = self.try_contextual_detection(text) {
+                                detections.push(d);
+                            }
                         }
-                        self.incomplete = None;
                         return detections;
                     }
                     parser::Continuation::VerseOnly(v) => {
@@ -624,10 +631,14 @@ impl DirectDetector {
                             ));
                             self.push_recent(&completed);
                             self.context.update(&completed);
+                            self.incomplete = None;
                         } else {
                             self.remember_rejected(&completed);
+                            self.incomplete = None;
+                            if let Some(d) = self.try_contextual_detection(text) {
+                                detections.push(d);
+                            }
                         }
-                        self.incomplete = None;
                         return detections;
                     }
                     parser::Continuation::ChapterOnly(ch) => {
@@ -667,6 +678,7 @@ impl DirectDetector {
         };
 
         // Step 2 & 3: Parse references and resolve context
+        let mut rejected_reference = false;
         for book_match in effective_matches {
             if let Some(verse_ref) = parser::parse_reference(text, book_match) {
                 // Resolve any partial references using context
@@ -683,6 +695,7 @@ impl DirectDetector {
                     && !is_valid_reference(resolved.book_number, resolved.chapter)
                 {
                     self.remember_rejected(&resolved);
+                    rejected_reference = true;
                     continue;
                 }
 
@@ -713,6 +726,7 @@ impl DirectDetector {
                     resolved.verse_start,
                 ) {
                     self.remember_rejected(&resolved);
+                    rejected_reference = true;
                     continue;
                 }
                 clamp_verse_end(&mut resolved);
@@ -750,10 +764,12 @@ impl DirectDetector {
             }
         }
 
-        // Step 4: No book name anywhere in the text — try to resolve a
-        // book-less reference ("22:20", "verse 5", "chapter 22 verse 20")
-        // against the last book heard (issue #141).
-        if detections.is_empty() && effective_matches.is_empty() {
+        // Step 4: Try to resolve a book-less reference ("22 20", "verse 5",
+        // "chapter 22 verse 20") against the last book heard (issue #141).
+        // Runs when the text has no book name at all, or when every parsed
+        // reference was rejected as non-existent — the trailing numbers may
+        // be a correction ("Revelation 20 22. 22 20.").
+        if detections.is_empty() && (effective_matches.is_empty() || rejected_reference) {
             if let Some(detection) = self.try_contextual_detection(text) {
                 detections.push(detection);
             }
@@ -767,10 +783,43 @@ impl DirectDetector {
     /// [`IncompleteRef`] (reusing the normal completion machinery) and
     /// returns `None`.
     fn try_contextual_detection(&mut self, text: &str) -> Option<Detection> {
-        let contextual = parser::parse_contextual(text)?;
         let (book_number, book_name) = {
             let (num, name) = self.context.last_book()?;
             (num, name.to_string())
+        };
+
+        let Some(contextual) = parser::parse_contextual(text) else {
+            // No keyword or colon pattern — fall back to adjacent number
+            // pairs ("22 20": Deepgram never renders spoken chapter:verse
+            // corrections with a colon). Same tight window as bare colons;
+            // the last pair that exists in the context book wins.
+            if !self.context.is_fresh(BARE_COLON_CONTEXT_WINDOW_SECS) {
+                return None;
+            }
+            let (chapter, verse) = parser::extract_adjacent_number_pairs(text)
+                .into_iter()
+                .rev()
+                .find(|&(ch, v)| {
+                    is_valid_reference(book_number, ch)
+                        && versification::is_valid_verse(book_number, ch, v)
+                })?;
+            let verse_ref = VerseRef {
+                book_number,
+                book_name,
+                chapter,
+                verse_start: verse,
+                verse_end: None,
+            };
+            self.push_recent(&verse_ref);
+            self.context.update(&verse_ref);
+            self.incomplete = None;
+            return Some(self.make_direct_detection(
+                &verse_ref,
+                CONTEXTUAL_BARE_COLON_CONFIDENCE,
+                text,
+                0,
+                text.len(),
+            ));
         };
 
         let (chapter, verse, confidence) = match contextual {
@@ -834,6 +883,18 @@ impl DirectDetector {
         self.context.update(&verse_ref);
         self.incomplete = None;
         Some(self.make_direct_detection(&verse_ref, confidence, text, 0, text.len()))
+    }
+
+    /// Book numbers explicitly named in the text (after transcript cleaning).
+    /// Lets the app layer keep reading mode from reinterpreting numbers that
+    /// belong to a spoken reference for a different book.
+    pub fn mentioned_books(&self, text: &str) -> Vec<i32> {
+        let cleaned = clean_transcript(text);
+        self.matcher
+            .find_books(&cleaned)
+            .iter()
+            .map(|m| m.book_number)
+            .collect()
     }
 
     /// Record a rejected reference's book (and chapter, when the chapter
@@ -1911,6 +1972,79 @@ mod tests {
         detector.detect("Revelation 20:2");
         assert!(detector.detect("the service starts at 10:30").is_empty());
         assert!(detector.detect("10:30 am tomorrow").is_empty());
+    }
+
+    #[test]
+    fn test_correction_pair_after_invalid_citation() {
+        // Live-test flow: Deepgram renders "Revelation 20:22" as
+        // "Revelation 20 22." and the correction as "22 20." — no colons.
+        let mut detector = DirectDetector::new();
+
+        let results = detector.detect("Revelation 20 22.");
+        assert!(results.is_empty());
+
+        let results = detector.detect("22 20.");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+    }
+
+    #[test]
+    fn test_correction_pair_with_pending_incomplete() {
+        // Partials park "Revelation 20" as incomplete before the correction
+        // arrives; the naive completion (20:22) is invalid and must fall
+        // through to the pair correction.
+        let mut detector = DirectDetector::new();
+
+        detector.detect("Revelation");
+        detector.detect("20 22");
+        assert!(detector.detect("Revelation 20 22.").is_empty());
+
+        let results = detector.detect("22 20.");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+    }
+
+    #[test]
+    fn test_single_utterance_pair_correction() {
+        // Citation and correction arrive in one final: the invalid pairs
+        // (20:22, 22:22) are skipped, the last valid pair (22:20) wins.
+        let mut detector = DirectDetector::new();
+
+        let results = detector.detect("Revelation 20 22. 22 20.");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+    }
+
+    #[test]
+    fn test_number_verse_correction() {
+        // "22 verse 20" — chapter spoken without the "chapter" keyword.
+        let mut detector = DirectDetector::new();
+
+        assert!(detector.detect("Revelation chapter 20 verse 22.").is_empty());
+
+        let results = detector.detect("22 verse 20.");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+    }
+
+    #[test]
+    fn test_pair_requires_context() {
+        let mut detector = DirectDetector::new();
+        assert!(detector.detect("22 20.").is_empty());
+    }
+
+    #[test]
+    fn test_mentioned_books() {
+        let detector = DirectDetector::new();
+        assert_eq!(detector.mentioned_books("Revelation chapter 20 verse 22"), vec![66]);
+        assert_eq!(detector.mentioned_books("22 verse 20."), Vec::<i32>::new());
     }
 
     #[test]

--- a/src-tauri/crates/detection/src/direct/detector.rs
+++ b/src-tauri/crates/detection/src/direct/detector.rs
@@ -8,6 +8,7 @@ use super::automaton::{BookMatch, BookMatcher};
 use super::context::ReferenceContext;
 use super::fuzzy;
 use super::parser;
+use super::versification;
 use crate::types::{Detection, DetectionSource, VerseRef};
 
 /// Translation command patterns — maps spoken phrases to translation abbreviations.
@@ -311,6 +312,19 @@ fn is_valid_reference(book_number: i32, chapter: i32) -> bool {
     chapter >= 1 && chapter <= max_ch
 }
 
+/// Drop a verse-range end that can't exist (past the chapter's last verse or
+/// before the start), so a bad range end doesn't invalidate a valid start.
+fn clamp_verse_end(verse_ref: &mut VerseRef) {
+    if let (Some(end), Some(max)) = (
+        verse_ref.verse_end,
+        versification::max_verse(verse_ref.book_number, verse_ref.chapter),
+    ) {
+        if end > max || end < verse_ref.verse_start {
+            verse_ref.verse_end = None;
+        }
+    }
+}
+
 /// Filler phrases commonly found in sermon transcripts that confuse detection.
 /// These are stripped (case-insensitively) before the text reaches the automaton.
 const FILLER_PHRASES: &[&str] = &[
@@ -413,6 +427,19 @@ fn clean_transcript(text: &str) -> String {
 /// How long to wait for an incomplete reference to be completed (15 seconds).
 /// Preachers often pause between book name and chapter/verse.
 const INCOMPLETE_REF_TIMEOUT_MS: u128 = 15_000;
+
+/// Confidence for contextual (book-less) detections resolved against the last
+/// book heard. All deliberately >= 0.90: that keeps the semantic FTS pass
+/// suppressed for the utterance and stays above the 0.80 auto-queue threshold.
+const CONTEXTUAL_CHAPTER_VERSE_CONFIDENCE: f64 = 0.95;
+const CONTEXTUAL_VERSE_ONLY_CONFIDENCE: f64 = 0.92;
+const CONTEXTUAL_BARE_COLON_CONFIDENCE: f64 = 0.90;
+
+/// Bare "N:M" (no "chapter"/"verse" keyword) is the riskiest contextual
+/// pattern — it can match times of day — so it only resolves against context
+/// updated within this window. Corrections ("Revelation 20:22... 22:20")
+/// arrive within seconds.
+const BARE_COLON_CONTEXT_WINDOW_SECS: u64 = 30;
 
 /// An incomplete reference waiting for verse completion.
 #[derive(Debug, Clone)]
@@ -554,7 +581,14 @@ impl DirectDetector {
                         let mut completed = incomplete.verse_ref.clone();
                         completed.chapter = ch;
                         completed.verse_start = v;
-                        if is_valid_reference(completed.book_number, completed.chapter) {
+                        if is_valid_reference(completed.book_number, completed.chapter)
+                            && versification::is_valid_verse(
+                                completed.book_number,
+                                completed.chapter,
+                                completed.verse_start,
+                            )
+                        {
+                            clamp_verse_end(&mut completed);
                             detections.push(self.make_direct_detection(
                                 &completed,
                                 compute_confidence(&completed, &completed),
@@ -564,6 +598,8 @@ impl DirectDetector {
                             ));
                             self.push_recent(&completed);
                             self.context.update(&completed);
+                        } else {
+                            self.remember_rejected(&completed);
                         }
                         self.incomplete = None;
                         return detections;
@@ -571,7 +607,14 @@ impl DirectDetector {
                     parser::Continuation::VerseOnly(v) => {
                         let mut completed = incomplete.verse_ref.clone();
                         completed.verse_start = v;
-                        if is_valid_reference(completed.book_number, completed.chapter) {
+                        if is_valid_reference(completed.book_number, completed.chapter)
+                            && versification::is_valid_verse(
+                                completed.book_number,
+                                completed.chapter,
+                                completed.verse_start,
+                            )
+                        {
+                            clamp_verse_end(&mut completed);
                             detections.push(self.make_direct_detection(
                                 &completed,
                                 compute_confidence(&completed, &completed),
@@ -581,6 +624,8 @@ impl DirectDetector {
                             ));
                             self.push_recent(&completed);
                             self.context.update(&completed);
+                        } else {
+                            self.remember_rejected(&completed);
                         }
                         self.incomplete = None;
                         return detections;
@@ -625,7 +670,7 @@ impl DirectDetector {
         for book_match in effective_matches {
             if let Some(verse_ref) = parser::parse_reference(text, book_match) {
                 // Resolve any partial references using context
-                let resolved = self.context.resolve(&verse_ref);
+                let mut resolved = self.context.resolve(&verse_ref);
 
                 // Skip if we couldn't resolve to a meaningful reference
                 if resolved.book_number == 0 || resolved.chapter == 0 {
@@ -637,6 +682,7 @@ impl DirectDetector {
                 if resolved.chapter > 0
                     && !is_valid_reference(resolved.book_number, resolved.chapter)
                 {
+                    self.remember_rejected(&resolved);
                     continue;
                 }
 
@@ -656,6 +702,20 @@ impl DirectDetector {
                     self.context.update(&resolved);
                     continue;
                 }
+
+                // Skip non-existent verses (e.g., "Revelation 20:22" — Rev 20
+                // ends at verse 15), but remember the book/chapter so a
+                // follow-up correction without the book name ("22:20") can
+                // still resolve (issue #141).
+                if !versification::is_valid_verse(
+                    resolved.book_number,
+                    resolved.chapter,
+                    resolved.verse_start,
+                ) {
+                    self.remember_rejected(&resolved);
+                    continue;
+                }
+                clamp_verse_end(&mut resolved);
 
                 // Full reference — also clear any pending incomplete
                 self.incomplete = None;
@@ -690,7 +750,103 @@ impl DirectDetector {
             }
         }
 
+        // Step 4: No book name anywhere in the text — try to resolve a
+        // book-less reference ("22:20", "verse 5", "chapter 22 verse 20")
+        // against the last book heard (issue #141).
+        if detections.is_empty() && effective_matches.is_empty() {
+            if let Some(detection) = self.try_contextual_detection(text) {
+                detections.push(detection);
+            }
+        }
+
         detections
+    }
+
+    /// Resolve a book-less reference against recent context. Returns a
+    /// detection for chapter+verse patterns; a chapter-only pattern parks an
+    /// [`IncompleteRef`] (reusing the normal completion machinery) and
+    /// returns `None`.
+    fn try_contextual_detection(&mut self, text: &str) -> Option<Detection> {
+        let contextual = parser::parse_contextual(text)?;
+        let (book_number, book_name) = {
+            let (num, name) = self.context.last_book()?;
+            (num, name.to_string())
+        };
+
+        let (chapter, verse, confidence) = match contextual {
+            parser::ContextualRef::ChapterVerse {
+                chapter,
+                verse,
+                keyword_anchored,
+            } => {
+                // Bare "N:M" only counts shortly after a citation — it's the
+                // pattern most likely to be something else (a time of day).
+                if !keyword_anchored && !self.context.is_fresh(BARE_COLON_CONTEXT_WINDOW_SECS) {
+                    return None;
+                }
+                let confidence = if keyword_anchored {
+                    CONTEXTUAL_CHAPTER_VERSE_CONFIDENCE
+                } else {
+                    CONTEXTUAL_BARE_COLON_CONFIDENCE
+                };
+                (chapter, verse, confidence)
+            }
+            parser::ContextualRef::VerseOnly(verse) => (
+                self.context.last_chapter()?,
+                verse,
+                CONTEXTUAL_VERSE_ONLY_CONFIDENCE,
+            ),
+            parser::ContextualRef::ChapterOnly(chapter) => {
+                if !is_valid_reference(book_number, chapter) {
+                    return None;
+                }
+                let verse_ref = VerseRef {
+                    book_number,
+                    book_name,
+                    chapter,
+                    verse_start: 0,
+                    verse_end: None,
+                };
+                self.context.update(&verse_ref);
+                self.incomplete = Some(IncompleteRef {
+                    verse_ref,
+                    timestamp: Instant::now(),
+                    chapter_is_default: false,
+                });
+                return None;
+            }
+        };
+
+        if !is_valid_reference(book_number, chapter)
+            || !versification::is_valid_verse(book_number, chapter, verse)
+        {
+            return None;
+        }
+
+        let verse_ref = VerseRef {
+            book_number,
+            book_name,
+            chapter,
+            verse_start: verse,
+            verse_end: None,
+        };
+        self.push_recent(&verse_ref);
+        self.context.update(&verse_ref);
+        self.incomplete = None;
+        Some(self.make_direct_detection(&verse_ref, confidence, text, 0, text.len()))
+    }
+
+    /// Record a rejected reference's book (and chapter, when the chapter
+    /// itself is valid) as context, so a follow-up correction that omits the
+    /// book name can still resolve.
+    fn remember_rejected(&mut self, verse_ref: &VerseRef) {
+        let mut ctx_ref = verse_ref.clone();
+        ctx_ref.verse_start = 0;
+        ctx_ref.verse_end = None;
+        if !is_valid_reference(ctx_ref.book_number, ctx_ref.chapter) {
+            ctx_ref.chapter = 0;
+        }
+        self.context.update(&ctx_ref);
     }
 
     /// Check if text contains a "previous verse" / "last verse" command.
@@ -769,6 +925,22 @@ impl DirectDetector {
             transcript_snippet: snippet,
             detected_at: now,
             is_chapter_only: false,
+        }
+    }
+
+    /// Test helper: backdate the pending incomplete reference past its
+    /// timeout without sleeping.
+    #[cfg(test)]
+    fn expire_incomplete(&mut self) {
+        if let Some(ref mut inc) = self.incomplete {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "timeout constant is far below u64::MAX millis"
+            )]
+            let past = std::time::Duration::from_millis(INCOMPLETE_REF_TIMEOUT_MS as u64 + 1_000);
+            if let Some(ts) = Instant::now().checked_sub(past) {
+                inc.timestamp = ts;
+            }
         }
     }
 }
@@ -1606,5 +1778,149 @@ mod tests {
         assert!(!results.is_empty());
         assert_eq!(results[0].verse_ref.chapter, 3);
         assert_eq!(results[0].verse_ref.verse_start, 15);
+    }
+
+    // --- Issue #141: verse-existence validation + contextual resolution ---
+
+    #[test]
+    fn test_nonexistent_verse_not_emitted() {
+        // Revelation 20 ends at verse 15 — 20:22 must never be emitted.
+        let mut detector = DirectDetector::new();
+        let results = detector.detect("Revelation 20:22");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_verse_then_bare_colon_correction() {
+        // The incident from issue #141: preacher says "Revelation 20:22"
+        // (doesn't exist), then corrects to "22:20" without the book name.
+        let mut detector = DirectDetector::new();
+
+        let results = detector.detect("Revelation 20:22");
+        assert!(results.is_empty());
+
+        let results = detector.detect("22:20");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+        assert!(results[0].confidence >= 0.90);
+    }
+
+    #[test]
+    fn test_late_verse_after_emitted_reference() {
+        // After a complete reference is emitted, a later "verse N" must still
+        // resolve against it (the incomplete machine is cleared on emit).
+        let mut detector = DirectDetector::new();
+
+        let results = detector.detect("Revelation chapter 20 verse 2");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.verse_start, 2);
+
+        let results = detector.detect("and the dragon was bound as john saw");
+        assert!(results.is_empty());
+
+        let results = detector.detect("now verse 5 says");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 20);
+        assert_eq!(results[0].verse_ref.verse_start, 5);
+    }
+
+    #[test]
+    fn test_late_verse_number_long_gap() {
+        // "Revelation chapter 20" parks an incomplete ref; after its 15s
+        // timeout expires, "verse 2" must still resolve via context.
+        let mut detector = DirectDetector::new();
+
+        let results = detector.detect("Revelation chapter 20");
+        assert!(results.is_empty());
+        assert!(detector.incomplete.is_some());
+
+        detector.expire_incomplete();
+
+        let results = detector.detect("verse 2");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 20);
+        assert_eq!(results[0].verse_ref.verse_start, 2);
+    }
+
+    #[test]
+    fn test_contextual_requires_context() {
+        // With no book ever heard, book-less patterns must not fire.
+        let mut detector = DirectDetector::new();
+        assert!(detector.detect("22:20").is_empty());
+        assert!(detector.detect("verse 5").is_empty());
+    }
+
+    #[test]
+    fn test_bare_colon_chapter_exceeds_context_book() {
+        // Revelation has 22 chapters — "50:1" can't resolve against it.
+        let mut detector = DirectDetector::new();
+        detector.detect("Revelation 20:2");
+        assert!(detector.detect("50:1").is_empty());
+    }
+
+    #[test]
+    fn test_contextual_nonexistent_verse_rejected() {
+        // Context is Revelation; "20:22" is book-less but still impossible.
+        let mut detector = DirectDetector::new();
+        detector.detect("Revelation 22:1");
+        assert!(detector.detect("20:22").is_empty());
+    }
+
+    #[test]
+    fn test_contextual_chapter_only_parks_incomplete() {
+        // "chapter 22" with Revelation context parks an incomplete ref that
+        // the normal continuation machinery then completes.
+        let mut detector = DirectDetector::new();
+        detector.detect("Revelation 20:2");
+
+        let results = detector.detect("turn to chapter 22");
+        assert!(results.is_empty());
+        let inc = detector.incomplete.as_ref().unwrap();
+        assert_eq!(inc.verse_ref.book_number, 66);
+        assert_eq!(inc.verse_ref.chapter, 22);
+
+        let results = detector.detect("verse 20");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+    }
+
+    #[test]
+    fn test_invalid_continuation_updates_context() {
+        // "Revelation 20" pending, then "22:20" — the continuation colon
+        // pattern must yield 22:20, not treat 22 as a bare verse.
+        let mut detector = DirectDetector::new();
+
+        let results = detector.detect("Revelation 20");
+        assert!(results.is_empty());
+
+        let results = detector.detect("22:20");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+    }
+
+    #[test]
+    fn test_contextual_ignores_time_of_day() {
+        let mut detector = DirectDetector::new();
+        detector.detect("Revelation 20:2");
+        assert!(detector.detect("the service starts at 10:30").is_empty());
+        assert!(detector.detect("10:30 am tomorrow").is_empty());
+    }
+
+    #[test]
+    fn test_verse_range_end_clamped() {
+        // John 3 ends at verse 36 — a range end past that is dropped, but
+        // the valid start still emits.
+        let mut detector = DirectDetector::new();
+        let results = detector.detect("John 3:16-99");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.verse_start, 16);
+        assert_eq!(results[0].verse_ref.verse_end, None);
     }
 }

--- a/src-tauri/crates/detection/src/direct/detector.rs
+++ b/src-tauri/crates/detection/src/direct/detector.rs
@@ -734,6 +734,17 @@ impl DirectDetector {
                 // Full reference — also clear any pending incomplete
                 self.incomplete = None;
 
+                // Repeated citations in one utterance ("Revelation 20:22
+                // Revelation 20:22 sorry…") parse once per book match —
+                // emit each distinct reference only once.
+                if detections.iter().any(|d: &Detection| {
+                    d.verse_ref.book_number == resolved.book_number
+                        && d.verse_ref.chapter == resolved.chapter
+                        && d.verse_ref.verse_start == resolved.verse_start
+                }) {
+                    continue;
+                }
+
                 let confidence = compute_confidence(&resolved, &verse_ref);
                 let snippet = extract_snippet(text, book_match.start, book_match.end);
 
@@ -2045,6 +2056,34 @@ mod tests {
         let detector = DirectDetector::new();
         assert_eq!(detector.mentioned_books("Revelation chapter 20 verse 22"), vec![66]);
         assert_eq!(detector.mentioned_books("22 verse 20."), Vec::<i32>::new());
+    }
+
+    #[test]
+    fn test_sorry_correction_live_sequence() {
+        // Exact live-test flow: repeated invalid citation, "oh, sorry", then
+        // the bare-pair correction — first within one utterance, then the
+        // partial without the correction must not invent a verse.
+        let mut detector = DirectDetector::new();
+
+        let results = detector.detect("Revelation chapter 20 22 Revelation 20 22 Oh, sorry.");
+        assert!(results.is_empty(), "must not invent Rev 20:1, got {results:?}");
+
+        let results =
+            detector.detect("Revelation chapter 20 22 Revelation 20 22 oh, sorry. 22 20.");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].verse_ref.book_number, 66);
+        assert_eq!(results[0].verse_ref.chapter, 22);
+        assert_eq!(results[0].verse_ref.verse_start, 20);
+    }
+
+    #[test]
+    fn test_contraction_is_not_a_book() {
+        // "we're" must not match the Revelation alias "Re".
+        let detector = DirectDetector::new();
+        assert!(detector
+            .mentioned_books("We're opening our bible to the book of Hebrews chapter 12.")
+            .iter()
+            .all(|&b| b == 58));
     }
 
     #[test]

--- a/src-tauri/crates/detection/src/direct/mod.rs
+++ b/src-tauri/crates/detection/src/direct/mod.rs
@@ -4,3 +4,4 @@ pub mod context;
 pub mod detector;
 pub mod fuzzy;
 pub mod parser;
+pub mod versification;

--- a/src-tauri/crates/detection/src/direct/parser.rs
+++ b/src-tauri/crates/detection/src/direct/parser.rs
@@ -669,6 +669,19 @@ pub fn try_extract_continuation(text: &str, is_book_only: bool) -> Option<Contin
         return None;
     }
 
+    // Pattern 0: "N:M" in the leading tokens — a re-citation like "22:20"
+    // right after an incomplete "Revelation 20". Must run before the bare
+    // number pattern, which would otherwise grab the 22 as a verse.
+    for i in 0..tokens.len().min(6) {
+        if let (Some(Token::Number(ch)), Some(Token::Colon), Some(Token::Number(v))) =
+            (tokens.get(i), tokens.get(i + 1), tokens.get(i + 2))
+        {
+            if *ch > 0 && *v > 0 && *v <= 176 {
+                return Some(Continuation::ChapterAndVerse(*ch, *v));
+            }
+        }
+    }
+
     // Pattern 1: "chapter N [... verse M]"
     for i in 0..tokens.len() {
         if let Token::Word(w) = &tokens[i] {
@@ -721,6 +734,120 @@ pub fn try_extract_continuation(text: &str, is_book_only: bool) -> Option<Contin
             }
             // After book+chapter (e.g., "Acts 3"), bare "22" = verse
             return Some(Continuation::VerseOnly(num));
+        }
+    }
+
+    None
+}
+
+/// A book-less reference resolved against recent context (the last book heard).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextualRef {
+    /// "chapter 22 verse 20" (`keyword_anchored: true`) or bare "22:20" (`false`).
+    ChapterVerse {
+        chapter: i32,
+        verse: i32,
+        keyword_anchored: bool,
+    },
+    /// "verse 5" — needs both book and chapter from context.
+    VerseOnly(i32),
+    /// "chapter 22" — book from context, verse still to come.
+    ChapterOnly(i32),
+}
+
+/// True when the "N:M" at token index `i` looks like a time of day rather than
+/// a chapter:verse pair ("at 10:30", "10:30 am", "10:30 a.m.", "10 o'clock").
+fn colon_pair_is_time(tokens: &[Token], i: usize) -> bool {
+    if i > 0 {
+        if let Some(Token::Word(w)) = tokens.get(i - 1) {
+            if w == "at" {
+                return true;
+            }
+        }
+    }
+    match (tokens.get(i + 3), tokens.get(i + 4)) {
+        (Some(Token::Word(w)), _) if w == "am" || w == "pm" || w == "oclock" => true,
+        // Alphabetic-only tokenization splits "a.m." into "a", "m" and
+        // "o'clock" into "o", "clock".
+        (Some(Token::Word(a)), Some(Token::Word(b))) => {
+            ((a == "a" || a == "p") && b == "m") || (a == "o" && b == "clock")
+        }
+        _ => false,
+    }
+}
+
+/// Parse a Bible reference from text that contains NO book name, so it can be
+/// resolved against the last book/chapter heard ([`crate::direct::context::ReferenceContext`]).
+///
+/// Only patterns that are unlikely to fire on ordinary speech are recognized:
+/// keyword-anchored "chapter N [verse M]" and "verse N", plus the bare colon
+/// pair "N:M" (guarded against times of day). Spoken number forms are handled
+/// by [`consume_number`].
+pub fn parse_contextual(text: &str) -> Option<ContextualRef> {
+    let lower = text.to_lowercase();
+    let tokens = tokenize(lower.trim());
+
+    if tokens.is_empty() {
+        return None;
+    }
+
+    // Pattern 1: "chapter N [... verse M]"
+    for i in 0..tokens.len() {
+        if let Token::Word(w) = &tokens[i] {
+            if w == "chapter" {
+                if let Some((chapter, next_idx)) = consume_number(&tokens, i + 1) {
+                    if chapter <= 0 {
+                        continue;
+                    }
+                    // Scan forward for "verse" keyword (up to 15 tokens)
+                    let scan_limit = (next_idx + 15).min(tokens.len());
+                    for j in next_idx..scan_limit {
+                        if let Token::Word(vw) = &tokens[j] {
+                            if vw == "verse" || vw == "verses" {
+                                if let Some((verse, _)) = consume_number(&tokens, j + 1) {
+                                    if verse > 0 && verse <= 176 {
+                                        return Some(ContextualRef::ChapterVerse {
+                                            chapter,
+                                            verse,
+                                            keyword_anchored: true,
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return Some(ContextualRef::ChapterOnly(chapter));
+                }
+            }
+        }
+    }
+
+    // Pattern 2: "verse N" / "verses N" anywhere in text
+    for i in 0..tokens.len() {
+        if let Token::Word(w) = &tokens[i] {
+            if w == "verse" || w == "verses" {
+                if let Some((verse, _)) = consume_number(&tokens, i + 1) {
+                    if verse > 0 && verse <= 176 {
+                        return Some(ContextualRef::VerseOnly(verse));
+                    }
+                }
+            }
+        }
+    }
+
+    // Pattern 3: bare "N:M" — riskier (times of day), so guarded here and
+    // held to a shorter context window by the detector.
+    for i in 0..tokens.len() {
+        if let (Some(Token::Number(ch)), Some(Token::Colon), Some(Token::Number(v))) =
+            (tokens.get(i), tokens.get(i + 1), tokens.get(i + 2))
+        {
+            if *ch > 0 && *v > 0 && *v <= 176 && !colon_pair_is_time(&tokens, i) {
+                return Some(ContextualRef::ChapterVerse {
+                    chapter: *ch,
+                    verse: *v,
+                    keyword_anchored: false,
+                });
+            }
         }
     }
 
@@ -1121,5 +1248,86 @@ mod tests {
             try_extract_continuation("something unrelated here", false),
             None
         );
+    }
+
+    #[test]
+    fn test_continuation_colon_pattern() {
+        // "Revelation 20" pending, then a correction "22:20" — must be
+        // chapter+verse, not a bare-22 verse continuation.
+        assert_eq!(
+            try_extract_continuation("22:20", false),
+            Some(Continuation::ChapterAndVerse(22, 20))
+        );
+        assert_eq!(
+            try_extract_continuation("22:20", true),
+            Some(Continuation::ChapterAndVerse(22, 20))
+        );
+    }
+
+    #[test]
+    fn test_contextual_chapter_verse() {
+        assert_eq!(
+            parse_contextual("go to chapter 22 verse 20"),
+            Some(ContextualRef::ChapterVerse {
+                chapter: 22,
+                verse: 20,
+                keyword_anchored: true
+            })
+        );
+        assert_eq!(
+            parse_contextual("chapter three verse sixteen"),
+            Some(ContextualRef::ChapterVerse {
+                chapter: 3,
+                verse: 16,
+                keyword_anchored: true
+            })
+        );
+    }
+
+    #[test]
+    fn test_contextual_verse_only() {
+        assert_eq!(
+            parse_contextual("now look at verse 2"),
+            Some(ContextualRef::VerseOnly(2))
+        );
+        assert_eq!(
+            parse_contextual("verse twenty two"),
+            Some(ContextualRef::VerseOnly(22))
+        );
+    }
+
+    #[test]
+    fn test_contextual_chapter_only() {
+        assert_eq!(
+            parse_contextual("turn to chapter 22"),
+            Some(ContextualRef::ChapterOnly(22))
+        );
+    }
+
+    #[test]
+    fn test_contextual_bare_colon() {
+        assert_eq!(
+            parse_contextual("22:20"),
+            Some(ContextualRef::ChapterVerse {
+                chapter: 22,
+                verse: 20,
+                keyword_anchored: false
+            })
+        );
+    }
+
+    #[test]
+    fn test_contextual_rejects_time_of_day() {
+        assert_eq!(parse_contextual("see you at 10:30"), None);
+        assert_eq!(parse_contextual("10:30 am"), None);
+        assert_eq!(parse_contextual("10:30 a.m. tomorrow"), None);
+        assert_eq!(parse_contextual("10:30 pm service"), None);
+    }
+
+    #[test]
+    fn test_contextual_none_on_plain_text() {
+        assert_eq!(parse_contextual("the weather is nice today"), None);
+        assert_eq!(parse_contextual("there were 12 disciples"), None);
+        assert_eq!(parse_contextual(""), None);
     }
 }

--- a/src-tauri/crates/detection/src/direct/parser.rs
+++ b/src-tauri/crates/detection/src/direct/parser.rs
@@ -822,12 +822,25 @@ pub fn parse_contextual(text: &str) -> Option<ContextualRef> {
         }
     }
 
-    // Pattern 2: "verse N" / "verses N" anywhere in text
+    // Pattern 2: "[N] verse M" anywhere in text. A number right before the
+    // "verse" keyword is the chapter ("22 verse 20" → 22:20), matching how
+    // spoken corrections omit the "chapter" keyword.
     for i in 0..tokens.len() {
         if let Token::Word(w) = &tokens[i] {
             if w == "verse" || w == "verses" {
                 if let Some((verse, _)) = consume_number(&tokens, i + 1) {
                     if verse > 0 && verse <= 176 {
+                        if i > 0 {
+                            if let Token::Number(chapter) = &tokens[i - 1] {
+                                if *chapter > 0 {
+                                    return Some(ContextualRef::ChapterVerse {
+                                        chapter: *chapter,
+                                        verse,
+                                        keyword_anchored: true,
+                                    });
+                                }
+                            }
+                        }
                         return Some(ContextualRef::VerseOnly(verse));
                     }
                 }
@@ -852,6 +865,27 @@ pub fn parse_contextual(text: &str) -> Option<ContextualRef> {
     }
 
     None
+}
+
+/// All adjacent digit-number pairs in the text, in order of appearance.
+///
+/// Deepgram renders a spoken "twenty-two twenty" as "22 20" — two plain
+/// numbers, never a colon — so corrections like "Revelation 20:22... 22 20"
+/// only surface this way. The detector validates each pair against the
+/// context book and takes the last valid one; this stays safe because it
+/// only runs in a short window after a citation.
+pub fn extract_adjacent_number_pairs(text: &str) -> Vec<(i32, i32)> {
+    let lower = text.to_lowercase();
+    let tokens = tokenize(lower.trim());
+    let mut pairs = Vec::new();
+    for i in 0..tokens.len().saturating_sub(1) {
+        if let (Token::Number(a), Token::Number(b)) = (&tokens[i], &tokens[i + 1]) {
+            if *a > 0 && *b > 0 && *b <= 176 {
+                pairs.push((*a, *b));
+            }
+        }
+    }
+    pairs
 }
 
 #[cfg(test)]
@@ -1329,5 +1363,30 @@ mod tests {
         assert_eq!(parse_contextual("the weather is nice today"), None);
         assert_eq!(parse_contextual("there were 12 disciples"), None);
         assert_eq!(parse_contextual(""), None);
+    }
+
+    #[test]
+    fn test_contextual_number_verse_number() {
+        // "22 verse 20" — a correction that omits the "chapter" keyword.
+        assert_eq!(
+            parse_contextual("22 verse 20."),
+            Some(ContextualRef::ChapterVerse {
+                chapter: 22,
+                verse: 20,
+                keyword_anchored: true
+            })
+        );
+    }
+
+    #[test]
+    fn test_extract_adjacent_number_pairs() {
+        // Deepgram renders spoken "twenty-two twenty" as "22 20", no colon.
+        assert_eq!(extract_adjacent_number_pairs("22 20."), vec![(22, 20)]);
+        assert_eq!(
+            extract_adjacent_number_pairs("Revelation 20 22. 22 20."),
+            vec![(20, 22), (22, 22), (22, 20)]
+        );
+        assert_eq!(extract_adjacent_number_pairs("there were 12 disciples"), vec![]);
+        assert_eq!(extract_adjacent_number_pairs("verse 5"), vec![]);
     }
 }

--- a/src-tauri/crates/detection/src/direct/parser.rs
+++ b/src-tauri/crates/detection/src/direct/parser.rs
@@ -247,6 +247,30 @@ fn try_correction_pattern(tokens: &[Token], book_match: &BookMatch) -> Option<Ve
         }
     }
 
+    // No keywords after the correction — a bare pair ("sorry. 22 20") or
+    // colon pair is the corrected chapter:verse itself.
+    if corrected_chapter.is_none() && corrected_verse.is_none() {
+        for i in (correction_idx + 1)..tokens.len().saturating_sub(1) {
+            if let (Token::Number(ch), second) = (&tokens[i], &tokens[i + 1]) {
+                let verse = match second {
+                    Token::Number(v) => Some(*v),
+                    Token::Colon => match tokens.get(i + 2) {
+                        Some(Token::Number(v)) => Some(*v),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                if let Some(v) = verse {
+                    if *ch > 0 && v > 0 && v <= 176 {
+                        corrected_chapter = Some(*ch);
+                        corrected_verse = Some(v);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     // Apply correction logic:
     // - If something is corrected, use the corrected value
     // - Otherwise, keep the initial value
@@ -258,11 +282,14 @@ fn try_correction_pattern(tokens: &[Token], book_match: &BookMatch) -> Option<Ve
         return None;
     }
 
+    // A missing verse stays 0 (chapter-only): the detector parks it as an
+    // incomplete ref. Defaulting to verse 1 invented detections like
+    // "…chapter 20 … oh, sorry." → 20:1 at full confidence (issue #141).
     Some(VerseRef {
         book_number: book_match.book_number,
         book_name: book_match.book_name.clone(),
         chapter: final_chapter.unwrap_or(1),
-        verse_start: final_verse.unwrap_or(1),
+        verse_start: final_verse.unwrap_or(0),
         verse_end: None,
     })
 }
@@ -1180,13 +1207,37 @@ mod tests {
 
     #[test]
     fn test_correction_chapter_only() {
-        // Pattern: "Romans chapter 8 sorry chapter 12" → Romans 12:1
+        // Pattern: "Romans chapter 8 sorry chapter 12" → Romans 12, no verse
+        // yet (verse_start 0 → parked as incomplete; defaulting to verse 1
+        // used to invent detections the preacher never spoke).
         let bm = make_book_match("Romans", 45, 6);
         let text = "Romans chapter 8 sorry chapter 12";
         let result = parse_reference(text, &bm).unwrap();
         assert_eq!(result.chapter, 12);
-        assert_eq!(result.verse_start, 1);
+        assert_eq!(result.verse_start, 0);
         assert_eq!(result.verse_end, None);
+    }
+
+    #[test]
+    fn test_correction_bare_pair_after_keyword() {
+        // Live incident: "…chapter 20 22 … oh, sorry. 22 20." — the corrected
+        // reference arrives as a bare pair with no chapter/verse keyword.
+        let bm = make_book_match("Revelation", 66, 0);
+        let text = "Revelation chapter 20 22 oh, sorry. 22 20.";
+        let result = parse_reference(text, &bm).unwrap();
+        assert_eq!(result.chapter, 22);
+        assert_eq!(result.verse_start, 20);
+    }
+
+    #[test]
+    fn test_correction_without_numbers_is_chapter_only() {
+        // "…chapter 20 … oh, sorry." with nothing after must NOT invent
+        // verse 1 — it stays chapter-only until the correction arrives.
+        let bm = make_book_match("Revelation", 66, 0);
+        let text = "Revelation chapter 20 oh, sorry.";
+        let result = parse_reference(text, &bm).unwrap();
+        assert_eq!(result.chapter, 20);
+        assert_eq!(result.verse_start, 0);
     }
 
     #[test]

--- a/src-tauri/crates/detection/src/direct/versification.rs
+++ b/src-tauri/crates/detection/src/direct/versification.rs
@@ -1,0 +1,153 @@
+//! Per-chapter verse counts for validating that a cited verse actually exists
+//! (e.g. "Revelation 20:22" is impossible — Revelation 20 ends at verse 15).
+//!
+//! The table is the union max across all bundled translations, generated from
+//! `data/rhema.db`:
+//!
+//! ```sql
+//! SELECT book_number, chapter, MAX(verse) FROM verses GROUP BY 1,2 ORDER BY 1,2
+//! ```
+//!
+//! clamped to the canonical 1,189 chapters (drops Joel 4, which exists only in
+//! Hebrew-numbering translations and is rejected by chapter validation anyway).
+//! Union max means a verse valid in *any* bundled translation passes; the
+//! app layer drops detections whose verse is missing from the *active*
+//! translation. Regenerate this table when translations are added or changed.
+
+/// Max verse number per chapter, indexed by book number (1-66), then by
+/// `chapter - 1`. Index 0 is unused.
+const MAX_VERSES: [&[u16]; 67] = [
+    &[], // 0 unused
+    &[31, 25, 24, 26, 32, 22, 24, 22, 29, 32, 32, 20, 18, 24, 21, 16, 27, 33, 38, 18, 34, 24, 20, 67, 34, 35, 46, 22, 35, 43, 55, 33, 20, 31, 29, 43, 36, 30, 23, 23, 57, 38, 34, 34, 28, 34, 31, 22, 33, 26], // 1 Genesis
+    &[22, 25, 22, 31, 23, 30, 29, 32, 35, 29, 10, 51, 22, 31, 27, 36, 16, 27, 25, 26, 37, 31, 33, 18, 40, 37, 21, 43, 46, 38, 18, 35, 23, 35, 35, 38, 29, 31, 43, 38], // 2 Exodus
+    &[17, 16, 17, 35, 26, 30, 38, 36, 24, 20, 47, 8, 59, 57, 33, 34, 16, 30, 37, 27, 24, 33, 44, 23, 55, 46, 34], // 3 Leviticus
+    &[54, 34, 51, 49, 31, 27, 89, 26, 23, 36, 35, 16, 33, 45, 41, 50, 28, 32, 22, 29, 35, 41, 30, 25, 19, 65, 23, 31, 40, 17, 54, 42, 56, 29, 34, 13], // 4 Numbers
+    &[46, 37, 29, 49, 33, 25, 26, 20, 29, 22, 32, 32, 19, 29, 23, 22, 20, 22, 21, 20, 23, 30, 26, 22, 19, 19, 26, 69, 29, 20, 30, 52, 29, 12], // 5 Deuteronomy
+    &[18, 24, 17, 24, 15, 27, 26, 35, 27, 43, 23, 24, 33, 15, 63, 10, 18, 28, 51, 9, 45, 34, 16, 33], // 6 Joshua
+    &[36, 23, 31, 24, 31, 40, 25, 35, 57, 18, 40, 15, 25, 20, 20, 31, 13, 31, 30, 48, 25], // 7 Judges
+    &[22, 23, 18, 22], // 8 Ruth
+    &[28, 36, 21, 22, 12, 21, 17, 22, 27, 27, 15, 25, 23, 52, 35, 23, 58, 30, 24, 42, 16, 23, 29, 23, 44, 25, 12, 25, 11, 31, 13], // 9 1 Samuel
+    &[27, 32, 39, 12, 25, 23, 29, 18, 13, 19, 27, 31, 39, 33, 37, 23, 29, 33, 44, 26, 22, 51, 39, 25], // 10 2 Samuel
+    &[53, 46, 28, 34, 32, 38, 51, 66, 28, 29, 43, 33, 34, 31, 34, 34, 24, 46, 21, 43, 29, 54], // 11 1 Kings
+    &[18, 25, 27, 44, 27, 33, 20, 29, 37, 36, 21, 22, 25, 29, 39, 20, 41, 37, 37, 21, 26, 20, 37, 20, 30], // 12 2 Kings
+    &[54, 55, 24, 43, 41, 81, 40, 40, 44, 14, 47, 41, 14, 17, 29, 43, 27, 17, 19, 8, 30, 19, 32, 31, 31, 32, 34, 21, 30], // 13 1 Chronicles
+    &[18, 18, 17, 22, 14, 42, 22, 18, 31, 19, 23, 16, 23, 15, 19, 14, 19, 34, 11, 37, 20, 12, 21, 27, 28, 23, 9, 27, 36, 27, 21, 33, 25, 33, 27, 23], // 14 2 Chronicles
+    &[11, 70, 13, 24, 17, 22, 28, 36, 15, 44], // 15 Ezra
+    &[11, 20, 38, 23, 19, 19, 73, 18, 38, 40, 36, 47, 31], // 16 Nehemiah
+    &[22, 23, 15, 17, 14, 14, 10, 17, 32, 3], // 17 Esther
+    &[22, 13, 26, 21, 27, 30, 21, 22, 35, 22, 20, 25, 28, 22, 35, 22, 16, 21, 29, 29, 34, 30, 17, 25, 6, 14, 23, 28, 25, 31, 40, 22, 33, 37, 16, 33, 24, 41, 30, 32, 34, 17], // 18 Job
+    &[6, 12, 9, 9, 13, 11, 18, 10, 21, 18, 7, 9, 6, 7, 5, 11, 15, 51, 15, 10, 14, 32, 6, 10, 22, 12, 14, 9, 11, 13, 25, 11, 22, 23, 28, 13, 40, 23, 14, 18, 14, 12, 5, 27, 18, 12, 10, 15, 21, 23, 21, 11, 7, 9, 24, 14, 12, 12, 18, 14, 9, 13, 12, 11, 14, 20, 8, 36, 37, 6, 24, 20, 28, 23, 11, 13, 21, 72, 13, 20, 17, 8, 19, 13, 14, 17, 7, 19, 53, 17, 16, 16, 5, 23, 11, 13, 12, 9, 9, 5, 8, 29, 22, 35, 45, 48, 43, 14, 31, 7, 10, 10, 9, 8, 18, 19, 2, 29, 176, 7, 8, 9, 4, 8, 5, 6, 5, 6, 8, 8, 3, 18, 3, 3, 21, 26, 9, 8, 24, 14, 10, 8, 12, 15, 21, 10, 20, 14, 9, 6], // 19 Psalms
+    &[33, 22, 35, 27, 23, 35, 27, 36, 18, 32, 31, 28, 25, 35, 33, 33, 28, 24, 29, 30, 31, 29, 35, 34, 28, 28, 27, 28, 27, 33, 31], // 20 Proverbs
+    &[18, 26, 22, 17, 20, 12, 29, 17, 18, 20, 10, 14], // 21 Ecclesiastes
+    &[17, 17, 11, 16, 16, 13, 14, 14], // 22 Song of Solomon
+    &[31, 22, 26, 6, 30, 13, 25, 23, 21, 34, 16, 6, 22, 32, 9, 14, 14, 7, 25, 6, 17, 25, 18, 23, 12, 21, 13, 29, 24, 33, 9, 20, 24, 17, 10, 22, 38, 22, 8, 31, 29, 25, 28, 28, 25, 13, 15, 22, 26, 11, 23, 15, 12, 17, 13, 12, 21, 14, 21, 22, 11, 12, 19, 12, 25, 24], // 23 Isaiah
+    &[19, 37, 25, 31, 31, 30, 34, 23, 26, 25, 23, 17, 27, 22, 21, 21, 27, 23, 15, 18, 14, 30, 40, 10, 38, 24, 22, 17, 32, 24, 40, 44, 26, 22, 19, 32, 21, 28, 18, 16, 18, 22, 13, 30, 5, 28, 7, 47, 39, 46, 64, 34], // 24 Jeremiah
+    &[22, 22, 66, 22, 22], // 25 Lamentations
+    &[28, 10, 27, 17, 17, 14, 27, 18, 11, 22, 25, 28, 23, 23, 8, 63, 24, 32, 14, 49, 37, 31, 49, 27, 17, 21, 36, 26, 21, 26, 18, 32, 33, 31, 15, 38, 28, 23, 29, 49, 26, 20, 27, 31, 25, 24, 23, 35], // 26 Ezekiel
+    &[21, 49, 33, 37, 31, 29, 28, 27, 27, 21, 45, 13], // 27 Daniel
+    &[11, 25, 5, 19, 15, 11, 16, 14, 17, 15, 12, 15, 16, 10], // 28 Hosea
+    &[20, 32, 21], // 29 Joel
+    &[15, 16, 15, 13, 27, 14, 17, 14, 15], // 30 Amos
+    &[21], // 31 Obadiah
+    &[17, 11, 10, 11], // 32 Jonah
+    &[16, 13, 12, 14, 15, 16, 20], // 33 Micah
+    &[15, 14, 19], // 34 Nahum
+    &[17, 20, 19], // 35 Habakkuk
+    &[18, 15, 20], // 36 Zephaniah
+    &[15, 23], // 37 Haggai
+    &[21, 17, 10, 14, 11, 15, 14, 23, 17, 12, 17, 14, 9, 21], // 38 Zechariah
+    &[14, 17, 24, 6], // 39 Malachi
+    &[25, 23, 17, 25, 48, 34, 29, 34, 38, 42, 30, 50, 58, 36, 39, 28, 27, 35, 30, 34, 46, 46, 39, 51, 46, 75, 66, 20], // 40 Matthew
+    &[45, 28, 35, 41, 43, 56, 37, 38, 50, 52, 33, 44, 37, 72, 47, 20], // 41 Mark
+    &[80, 52, 38, 44, 39, 49, 50, 56, 62, 42, 54, 59, 35, 35, 32, 31, 37, 43, 48, 47, 38, 71, 56, 53], // 42 Luke
+    &[51, 25, 36, 54, 47, 71, 53, 59, 41, 42, 57, 50, 38, 31, 27, 33, 26, 40, 42, 31, 25], // 43 John
+    &[26, 47, 26, 37, 42, 15, 60, 40, 43, 48, 30, 25, 52, 28, 41, 40, 34, 28, 41, 38, 40, 30, 35, 27, 27, 32, 44, 31], // 44 Acts
+    &[32, 29, 31, 25, 21, 23, 25, 39, 33, 21, 36, 21, 14, 23, 33, 27], // 45 Romans
+    &[31, 16, 23, 21, 13, 20, 40, 13, 27, 33, 34, 31, 13, 40, 58, 24], // 46 1 Corinthians
+    &[24, 17, 18, 18, 21, 18, 16, 24, 15, 18, 33, 21, 14], // 47 2 Corinthians
+    &[24, 21, 29, 31, 26, 18], // 48 Galatians
+    &[23, 22, 21, 32, 33, 24], // 49 Ephesians
+    &[30, 30, 21, 23], // 50 Philippians
+    &[29, 23, 25, 18], // 51 Colossians
+    &[10, 20, 13, 18, 28], // 52 1 Thessalonians
+    &[12, 17, 18], // 53 2 Thessalonians
+    &[20, 15, 16, 16, 25, 21], // 54 1 Timothy
+    &[18, 26, 17, 22], // 55 2 Timothy
+    &[16, 15, 15], // 56 Titus
+    &[25], // 57 Philemon
+    &[14, 18, 19, 16, 14, 20, 28, 13, 28, 39, 40, 29, 25], // 58 Hebrews
+    &[27, 26, 18, 17, 20], // 59 James
+    &[25, 25, 22, 19, 14], // 60 1 Peter
+    &[21, 22, 18], // 61 2 Peter
+    &[10, 29, 24, 21, 21], // 62 1 John
+    &[13], // 63 2 John
+    &[15], // 64 3 John
+    &[25], // 65 Jude
+    &[20, 29, 22, 11, 14, 17, 17, 13, 21, 11, 19, 18, 18, 20, 8, 21, 18, 24, 21, 15, 27, 21], // 66 Revelation
+];
+
+/// The last verse number of the given chapter, or `None` when the book or
+/// chapter is out of range.
+pub fn max_verse(book_number: i32, chapter: i32) -> Option<i32> {
+    if !(1..=66).contains(&book_number) || chapter < 1 {
+        return None;
+    }
+    #[expect(clippy::cast_sign_loss, reason = "book_number validated to be 1..=66")]
+    let chapters = MAX_VERSES[book_number as usize];
+    #[expect(clippy::cast_sign_loss, reason = "chapter validated to be >= 1")]
+    chapters.get(chapter as usize - 1).map(|&v| i32::from(v))
+}
+
+/// Check that a book/chapter/verse combination exists in at least one
+/// bundled translation.
+pub fn is_valid_verse(book_number: i32, chapter: i32, verse: i32) -> bool {
+    match max_verse(book_number, chapter) {
+        Some(max) => verse >= 1 && verse <= max,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_revelation_20_ends_at_verse_15() {
+        assert_eq!(max_verse(66, 20), Some(15));
+        assert!(!is_valid_verse(66, 20, 22)); // the issue #141 incident
+        assert!(is_valid_verse(66, 20, 15));
+        assert!(is_valid_verse(66, 22, 21)); // last verse of the Bible
+        assert!(!is_valid_verse(66, 22, 22));
+    }
+
+    #[test]
+    fn test_known_chapter_lengths() {
+        assert_eq!(max_verse(19, 119), Some(176)); // Psalm 119
+        assert_eq!(max_verse(43, 3), Some(36)); // John 3
+        assert_eq!(max_verse(1, 1), Some(31)); // Genesis 1
+    }
+
+    #[test]
+    fn test_out_of_range() {
+        assert_eq!(max_verse(0, 1), None);
+        assert_eq!(max_verse(67, 1), None);
+        assert_eq!(max_verse(66, 0), None);
+        assert_eq!(max_verse(66, 23), None); // Revelation has 22 chapters
+        assert!(!is_valid_verse(66, 20, 0));
+        assert!(!is_valid_verse(-1, 1, 1));
+    }
+
+    #[test]
+    fn test_table_shape() {
+        assert!(MAX_VERSES[0].is_empty());
+        let total: usize = MAX_VERSES.iter().map(|c| c.len()).sum();
+        assert_eq!(total, 1189);
+        // Every chapter must have at least one verse.
+        for (book, chapters) in MAX_VERSES.iter().enumerate().skip(1) {
+            assert!(!chapters.is_empty(), "book {book} has no chapters");
+            for (i, &v) in chapters.iter().enumerate() {
+                assert!(v >= 1, "book {book} chapter {} has zero verses", i + 1);
+            }
+        }
+    }
+}

--- a/src-tauri/src/commands/stt.rs
+++ b/src-tauri/src/commands/stt.rs
@@ -804,6 +804,31 @@ fn check_reading_mode(app: &AppHandle, transcript: &str, direct_found: bool) -> 
 
     let rm_managed: &Mutex<ReadingMode> = app.state::<Mutex<ReadingMode>>().inner();
 
+    // If the utterance explicitly names a book that differs from the one
+    // being read, it's a spoken reference (possibly one direct detection
+    // rejected as non-existent), not an in-book navigation command. Reading
+    // mode must not reinterpret its numbers against its own book — that's
+    // how "Revelation chapter 20 verse 22" while reading Hebrews 12 ended
+    // up presenting Hebrews 12:22 (issue #141).
+    {
+        let rm_book = {
+            let Ok(rm) = rm_managed.lock() else { return false };
+            if rm.is_active() || rm.has_verses() { rm.current_book() } else { 0 }
+        };
+        if rm_book != 0 {
+            let detector_state: State<'_, Mutex<rhema_detection::DirectDetector>> = app.state();
+            let mentioned = match detector_state.lock() {
+                Ok(d) => d.mentioned_books(transcript),
+                Err(_) => Vec::new(),
+            };
+            drop(detector_state);
+            if !mentioned.is_empty() && !mentioned.contains(&rm_book) {
+                log::info!("[READING] Skipping — utterance names a different book than the one being read");
+                return false;
+            }
+        }
+    }
+
     // Check for chapter navigation commands (e.g., "let's go to chapter seven").
     {
         let chapter_change = {
@@ -841,12 +866,22 @@ fn check_reading_mode(app: &AppHandle, transcript: &str, direct_found: bool) -> 
                 if !chapter_verses.is_empty() {
                     let start_verse = change.start_verse.unwrap_or(1);
 
-                    // Find the text for the starting verse
-                    let start_verse_text = chapter_verses
+                    // Never navigate to a verse that doesn't exist in the
+                    // chapter (e.g. "chapter 12 verse 64") — presenting
+                    // verse 1's text under a wrong reference is worse than
+                    // ignoring the command (issue #141).
+                    let Some(start_verse_text) = chapter_verses
                         .iter()
                         .find(|v| v.verse == start_verse)
                         .map(|v| v.text.clone())
-                        .unwrap_or_else(|| chapter_verses[0].text.clone());
+                    else {
+                        log::warn!(
+                            "[READING] Ignoring chapter change — verse {start_verse} not in {} {}",
+                            change.book_name,
+                            change.new_chapter
+                        );
+                        return false;
+                    };
 
                     let verses: Vec<(i32, String)> = chapter_verses
                         .into_iter()

--- a/src-tauri/src/commands/stt.rs
+++ b/src-tauri/src/commands/stt.rs
@@ -562,15 +562,35 @@ fn run_direct_detection(app: &AppHandle, transcript: &str) -> bool {
             return false;
         }
     };
-    let results: Vec<super::detection::DetectionResult> = merged
+    let mut results: Vec<super::detection::DetectionResult> = merged
         .iter()
         .map(|m| super::detection::to_result(&app_state, m))
         .collect();
+
+    // Backstop for issue #141: the detector validates against union-max verse
+    // counts across all translations, so a verse can still be missing from
+    // the *active* translation. Never emit a detection with no text.
+    if app_state.bible_db.is_some() {
+        results.retain(|r| {
+            if r.verse_text.is_empty() {
+                log::warn!(
+                    "[DET-DIRECT] Dropping {} — verse not found in active translation",
+                    r.verse_ref
+                );
+                false
+            } else {
+                true
+            }
+        });
+    }
 
     for r in &results {
         log::info!("[DET-DIRECT] Found: {} ({:.0}%)", r.verse_ref, r.confidence * 100.0);
     }
     drop(app_state);
+    if results.is_empty() {
+        return false;
+    }
     log::info!(
         "[LAT] emit verse_detections t={} src=direct n={} first={:?}",
         epoch_ms(),

--- a/src/hooks/use-broadcast.test.ts
+++ b/src/hooks/use-broadcast.test.ts
@@ -120,6 +120,36 @@ describe("presentVerse", () => {
     expect(useBroadcastStore.getState().liveSourceVerse).toEqual(fullVerse)
   })
 
+  it("refuses to present a verse with empty text (issue #141)", async () => {
+    // Refetch finds nothing and the cached verse has no text (e.g. a cited
+    // verse that doesn't exist) — the live output must not change.
+    mockInvoke.mockResolvedValue(null)
+
+    await presentVerse(staleVerse)
+
+    expect(useBroadcastStore.getState().liveVerse).toBeNull()
+    expect(useBroadcastStore.getState().liveSourceVerse).toBeNull()
+  })
+
+  it("refuses to replace the live verse with an empty one", async () => {
+    const fullVerse: Verse = { ...staleVerse, id: 26137, translation_id: 2, text: "For God so loved the world" }
+    // Route by command — mark() also calls invoke ("ui_mark"), so Once
+    // queues would be consumed by instrumentation.
+    let lookups = 0
+    mockInvoke.mockImplementation((cmd: unknown) => {
+      if (cmd !== "get_verse") return Promise.resolve(undefined)
+      lookups += 1
+      return Promise.resolve(lookups === 1 ? fullVerse : null)
+    })
+
+    await presentVerse(staleVerse)
+    await presentVerse({ ...sampleVerse, text: "" })
+
+    expect(useBroadcastStore.getState().liveVerse?.reference).toBe(
+      "John 3:16 (NKJV)",
+    )
+  })
+
   it("ignores a stale refetch that resolves after a newer present call", async () => {
     const older: Verse = { ...sampleVerse, verse: 1, text: "In the beginning" }
     let resolveOlder: (v: Verse) => void = () => {}

--- a/src/hooks/use-broadcast.ts
+++ b/src/hooks/use-broadcast.ts
@@ -49,6 +49,16 @@ export async function presentVerse(verse: Verse): Promise<void> {
   // A newer present started while we were refetching — let it win.
   if (ticket !== presentSeq) return
 
+  // Never present a verse with no text (e.g. a citation that doesn't exist
+  // in the active translation) — keep whatever is currently live instead.
+  if (!verseToPresent.text?.trim()) {
+    console.warn(
+      "[broadcast] refusing to present verse with empty text:",
+      `${verseToPresent.book_name} ${verseToPresent.chapter}:${verseToPresent.verse}`,
+    )
+    return
+  }
+
   const bibleState = useBibleStore.getState()
   const translation =
     bibleState.translations.find((t) => t.id === bibleState.activeTranslationId)


### PR DESCRIPTION
Addresses items 1 and 3 of #141 (item 2 needs clarification from the reporter — see below).

## Problem

From a live service ([video](https://youtu.be/0sd79akM6Qo?t=4809)):

1. The preacher cited **Revelation 20:22** — a verse that doesn't exist (Rev 20 ends at v15). The app projected it with a blank body. He then corrected himself to **"22:20"** without repeating the book name, and nothing was detected.
2. A verse number called out well after the book ("Revelation chapter 20 … several sentences … verse 2") was missed: the incomplete-reference machine times out after 15s and is cleared whenever a complete reference is emitted.

## Changes

**Verse-existence validation**
- New `versification.rs` in the detection crate: per-chapter max-verse table (union max across all bundled translations, generated from `data/rhema.db`, 1,189 chapters). All three emit paths in `DirectDetector` now reject verses that can't exist — while still recording the book/chapter as context so a follow-up correction can resolve.
- App-layer backstop in `run_direct_detection`: detections whose verse is missing from the *active* translation (empty text) are dropped with a warning instead of emitted.
- `presentVerse` refuses to put a verse with empty text on the live display.
- Invalid range ends are clamped (`John 3:16-99` → 3:16) instead of killing the detection.

**Contextual (book-less) resolution**
- `ReferenceContext` — previously dead code — is now consulted when a transcript contains no book name. `parse_contextual` recognizes `chapter N verse M` (0.95), `verse N` (0.92), bare `N:M` (0.90), and `chapter N` (parks an incomplete ref). Context window raised 60s → 90s.
- Bare `N:M` is the riskiest pattern (times of day), so it additionally requires context updated within 30s and is guarded against "at 10:30" / "10:30 am" / "o'clock".
- The continuation parser now understands `N:M` after an incomplete reference ("Revelation 20" → "22:20" used to parse as verse 22).

All contextual confidences are ≥0.90 so the semantic FTS pass stays suppressed and auto-queue (≥0.80) still applies.

## The incident, end-to-end

"Revelation 20:22" → verse validation fails → nothing emitted, context = Revelation 20 → "22:20" → no book match → contextual colon pattern → **Revelation 22:20** → valid → presented.

## Tests

- 11 new detector scenario tests (including the exact incident and the late-verse-after-timeout case), 7 new parser tests, 4 versification tests — `cargo test -p rhema-detection`: **194 passed**.
- 2 new `presentVerse` guard tests — `npm test`: **144 passed**.

## Not in this PR

Issue item 2 ("when a direct verse is detected, it rarely changes the live display to another (semantic) verse while still presenting") is ambiguous — semantic detections never auto-present today. Will ask the reporter to clarify on the issue.