### PR TITLE
feat(remote): send-to-live, Bible-panel stepping, and add-to-queue commands

### DIFF
--- a/documentation/remote-control.md
+++ b/documentation/remote-control.md
@@ -5,7 +5,10 @@ Rhema provides two remote control protocols for external integration: **OSC** (O
 ## Overview
 
 Remote control enables you to:
-- **Navigate verses** - Advance or go back through your verse queue
+- **Navigate the queue** - Advance or go back through your verse queue
+- **Read through a passage** - Step the Bible Text panel verse by verse, independently of the queue
+- **Drive the Live output** - Send the current Preview to Live
+- **Build the queue** - Add the previewed verse to the queue
 - **Control broadcast** - Show/hide output, toggle on-air status
 - **Switch themes** - Change active broadcast theme by name
 - **Adjust settings** - Modify confidence threshold and opacity
@@ -196,6 +199,98 @@ curl -X POST http://localhost:8080/api/v1/command \
   -d '{"command":"confidence","value":0.8}'
 ```
 
+### 9. **send_to_live** — Send the Preview to the Live Display
+
+Puts the verse currently showing in **Program preview** on the Live output — the same thing
+the panel's "Send to live" button does.
+
+Detections that Rhema is confident about go straight to Live; everything else stages in
+Preview first. This command is how you push a staged verse out without touching the app
+window. If nothing is in Preview, the command does nothing — it will never blank what the
+congregation is seeing.
+
+**OSC:**
+```
+/rhema/send_to_live
+```
+
+**HTTP:**
+```bash
+curl -X POST http://localhost:8080/api/v1/command \
+  -H "Content-Type: application/json" \
+  -d '{"command":"send_to_live"}'
+```
+
+### 10. **bible_next** — Next Verse in the Bible Text Panel
+
+Moves the **Bible Text** panel's selection forward one verse and scrolls it into view. The
+verse lands in Preview, ready for `send_to_live`.
+
+This is separate from `next`, which moves the **Queue**. Use `bible_next` to read straight
+through a passage the AI has not picked up yet; the Queue does not move.
+
+At the end of a chapter it continues into the next chapter of the same book. At the end of a
+book it stops — it does not roll over into the next book.
+
+**OSC:**
+```
+/rhema/bible_next
+```
+
+**HTTP:**
+```bash
+curl -X POST http://localhost:8080/api/v1/command \
+  -H "Content-Type: application/json" \
+  -d '{"command":"bible_next"}'
+```
+
+### 11. **bible_prev** — Previous Verse in the Bible Text Panel
+
+The reverse of `bible_next`. At the start of a chapter it continues into the last verse of the
+previous chapter; at the start of a book it stops.
+
+**OSC:**
+```
+/rhema/bible_prev
+```
+
+**HTTP:**
+```bash
+curl -X POST http://localhost:8080/api/v1/command \
+  -H "Content-Type: application/json" \
+  -d '{"command":"bible_prev"}'
+```
+
+### 12. **add_to_queue** — Add the Previewed Verse to the Queue
+
+Adds the verse currently showing in Preview to the Queue, exactly as the **+** button on a
+verse row does. Pressing it twice for the same verse is harmless — the Queue rejects
+duplicates.
+
+**OSC:**
+```
+/rhema/add_to_queue
+```
+
+**HTTP:**
+```bash
+curl -X POST http://localhost:8080/api/v1/command \
+  -H "Content-Type: application/json" \
+  -d '{"command":"add_to_queue"}'
+```
+
+> **Note on arguments:** `send_to_live`, `bible_next`, `bible_prev` and `add_to_queue` take no
+> arguments.
+>
+> Over **OSC** this is forgiving: controllers that send a value with every button press
+> (TouchOSC and Companion both do) work fine — the extra argument is ignored. Verified with
+> `/rhema/bible_next` carrying a float and `/rhema/add_to_queue` carrying an int; both dispatch
+> normally.
+>
+> Over **HTTP** it is strict: send `{"command":"bible_next"}` exactly. Adding a `value` key
+> returns `422 Unprocessable Entity`, because these commands deserialize as argument-free
+> variants. The same applies to `show` and `hide`.
+
 ## HTTP API Endpoints
 
 The HTTP API provides additional endpoints for querying status.
@@ -234,7 +329,16 @@ curl -X POST http://localhost:8080/api/v1/command \
 **Response:**
 ```json
 {
-  "status": "ok"
+  "success": true
+}
+```
+
+A rejected command returns `500` with the reason attached:
+
+```json
+{
+  "success": false,
+  "error": "Unknown OSC address: /rhema/nope"
 }
 ```
 
@@ -249,11 +353,18 @@ curl -X POST http://localhost:8080/api/v1/command \
    - Host: `127.0.0.1` (or your Rhema computer's IP)
    - Port: `8000`
 3. **Create buttons** for each command:
-   - **Next Verse**: OSC path `/rhema/next`
-   - **Prev Verse**: OSC path `/rhema/prev`
+   - **Next in Queue**: OSC path `/rhema/next`
+   - **Prev in Queue**: OSC path `/rhema/prev`
+   - **Next Verse (Bible panel)**: OSC path `/rhema/bible_next`
+   - **Prev Verse (Bible panel)**: OSC path `/rhema/bible_prev`
+   - **Send to Live**: OSC path `/rhema/send_to_live`
+   - **Add to Queue**: OSC path `/rhema/add_to_queue`
    - **Show Output**: OSC path `/rhema/show`
    - **Hide Output**: OSC path `/rhema/hide`
    - **Go Live**: OSC path `/rhema/on_air` with argument `true`
+
+A useful three-button layout for reading through a passage the AI has not detected:
+`bible_next` / `bible_prev` to move, `send_to_live` to push the verse you land on.
 
 ### TouchOSC / Lemur
 
@@ -265,6 +376,10 @@ Mobile control surfaces can send OSC commands directly.
 3. Configure OSC addresses:
    - `/rhema/next`
    - `/rhema/prev`
+   - `/rhema/bible_next`
+   - `/rhema/bible_prev`
+   - `/rhema/send_to_live`
+   - `/rhema/add_to_queue`
    - `/rhema/show`
    - `/rhema/hide`
 
@@ -313,6 +428,10 @@ const osc = new Client('localhost', 8000);
 // Send commands
 osc.send('/rhema/next');
 osc.send('/rhema/prev');
+osc.send('/rhema/bible_next');
+osc.send('/rhema/bible_prev');
+osc.send('/rhema/send_to_live');
+osc.send('/rhema/add_to_queue');
 osc.send('/rhema/theme', 'Classic Dark');
 osc.send('/rhema/opacity', 0.8);
 osc.send('/rhema/on_air', true);
@@ -356,6 +475,10 @@ osc = udp_client.SimpleUDPClient('localhost', 8000)
 # Send commands
 osc.send_message('/rhema/next', [])
 osc.send_message('/rhema/prev', [])
+osc.send_message('/rhema/bible_next', [])
+osc.send_message('/rhema/bible_prev', [])
+osc.send_message('/rhema/send_to_live', [])
+osc.send_message('/rhema/add_to_queue', [])
 osc.send_message('/rhema/theme', 'Classic Dark')
 osc.send_message('/rhema/opacity', 0.8)
 osc.send_message('/rhema/on_air', True)
@@ -439,16 +562,24 @@ If you see "Port already in use" error:
 
 ### Network Exposure
 
-By default, both OSC and HTTP bind to `0.0.0.0`, making them accessible from any device on your network.
+Both OSC and HTTP bind to `0.0.0.0`, so while a server is running it is reachable from any
+device on your network. There is no authentication, and CORS allows any origin. **This is not
+currently configurable from the app** — enabling a server exposes it to the whole network.
 
-**For local-only access:**
-- Bind to `127.0.0.1` instead (requires editing settings)
-- This prevents remote network access
+**`send_to_live` raises what that costs you.** Until now the worst an unauthenticated request
+could do was advance the queue or toggle opacity. It can now put a verse of its choosing on
+the Live output in front of the congregation. Treat an enabled remote-control server as an
+open door to your broadcast.
 
-**For production environments:**
-- Use firewall rules to restrict access
-- Consider VPN or SSH tunneling for remote access
-- HTTP does not include authentication (add reverse proxy with auth if needed)
+**Until a loopback-by-default option ships:**
+- Only enable the OSC and HTTP servers when you are actually using them
+- Restrict the ports (default 8000/UDP and 8080/TCP) with firewall rules to the devices that
+  need them
+- Prefer a trusted, password-protected network over open guest Wi-Fi
+- For remote access, use a VPN or SSH tunnel rather than exposing the ports directly
+
+Binding to loopback by default, with network exposure as an explicit opt-in, is the next
+change scheduled for this surface.
 
 ### Command Validation
 
@@ -472,7 +603,7 @@ All commands are validated before execution:
 - **Framework**: Axum (Rust async web framework)
 - **Transport**: TCP with keep-alive
 - **Content-Type**: `application/json`
-- **CORS**: Disabled by default (local use only)
+- **CORS**: Permissive — any origin is allowed. A page open in a browser on the same machine or network can reach this API. See [Security Considerations](#security-considerations).
 
 ### Command Flow
 
@@ -498,12 +629,13 @@ This ensures the `/api/v1/status` endpoint always returns current data.
 
 Planned additions to remote control:
 
+- **Loopback binding by default**, with network exposure as an explicit opt-in
+- **Authentication** for HTTP API (API keys or OAuth)
 - **WebSocket API** for real-time bidirectional communication
 - **MIDI support** for hardware controllers with MIDI over USB
-- **Authentication** for HTTP API (API keys or OAuth)
 - **Custom command macros** (trigger multiple commands at once)
 - **Verse navigation by reference** (e.g., `/rhema/goto John 3:16`)
-- **Queue management** (add/remove/reorder verses remotely)
+- **Further queue management** — removing, reordering and clearing (adding is covered by `add_to_queue`)
 
 ## Support
 

--- a/src-tauri/crates/api/src/coerce.rs
+++ b/src-tauri/crates/api/src/coerce.rs
@@ -89,8 +89,10 @@ pub fn coerce_string(arg: &OscType) -> Result<String, CommandError> {
 
 /// Parse an OSC address + arguments into a `RemoteCommand`.
 ///
-/// Handles all 8 Rhema OSC addresses:
+/// Handles all 12 Rhema OSC addresses:
 /// - `/rhema/next`, `/rhema/prev`, `/rhema/show`, `/rhema/hide` (no arguments)
+/// - `/rhema/send_to_live`, `/rhema/bible_next`, `/rhema/bible_prev`,
+///   `/rhema/add_to_queue` (no arguments)
 /// - `/rhema/theme` (string argument)
 /// - `/rhema/opacity`, `/rhema/confidence` (float argument, normalized to [0.0, 1.0])
 /// - `/rhema/on_air` (bool argument)
@@ -100,6 +102,10 @@ pub fn parse_osc(address: &str, args: &[OscType]) -> Result<RemoteCommand, Comma
         "/rhema/prev" => Ok(RemoteCommand::Prev),
         "/rhema/show" => Ok(RemoteCommand::Show),
         "/rhema/hide" => Ok(RemoteCommand::Hide),
+        "/rhema/send_to_live" => Ok(RemoteCommand::SendToLive),
+        "/rhema/bible_next" => Ok(RemoteCommand::BibleNext),
+        "/rhema/bible_prev" => Ok(RemoteCommand::BiblePrev),
+        "/rhema/add_to_queue" => Ok(RemoteCommand::AddToQueue),
         "/rhema/theme" => {
             let arg = args.first().ok_or_else(|| CommandError::MissingArgument {
                 address: address.into(),
@@ -278,6 +284,52 @@ mod tests {
     #[test]
     fn parse_osc_hide() {
         assert_eq!(parse_osc("/rhema/hide", &[]).unwrap(), RemoteCommand::Hide);
+    }
+
+    #[test]
+    fn parse_osc_send_to_live() {
+        assert_eq!(
+            parse_osc("/rhema/send_to_live", &[]).unwrap(),
+            RemoteCommand::SendToLive
+        );
+    }
+
+    #[test]
+    fn parse_osc_bible_next() {
+        assert_eq!(
+            parse_osc("/rhema/bible_next", &[]).unwrap(),
+            RemoteCommand::BibleNext
+        );
+    }
+
+    #[test]
+    fn parse_osc_bible_prev() {
+        assert_eq!(
+            parse_osc("/rhema/bible_prev", &[]).unwrap(),
+            RemoteCommand::BiblePrev
+        );
+    }
+
+    #[test]
+    fn parse_osc_add_to_queue() {
+        assert_eq!(
+            parse_osc("/rhema/add_to_queue", &[]).unwrap(),
+            RemoteCommand::AddToQueue
+        );
+    }
+
+    #[test]
+    fn parse_osc_argument_free_commands_ignore_stray_args() {
+        // Controllers send a trailing value on every button press; the
+        // argument-free commands must treat it as noise, not an error.
+        assert_eq!(
+            parse_osc("/rhema/send_to_live", &[OscType::Float(1.0)]).unwrap(),
+            RemoteCommand::SendToLive
+        );
+        assert_eq!(
+            parse_osc("/rhema/bible_next", &[OscType::Int(1)]).unwrap(),
+            RemoteCommand::BibleNext
+        );
     }
 
     #[test]

--- a/src-tauri/crates/api/src/command.rs
+++ b/src-tauri/crates/api/src/command.rs
@@ -17,6 +17,10 @@ pub enum RemoteCommand {
     Opacity(f32),
     Confidence(f32),
     OnAir(bool),
+    SendToLive,
+    BibleNext,
+    BiblePrev,
+    AddToQueue,
 }
 
 impl fmt::Display for RemoteCommand {
@@ -30,6 +34,10 @@ impl fmt::Display for RemoteCommand {
             RemoteCommand::Opacity(val) => write!(f, "opacity({val:.2})"),
             RemoteCommand::Confidence(val) => write!(f, "confidence({val:.2})"),
             RemoteCommand::OnAir(active) => write!(f, "on_air({active})"),
+            RemoteCommand::SendToLive => write!(f, "send_to_live"),
+            RemoteCommand::BibleNext => write!(f, "bible_next"),
+            RemoteCommand::BiblePrev => write!(f, "bible_prev"),
+            RemoteCommand::AddToQueue => write!(f, "add_to_queue"),
         }
     }
 }
@@ -88,6 +96,30 @@ mod tests {
         assert_eq!(json, serde_json::json!({"command": "on_air", "value": true}));
     }
 
+    #[test]
+    fn serialize_send_to_live() {
+        let json = serde_json::to_value(&RemoteCommand::SendToLive).unwrap();
+        assert_eq!(json, serde_json::json!({"command": "send_to_live"}));
+    }
+
+    #[test]
+    fn serialize_bible_next() {
+        let json = serde_json::to_value(&RemoteCommand::BibleNext).unwrap();
+        assert_eq!(json, serde_json::json!({"command": "bible_next"}));
+    }
+
+    #[test]
+    fn serialize_bible_prev() {
+        let json = serde_json::to_value(&RemoteCommand::BiblePrev).unwrap();
+        assert_eq!(json, serde_json::json!({"command": "bible_prev"}));
+    }
+
+    #[test]
+    fn serialize_add_to_queue() {
+        let json = serde_json::to_value(&RemoteCommand::AddToQueue).unwrap();
+        assert_eq!(json, serde_json::json!({"command": "add_to_queue"}));
+    }
+
     // --- Serde deserialization tests ---
 
     #[test]
@@ -110,6 +142,30 @@ mod tests {
         assert_eq!(cmd, RemoteCommand::Confidence(0.75));
     }
 
+    #[test]
+    fn deserialize_send_to_live() {
+        let cmd: RemoteCommand = serde_json::from_str(r#"{"command":"send_to_live"}"#).unwrap();
+        assert_eq!(cmd, RemoteCommand::SendToLive);
+    }
+
+    #[test]
+    fn deserialize_bible_next() {
+        let cmd: RemoteCommand = serde_json::from_str(r#"{"command":"bible_next"}"#).unwrap();
+        assert_eq!(cmd, RemoteCommand::BibleNext);
+    }
+
+    #[test]
+    fn deserialize_bible_prev() {
+        let cmd: RemoteCommand = serde_json::from_str(r#"{"command":"bible_prev"}"#).unwrap();
+        assert_eq!(cmd, RemoteCommand::BiblePrev);
+    }
+
+    #[test]
+    fn deserialize_add_to_queue() {
+        let cmd: RemoteCommand = serde_json::from_str(r#"{"command":"add_to_queue"}"#).unwrap();
+        assert_eq!(cmd, RemoteCommand::AddToQueue);
+    }
+
     // --- Round-trip tests ---
 
     #[test]
@@ -123,6 +179,10 @@ mod tests {
             RemoteCommand::Opacity(0.5),
             RemoteCommand::Confidence(0.9),
             RemoteCommand::OnAir(false),
+            RemoteCommand::SendToLive,
+            RemoteCommand::BibleNext,
+            RemoteCommand::BiblePrev,
+            RemoteCommand::AddToQueue,
         ];
 
         for cmd in variants {
@@ -171,11 +231,31 @@ mod tests {
         assert_eq!(RemoteCommand::OnAir(false).to_string(), "on_air(false)");
     }
 
+    #[test]
+    fn display_send_to_live() {
+        assert_eq!(RemoteCommand::SendToLive.to_string(), "send_to_live");
+    }
+
+    #[test]
+    fn display_bible_next() {
+        assert_eq!(RemoteCommand::BibleNext.to_string(), "bible_next");
+    }
+
+    #[test]
+    fn display_bible_prev() {
+        assert_eq!(RemoteCommand::BiblePrev.to_string(), "bible_prev");
+    }
+
+    #[test]
+    fn display_add_to_queue() {
+        assert_eq!(RemoteCommand::AddToQueue.to_string(), "add_to_queue");
+    }
+
     // --- Exhaustive match test ---
 
     #[test]
-    fn enum_has_exactly_8_variants() {
-        // This test ensures all 8 variants are covered.
+    fn enum_has_exactly_12_variants() {
+        // This test ensures all 12 variants are covered.
         // If a new variant is added, this match will fail to compile.
         let cmds: Vec<RemoteCommand> = vec![
             RemoteCommand::Next,
@@ -186,6 +266,10 @@ mod tests {
             RemoteCommand::Opacity(0.0),
             RemoteCommand::Confidence(0.0),
             RemoteCommand::OnAir(false),
+            RemoteCommand::SendToLive,
+            RemoteCommand::BibleNext,
+            RemoteCommand::BiblePrev,
+            RemoteCommand::AddToQueue,
         ];
 
         for cmd in &cmds {
@@ -198,9 +282,13 @@ mod tests {
                 RemoteCommand::Opacity(_) => {}
                 RemoteCommand::Confidence(_) => {}
                 RemoteCommand::OnAir(_) => {}
+                RemoteCommand::SendToLive => {}
+                RemoteCommand::BibleNext => {}
+                RemoteCommand::BiblePrev => {}
+                RemoteCommand::AddToQueue => {}
             }
         }
 
-        assert_eq!(cmds.len(), 8);
+        assert_eq!(cmds.len(), 12);
     }
 }

--- a/src-tauri/crates/api/src/dispatch.rs
+++ b/src-tauri/crates/api/src/dispatch.rs
@@ -16,7 +16,8 @@ pub trait CommandSink: Send + Sync {
 
 /// Routes `RemoteCommand` variants to the correct sink method.
 ///
-/// Frontend-bound (`emit_event`): Next, Prev, Theme, Opacity, `OnAir`
+/// Frontend-bound (`emit_event`): Next, Prev, Theme, Opacity, `OnAir`,
+/// `SendToLive`, `BibleNext`, `BiblePrev`, `AddToQueue`
 /// Backend-bound (`invoke_backend`): Show, Hide, Confidence
 pub struct CommandDispatcher;
 
@@ -40,6 +41,10 @@ impl CommandDispatcher {
                 let payload = serde_json::json!({ "active": active }).to_string();
                 sink.emit_event("remote:on_air", &payload)
             }
+            RemoteCommand::SendToLive => sink.emit_event("remote:send_to_live", "{}"),
+            RemoteCommand::BibleNext => sink.emit_event("remote:bible_next", "{}"),
+            RemoteCommand::BiblePrev => sink.emit_event("remote:bible_prev", "{}"),
+            RemoteCommand::AddToQueue => sink.emit_event("remote:add_to_queue", "{}"),
             RemoteCommand::Show => sink.invoke_backend("show_broadcast", "{}"),
             RemoteCommand::Hide => sink.invoke_backend("hide_broadcast", "{}"),
             RemoteCommand::Confidence(val) => {
@@ -170,6 +175,46 @@ mod tests {
         assert!(payload.contains("true"));
     }
 
+    // The event name is the whole contract with the frontend listener — no
+    // compiler or type checker crosses that boundary, so each one is pinned
+    // here as a literal and again in src/lib/remote-events.ts.
+
+    #[test]
+    fn dispatch_send_to_live_emits_event() {
+        let sink = MockSink::new();
+        CommandDispatcher::dispatch(&RemoteCommand::SendToLive, &sink).unwrap();
+        assert_eq!(sink.event_count(), 1);
+        assert_eq!(sink.backend_count(), 0);
+        assert_eq!(sink.last_event().0, "remote:send_to_live");
+    }
+
+    #[test]
+    fn dispatch_bible_next_emits_event() {
+        let sink = MockSink::new();
+        CommandDispatcher::dispatch(&RemoteCommand::BibleNext, &sink).unwrap();
+        assert_eq!(sink.event_count(), 1);
+        assert_eq!(sink.backend_count(), 0);
+        assert_eq!(sink.last_event().0, "remote:bible_next");
+    }
+
+    #[test]
+    fn dispatch_bible_prev_emits_event() {
+        let sink = MockSink::new();
+        CommandDispatcher::dispatch(&RemoteCommand::BiblePrev, &sink).unwrap();
+        assert_eq!(sink.event_count(), 1);
+        assert_eq!(sink.backend_count(), 0);
+        assert_eq!(sink.last_event().0, "remote:bible_prev");
+    }
+
+    #[test]
+    fn dispatch_add_to_queue_emits_event() {
+        let sink = MockSink::new();
+        CommandDispatcher::dispatch(&RemoteCommand::AddToQueue, &sink).unwrap();
+        assert_eq!(sink.event_count(), 1);
+        assert_eq!(sink.backend_count(), 0);
+        assert_eq!(sink.last_event().0, "remote:add_to_queue");
+    }
+
     // --- Backend-bound command tests ---
 
     #[test]
@@ -211,6 +256,10 @@ mod tests {
             RemoteCommand::Theme("test".into()),
             RemoteCommand::Opacity(0.5),
             RemoteCommand::OnAir(false),
+            RemoteCommand::SendToLive,
+            RemoteCommand::BibleNext,
+            RemoteCommand::BiblePrev,
+            RemoteCommand::AddToQueue,
         ];
 
         for cmd in &frontend_cmds {
@@ -227,6 +276,8 @@ mod tests {
 
     #[test]
     fn backend_commands_never_emit_events() {
+        // Unchanged by the four commands added for #144 — all of them are
+        // frontend-bound, so none belongs in this list.
         let backend_cmds = vec![
             RemoteCommand::Show,
             RemoteCommand::Hide,

--- a/src-tauri/crates/api/src/http.rs
+++ b/src-tauri/crates/api/src/http.rs
@@ -115,7 +115,9 @@ where
     let app = Router::new()
         .route("/api/v1/health", get(health_handler))
         .route("/api/v1/status", get(status_handler::<S>))
-        .route("/api/v1/control", post(control_handler::<S>))
+        .route("/api/v1/command", post(command_handler::<S>))
+        // Undocumented alias for the path the code shipped with before #146.
+        .route("/api/v1/control", post(command_handler::<S>))
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -178,33 +180,33 @@ async fn status_handler<S: CommandSink + 'static>(
 }
 
 #[derive(Deserialize)]
-struct ControlRequest {
+struct CommandRequest {
     #[serde(flatten)]
     command: RemoteCommand,
 }
 
 #[derive(Serialize)]
-struct ControlResponse {
+struct CommandResponse {
     success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
 
-async fn control_handler<S: CommandSink + 'static>(
+async fn command_handler<S: CommandSink + 'static>(
     AxumState(state): AxumState<Arc<AppState<S>>>,
-    Json(request): Json<ControlRequest>,
+    Json(request): Json<CommandRequest>,
 ) -> impl IntoResponse {
     match CommandDispatcher::dispatch(&request.command, &*state.sink) {
         Ok(()) => (
             StatusCode::OK,
-            Json(ControlResponse {
+            Json(CommandResponse {
                 success: true,
                 error: None,
             }),
         ),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ControlResponse {
+            Json(CommandResponse {
                 success: false,
                 error: Some(e.to_string()),
             }),
@@ -350,8 +352,41 @@ mod tests {
         handle.stop();
     }
 
+    /// The path asserted here is the one `documentation/remote-control.md`
+    /// publishes. Issue #146 shipped because this test asserted the path the
+    /// router happened to mount instead, so the two could drift apart and
+    /// still pass.
     #[tokio::test]
-    async fn control_endpoint_dispatches_command() {
+    async fn command_endpoint_dispatches_command() {
+        let sink = Arc::new(MockSink::new());
+        let status = new_shared_status();
+        let config = HttpConfig {
+            port: 0,
+            host: "127.0.0.1".into(),
+        };
+
+        let result = start_http_server(config, sink.clone(), status)
+            .await
+            .expect("should bind");
+        let port = result.bound_port;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let body = r#"{"command":"next"}"#;
+        let resp = raw_http_request(port, "POST", "/api/v1/command", Some(body)).await;
+        assert!(resp.contains("200 OK"), "Expected 200, got: {resp}");
+        assert!(resp.contains("\"success\":true"));
+
+        // Give dispatch a moment
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(sink.command_count() > 0, "Sink should have received command");
+
+        let mut handle = result.handle;
+        handle.stop();
+    }
+
+    #[tokio::test]
+    async fn control_alias_still_dispatches() {
         let sink = Arc::new(MockSink::new());
         let status = new_shared_status();
         let config = HttpConfig {
@@ -371,7 +406,31 @@ mod tests {
         assert!(resp.contains("200 OK"), "Expected 200, got: {resp}");
         assert!(resp.contains("\"success\":true"));
 
-        // Give dispatch a moment
+        let mut handle = result.handle;
+        handle.stop();
+    }
+
+    #[tokio::test]
+    async fn command_endpoint_dispatches_send_to_live() {
+        let sink = Arc::new(MockSink::new());
+        let status = new_shared_status();
+        let config = HttpConfig {
+            port: 0,
+            host: "127.0.0.1".into(),
+        };
+
+        let result = start_http_server(config, sink.clone(), status)
+            .await
+            .expect("should bind");
+        let port = result.bound_port;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let body = r#"{"command":"send_to_live"}"#;
+        let resp = raw_http_request(port, "POST", "/api/v1/command", Some(body)).await;
+        assert!(resp.contains("200 OK"), "Expected 200, got: {resp}");
+        assert!(resp.contains("\"success\":true"));
+
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(sink.command_count() > 0, "Sink should have received command");
 

--- a/src/components/panels/search-panel.tsx
+++ b/src/components/panels/search-panel.tsx
@@ -29,7 +29,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { useBible, bibleActions } from "@/hooks/use-bible"
+import { useBible, bibleActions, findLoadedVerse } from "@/hooks/use-bible"
 import { useBibleStore, useQueueStore } from "@/stores"
 import type { Book, Verse, SemanticSearchResult } from "@/types"
 import { Input } from "@/components/ui/input"
@@ -105,11 +105,14 @@ function HighlightedText({ text, query }: { text: string; query: string }) {
   )
 }
 
+// Monotonic ticket so an older chapter load that resolves late can neither
+// select its verse nor clear a newer navigation's pending target.
+let navSeq = 0
+
 export function SearchPanel() {
   const [activeTab, setActiveTab] = useState<SearchTab>("book")
   const [selectedBook, setSelectedBook] = useState<Book | null>(null)
   const [chapter, setChapter] = useState(1)
-  const [selectedVerseId, setSelectedVerseId] = useState<number | null>(null)
   const [contextQuery, setContextQuery] = useState("")
 
   // EasyWorship-style autocomplete
@@ -157,24 +160,64 @@ export function SearchPanel() {
     }
   }, [selectedBookNumber, chapter, activeTranslationId])
 
-  const effectiveSelectedVerseId = useMemo(() => {
-    if (!selectedVerseId || currentChapter.length === 0) return null
-    if (currentChapter.some((v) => v.id === selectedVerseId)) return selectedVerseId
-    if (!selectedVerse) return null
-    return currentChapter.find((v) => v.verse === selectedVerse.verse)?.id ?? null
-  }, [currentChapter, selectedVerseId, selectedVerse])
+  // The highlight follows the store, not component state, so a remote command
+  // or a keyboard shortcut moves it just as a click does. Matching on
+  // book/chapter/verse is also what drops the highlight when the operator
+  // changes chapter — the selected verse no longer belongs to what's on screen.
+  const effectiveSelectedVerseId = useMemo(
+    () =>
+      findLoadedVerse(
+        currentChapter,
+        selectedVerse
+          ? {
+              bookNumber: selectedVerse.book_number,
+              chapter: selectedVerse.chapter,
+              verse: selectedVerse.verse,
+            }
+          : null
+      )?.id ?? null,
+    [currentChapter, selectedVerse]
+  )
 
-  // After chapter reloads (e.g., translation change), re-select by verse number
+  // After a chapter reloads in a different translation the verse rows carry new
+  // ids, so re-point the selection at the row that is actually on screen.
   useEffect(() => {
-    if (!selectedVerseId || !selectedVerse || currentChapter.length === 0) return
-    const stillExists = currentChapter.some((v) => v.id === selectedVerseId)
-    if (!stillExists) {
-      const match = currentChapter.find((v) => v.verse === selectedVerse.verse)
-      if (match && match.id !== selectedVerse.id) {
-        bibleActions.selectVerse(match)
-      }
+    if (!selectedVerse || currentChapter.length === 0) return
+    const match = currentChapter.find(
+      (v) =>
+        v.book_number === selectedVerse.book_number &&
+        v.chapter === selectedVerse.chapter &&
+        v.verse === selectedVerse.verse
+    )
+    if (match && match.id !== selectedVerse.id) {
+      bibleActions.selectVerse(match)
     }
-  }, [currentChapter, selectedVerseId, selectedVerse])
+  }, [currentChapter, selectedVerse])
+
+  // The one place a verse row is scrolled into view. Driven by an explicit
+  // reveal request rather than by `selectedVerse`, because `presentVerse`
+  // selects a verse on every auto-live detection and must not drag the
+  // operator's scroll position around mid-service.
+  const revealRequest = useBibleStore((s) => s.revealRequest)
+  useEffect(() => {
+    if (revealRequest === 0) return
+    const { selectedVerse: target, currentChapter: chapterVerses, revealBlock } =
+      useBibleStore.getState()
+    const row = findLoadedVerse(
+      chapterVerses,
+      target
+        ? {
+            bookNumber: target.book_number,
+            chapter: target.chapter,
+            verse: target.verse,
+          }
+        : null
+    )
+    if (!row) return
+    document
+      .getElementById(`verse-${row.id}`)
+      ?.scrollIntoView({ behavior: "smooth", block: revealBlock })
+  }, [revealRequest])
 
   const applyNavigationSelection = useCallback(
     (book: Book, navChapter: number) => {
@@ -201,26 +244,35 @@ export function SearchPanel() {
       if (pendingKey === lastHandledKey) return
 
       const book = state.books.find((b) => b.book_number === bookNumber)
-      if (!book) return
+      if (!book) {
+        // Unreachable navigation — clear it, or every later step chains off a
+        // target that can never land. Reachable with no Bible database, where
+        // the book list stays empty indefinitely.
+        useBibleStore.getState().setPendingNavigation(null)
+        return
+      }
 
       lastHandledKey = pendingKey
       applyNavigationSelection(book, navChapter)
 
-      // Load chapter explicitly, then select + scroll to the verse.
+      navSeq += 1
+      const ticket = navSeq
+
+      // Load chapter explicitly, then select + reveal the verse.
       mark(`nav loadChapter start ${bookNumber} ${navChapter}:${navVerse}`)
       bibleActions.loadChapter(bookNumber, navChapter).then((verses) => {
         mark(`nav loadChapter done ${bookNumber} ${navChapter}:${navVerse} n=${verses.length}`)
+        if (ticket !== navSeq) return
         const target = verses.find((v) => v.verse === navVerse)
         if (target) {
-          setSelectedVerseId(target.id)
           bibleActions.selectVerse(target)
-          document
-            .getElementById(`verse-${target.id}`)
-            ?.scrollIntoView({ behavior: "smooth", block: "center" })
+          useBibleStore.getState().requestVerseReveal("center")
         }
         panelRef.current?.focus()
       }).catch(console.error).finally(() => {
-        useBibleStore.getState().setPendingNavigation(null)
+        // Only the newest load may clear the pending target; a stale one would
+        // wipe the cursor the next step is chaining off.
+        if (ticket === navSeq) useBibleStore.getState().setPendingNavigation(null)
       })
     })
 
@@ -228,56 +280,30 @@ export function SearchPanel() {
   }, [applyNavigationSelection])
 
   const handleVerseClick = useCallback((verse: Verse) => {
-    setSelectedVerseId(verse.id)
     bibleActions.selectVerse(verse)
   }, [])
 
-  // Arrow key navigation
+  // Arrow key navigation. Up and Down run the same stepping action the remote
+  // bible_next / bible_prev commands do, so the two surfaces cannot diverge.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "ArrowLeft") {
         e.preventDefault()
         if (chapter > 1) {
           setChapter((c) => c - 1)
-            setSelectedVerseId(null)
         }
       } else if (e.key === "ArrowRight") {
         e.preventDefault()
         setChapter((c) => c + 1)
-        setSelectedVerseId(null)
       } else if (e.key === "ArrowDown") {
         e.preventDefault()
-        if (currentChapter.length === 0) return
-        const currentIdx = effectiveSelectedVerseId
-          ? currentChapter.findIndex((v) => v.id === effectiveSelectedVerseId)
-          : -1
-        const nextIdx = Math.min(currentIdx + 1, currentChapter.length - 1)
-        const next = currentChapter[nextIdx]
-        if (next) {
-          setSelectedVerseId(next.id)
-          bibleActions.selectVerse(next)
-          document
-            .getElementById(`verse-${next.id}`)
-            ?.scrollIntoView({ behavior: "smooth", block: "nearest" })
-        }
+        void bibleActions.stepVerse("next")
       } else if (e.key === "ArrowUp") {
         e.preventDefault()
-        if (currentChapter.length === 0) return
-        const currentIdx = effectiveSelectedVerseId
-          ? currentChapter.findIndex((v) => v.id === effectiveSelectedVerseId)
-          : currentChapter.length
-        const prevIdx = Math.max(currentIdx - 1, 0)
-        const prev = currentChapter[prevIdx]
-        if (prev) {
-          setSelectedVerseId(prev.id)
-          bibleActions.selectVerse(prev)
-          document
-            .getElementById(`verse-${prev.id}`)
-            ?.scrollIntoView({ behavior: "smooth", block: "nearest" })
-        }
+        void bibleActions.stepVerse("prev")
       }
     },
-    [chapter, currentChapter, effectiveSelectedVerseId]
+    [chapter]
   )
 
   // Context search — hybrid backend (vector + FTS5 BM25) as primary,
@@ -626,7 +652,6 @@ export function SearchPanel() {
                 onClick={() => {
                   if (chapter > 1) {
                     setChapter((c) => c - 1)
-                                setSelectedVerseId(null)
                   }
                 }}
                 disabled={chapter <= 1}
@@ -638,7 +663,6 @@ export function SearchPanel() {
                 size="icon-xs"
                 onClick={() => {
                   setChapter((c) => c + 1)
-                            setSelectedVerseId(null)
                 }}
               >
                 <ArrowRightIcon className="size-3" />

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -48,6 +48,7 @@ import { useSettingsStore } from "@/stores"
 import { useTranscriptStore } from "@/stores/transcript-store"
 import { useTutorialStore } from "@/stores/tutorial-store"
 import { useSettingsDialogStore } from "@/lib/settings-dialog"
+import { REMOTE_EVENTS } from "@/lib/remote-events"
 import type { DeviceInfo } from "@/types/audio"
 
 /* -------------------------------------------------------------------------- */
@@ -632,12 +633,7 @@ function RemoteControlSection() {
     async function setup() {
       const { listen } = await import("@tauri-apps/api/event")
 
-      const remoteEvents = [
-        "remote:next", "remote:prev", "remote:theme", "remote:opacity",
-        "remote:on_air", "remote:show", "remote:hide", "remote:confidence",
-      ]
-
-      for (const event of remoteEvents) {
+      for (const event of Object.values(REMOTE_EVENTS)) {
         const unlisten = await listen(event, () => {
           if (cancelled) return
           const entry: CommandLogEntry = {

--- a/src/hooks/use-bible.test.ts
+++ b/src/hooks/use-bible.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { Verse } from "@/types"
+
+const mockInvoke = vi.fn()
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+import { findLoadedVerse, stepVerse } from "./use-bible"
+import { useBibleStore } from "@/stores/bible-store"
+
+function verse(
+  bookNumber: number,
+  chapter: number,
+  verseNumber: number,
+  bookName = "John"
+): Verse {
+  return {
+    id: bookNumber * 1_000_000 + chapter * 1_000 + verseNumber,
+    translation_id: 1,
+    book_number: bookNumber,
+    book_name: bookName,
+    book_abbreviation: bookName.slice(0, 3),
+    chapter,
+    verse: verseNumber,
+    text: `${bookName} ${chapter}:${verseNumber}`,
+  }
+}
+
+/** John 3, verses 1..10. */
+const johnThree = Array.from({ length: 10 }, (_, i) => verse(43, 3, i + 1))
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+  useBibleStore.setState({
+    activeTranslationId: 1,
+    currentChapter: johnThree,
+    selectedVerse: johnThree[4], // John 3:5
+    pendingNavigation: null,
+    revealRequest: 0,
+    revealBlock: "nearest",
+  })
+})
+
+describe("findLoadedVerse", () => {
+  it("matches on book, chapter and verse together", () => {
+    expect(
+      findLoadedVerse(johnThree, { bookNumber: 43, chapter: 3, verse: 7 })?.verse
+    ).toBe(7)
+  })
+
+  it("does not match a verse number from a different chapter", () => {
+    expect(
+      findLoadedVerse(johnThree, { bookNumber: 43, chapter: 4, verse: 7 })
+    ).toBeNull()
+  })
+
+  it("returns null for a null target", () => {
+    expect(findLoadedVerse(johnThree, null)).toBeNull()
+  })
+})
+
+describe("stepVerse within a loaded chapter", () => {
+  it("selects the next verse without any IPC round trip", async () => {
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(6)
+    expect(useBibleStore.getState().pendingNavigation).toBeNull()
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it("selects the previous verse without any IPC round trip", async () => {
+    await stepVerse("prev")
+
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(4)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it("asks the panel to reveal the verse it selected", async () => {
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().revealRequest).toBe(1)
+    expect(useBibleStore.getState().revealBlock).toBe("nearest")
+  })
+
+  it("enters the loaded chapter at the first verse when nothing is selected", async () => {
+    useBibleStore.setState({ selectedVerse: null })
+
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(1)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it("enters the loaded chapter at the last verse when stepping back from nothing", async () => {
+    useBibleStore.setState({ selectedVerse: null })
+
+    await stepVerse("prev")
+
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(10)
+  })
+
+  it("does nothing when nothing is selected and no chapter is loaded", async () => {
+    useBibleStore.setState({ selectedVerse: null, currentChapter: [] })
+
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().selectedVerse).toBeNull()
+    expect(useBibleStore.getState().pendingNavigation).toBeNull()
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+})
+
+describe("stepVerse across a chapter boundary", () => {
+  it("lands on the first verse of the next chapter", async () => {
+    useBibleStore.setState({ selectedVerse: johnThree[9] }) // John 3:10, last loaded
+    const johnFour = Array.from({ length: 5 }, (_, i) => verse(43, 4, i + 1))
+    mockInvoke.mockResolvedValue(johnFour)
+
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().pendingNavigation).toEqual({
+      bookNumber: 43,
+      chapter: 4,
+      verse: 1,
+    })
+  })
+
+  it("leaves the loaded chapter untouched — the probe never writes the store", async () => {
+    useBibleStore.setState({ selectedVerse: johnThree[9] })
+    mockInvoke.mockResolvedValue([verse(43, 4, 1)])
+
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().currentChapter).toBe(johnThree)
+  })
+
+  it("resolves the concrete last verse of the previous chapter, not a sentinel", async () => {
+    useBibleStore.setState({ selectedVerse: johnThree[0] }) // John 3:1
+    const johnTwo = Array.from({ length: 25 }, (_, i) => verse(43, 2, i + 1))
+    mockInvoke.mockResolvedValue(johnTwo)
+
+    await stepVerse("prev")
+
+    expect(useBibleStore.getState().pendingNavigation).toEqual({
+      bookNumber: 43,
+      chapter: 2,
+      verse: 25,
+    })
+  })
+
+  it("does nothing at the end of a book — stepping never crosses into the next book", async () => {
+    const malachiFour = Array.from({ length: 6 }, (_, i) => verse(39, 4, i + 1, "Malachi"))
+    useBibleStore.setState({
+      currentChapter: malachiFour,
+      selectedVerse: malachiFour[5], // Malachi 4:6
+    })
+    mockInvoke.mockResolvedValue([]) // Malachi 5 does not exist
+
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().pendingNavigation).toBeNull()
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(6)
+    expect(useBibleStore.getState().currentChapter).toBe(malachiFour)
+  })
+
+  it("does nothing before Genesis 1:1, without any IPC round trip", async () => {
+    const genesisOne = [verse(1, 1, 1, "Genesis"), verse(1, 1, 2, "Genesis")]
+    useBibleStore.setState({
+      currentChapter: genesisOne,
+      selectedVerse: genesisOne[0],
+    })
+
+    await stepVerse("prev")
+
+    expect(useBibleStore.getState().pendingNavigation).toBeNull()
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it("leaves every piece of state untouched when the probe rejects", async () => {
+    useBibleStore.setState({ selectedVerse: johnThree[9] })
+    mockInvoke.mockRejectedValue(new Error("db unavailable"))
+
+    await expect(stepVerse("next")).resolves.toBeUndefined()
+
+    expect(useBibleStore.getState().pendingNavigation).toBeNull()
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(10)
+    expect(useBibleStore.getState().currentChapter).toBe(johnThree)
+  })
+})
+
+describe("stepVerse under rapid presses", () => {
+  it("advances from the in-flight target rather than the stale selection", async () => {
+    useBibleStore.setState({
+      pendingNavigation: { bookNumber: 43, chapter: 3, verse: 7 },
+    })
+
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().pendingNavigation).toEqual({
+      bookNumber: 43,
+      chapter: 3,
+      verse: 8,
+    })
+  })
+
+  it("lets a corrective step in the loaded chapter cancel an in-flight crossing", async () => {
+    // The operator overshoots at the end of a chapter, then immediately steps
+    // back. The correction lands synchronously; the crossing it replaced must
+    // not arrive afterwards and drag the panel into the next chapter.
+    useBibleStore.setState({ selectedVerse: johnThree[9] }) // John 3:10
+
+    let resolveStale: (v: Verse[]) => void = () => {}
+    mockInvoke.mockImplementationOnce(
+      () => new Promise<Verse[]>((resolve) => (resolveStale = resolve))
+    )
+
+    const stale = stepVerse("next")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await stepVerse("prev")
+
+    resolveStale([verse(43, 4, 1)])
+    await stale
+
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(9)
+    expect(useBibleStore.getState().pendingNavigation).toBeNull()
+  })
+
+  it("lets the newer crossing win when an older probe resolves last", async () => {
+    useBibleStore.setState({ selectedVerse: johnThree[9] }) // John 3:10, last loaded
+
+    let resolveStale: (v: Verse[]) => void = () => {}
+    mockInvoke
+      .mockImplementationOnce(
+        () => new Promise<Verse[]>((resolve) => (resolveStale = resolve))
+      )
+      .mockResolvedValue([verse(43, 4, 1)])
+
+    const stale = stepVerse("next")
+    // Let the first step get as far as its chapter probe before the second
+    // starts, so the two are genuinely in flight together.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await stepVerse("next")
+
+    expect(useBibleStore.getState().pendingNavigation).toEqual({
+      bookNumber: 43,
+      chapter: 4,
+      verse: 1,
+    })
+
+    // The stale probe lands afterwards carrying a different first verse — it
+    // must not overwrite the navigation the newer step already committed.
+    resolveStale([verse(43, 4, 3)])
+    await stale
+
+    expect(useBibleStore.getState().pendingNavigation).toEqual({
+      bookNumber: 43,
+      chapter: 4,
+      verse: 1,
+    })
+  })
+})

--- a/src/hooks/use-bible.ts
+++ b/src/hooks/use-bible.ts
@@ -19,17 +19,31 @@ async function loadBooks(translationId?: number) {
   return books
 }
 
-async function loadChapter(
+/**
+ * Read a chapter without touching the store. A chapter that does not exist
+ * comes back as an empty array, never an error, which makes this the probe
+ * used to test a chapter boundary — `loadChapter` would blank the panel it is
+ * being asked to protect.
+ */
+export async function fetchChapter(
   bookNumber: number,
   chapter: number,
   translationId?: number
 ) {
   const id = translationId ?? useBibleStore.getState().activeTranslationId
-  const verses = await invoke<Verse[]>("get_chapter", {
+  return invoke<Verse[]>("get_chapter", {
     translationId: id,
     bookNumber,
     chapter,
   })
+}
+
+async function loadChapter(
+  bookNumber: number,
+  chapter: number,
+  translationId?: number
+) {
+  const verses = await fetchChapter(bookNumber, chapter, translationId)
   useBibleStore.getState().setCurrentChapter(verses)
   return verses
 }
@@ -87,11 +101,151 @@ async function loadCrossReferences(
   return refs
 }
 
+interface VerseCoordinates {
+  bookNumber: number
+  chapter: number
+  verse: number
+}
+
+/**
+ * Find a verse in a loaded chapter by its coordinates.
+ *
+ * Matching on book/chapter/verse rather than `Verse.id` is what keeps a
+ * selection meaningful across a translation switch, where ids change, and what
+ * drops the selection when the panel moves to a different chapter.
+ */
+export function findLoadedVerse(
+  chapterVerses: Verse[],
+  target: VerseCoordinates | null
+): Verse | null {
+  if (!target) return null
+  return (
+    chapterVerses.find(
+      (v) =>
+        v.book_number === target.bookNumber &&
+        v.chapter === target.chapter &&
+        v.verse === target.verse
+    ) ?? null
+  )
+}
+
+function coordinatesOf(verse: Verse): VerseCoordinates {
+  return {
+    bookNumber: verse.book_number,
+    chapter: verse.chapter,
+    verse: verse.verse,
+  }
+}
+
+// Monotonic ticket so an older step whose chapter probe resolves late can't
+// overwrite a newer one (a held controller button steps in quick succession).
+let stepSeq = 0
+
+/**
+ * Move the Bible panel's selection one verse in `direction`.
+ *
+ * Shared by the panel's arrow keys, the OSC/HTTP `bible_next` and `bible_prev`
+ * commands, and (from Phase 2) the bracket shortcuts, so the surfaces cannot
+ * drift apart.
+ *
+ * A target already in the loaded chapter is selected synchronously. Anything
+ * else — a chapter boundary, or a verse picked from a context search in a
+ * chapter the panel never loaded — goes through `pendingNavigation`, the
+ * panel's existing load-then-select path.
+ *
+ * Both boundary directions probe before navigating, and the probe never writes
+ * the store: the end of a book, the start of Genesis, and a chapter missing
+ * from the active translation all resolve to doing nothing at all, leaving the
+ * panel showing exactly what it was showing.
+ */
+export async function stepVerse(direction: "next" | "prev"): Promise<void> {
+  // Claim the ticket before anything else. A step that resolves synchronously
+  // still has to invalidate a crossing already in flight, or the operator's
+  // correction lands and the crossing it replaced arrives afterwards.
+  stepSeq += 1
+  const ticket = stepSeq
+
+  const state = useBibleStore.getState()
+  const offset = direction === "next" ? 1 : -1
+
+  const cursor =
+    state.pendingNavigation ??
+    (state.selectedVerse ? coordinatesOf(state.selectedVerse) : null)
+
+  // Nothing selected yet: enter the loaded chapter from the end the operator
+  // is stepping away from.
+  if (!cursor) {
+    const entry =
+      direction === "next"
+        ? state.currentChapter[0]
+        : state.currentChapter[state.currentChapter.length - 1]
+    if (!entry) return
+    state.selectVerse(entry)
+    state.requestVerseReveal("nearest")
+    return
+  }
+
+  const target = { ...cursor, verse: cursor.verse + offset }
+
+  if (!state.pendingNavigation) {
+    const loaded = findLoadedVerse(state.currentChapter, target)
+    if (loaded) {
+      state.selectVerse(loaded)
+      state.requestVerseReveal("nearest")
+      return
+    }
+  }
+
+  try {
+    const cursorChapter = await resolveChapter(state.currentChapter, cursor)
+    if (ticket !== stepSeq) return
+
+    if (cursorChapter.some((v) => v.verse === target.verse)) {
+      useBibleStore.getState().setPendingNavigation(target)
+      return
+    }
+
+    const crossingChapter = cursor.chapter + offset
+    if (crossingChapter < 1) return
+
+    const crossing = await fetchChapter(cursor.bookNumber, crossingChapter)
+    if (ticket !== stepSeq) return
+    if (crossing.length === 0) return
+
+    const landing = direction === "next" ? crossing[0] : crossing[crossing.length - 1]
+    useBibleStore.getState().setPendingNavigation({
+      bookNumber: cursor.bookNumber,
+      chapter: crossingChapter,
+      verse: landing.verse,
+    })
+  } catch (e) {
+    console.warn("[bible] stepVerse chapter lookup failed:", e)
+  }
+}
+
+async function resolveChapter(
+  currentChapter: Verse[],
+  cursor: VerseCoordinates
+): Promise<Verse[]> {
+  const loaded = currentChapter[0]
+  if (
+    loaded &&
+    loaded.book_number === cursor.bookNumber &&
+    loaded.chapter === cursor.chapter
+  ) {
+    return currentChapter
+  }
+  return fetchChapter(cursor.bookNumber, cursor.chapter)
+}
+
 // Exported stable references — these never change between renders
 export const bibleActions = {
   loadTranslations,
   loadBooks,
   loadChapter,
+  fetchChapter,
+  findLoadedVerse,
+  stepVerse,
   fetchVerse,
   searchVerses,
   semanticSearch,

--- a/src/hooks/use-remote-control.ts
+++ b/src/hooks/use-remote-control.ts
@@ -4,7 +4,8 @@ import { invoke } from "@tauri-apps/api/core"
 import { useBroadcastStore } from "@/stores/broadcast-store"
 import { useQueueStore } from "@/stores/queue-store"
 import { useSettingsStore } from "@/stores/settings-store"
-import { presentVerse } from "@/hooks/use-broadcast"
+import { REMOTE_EVENTS } from "@/lib/remote-events"
+import { remoteActions } from "@/lib/remote-actions"
 
 /**
  * Listens for remote control events from the Rust backend (OSC / HTTP API)
@@ -18,40 +19,26 @@ export function useRemoteControl() {
     const unlisteners: UnlistenFn[] = []
 
     async function setup() {
-      // remote:next — advance queue to next verse and present it
-      const u1 = await listen("remote:next", () => {
-        if (cancelled) return
-        const { items, activeIndex } = useQueueStore.getState()
-        if (items.length === 0) return
-
-        const currentIndex = activeIndex ?? findCurrentVerseIndex()
-        const nextIndex = Math.min(
-          currentIndex === null ? 0 : currentIndex + 1,
-          items.length - 1
+      const register = async (event: string, handler: () => void) => {
+        unlisteners.push(
+          await listen(event, () => {
+            if (cancelled) return
+            handler()
+          }),
         )
-        useQueueStore.getState().setActive(nextIndex)
-        presentQueueItem(nextIndex)
-      })
-      unlisteners.push(u1)
+      }
 
-      // remote:prev — go to previous verse in queue and present it
-      const u2 = await listen("remote:prev", () => {
-        if (cancelled) return
-        const { items, activeIndex } = useQueueStore.getState()
-        if (items.length === 0) return
-
-        const currentIndex = activeIndex ?? findCurrentVerseIndex()
-        const prevIndex = Math.max(
-          currentIndex === null ? 0 : currentIndex - 1,
-          0
-        )
-        useQueueStore.getState().setActive(prevIndex)
-        presentQueueItem(prevIndex)
-      })
-      unlisteners.push(u2)
+      await register(REMOTE_EVENTS.next, remoteActions.queueNext)
+      await register(REMOTE_EVENTS.prev, remoteActions.queuePrev)
+      await register(REMOTE_EVENTS.send_to_live, remoteActions.sendToLive)
+      await register(REMOTE_EVENTS.add_to_queue, remoteActions.addToQueue)
+      await register(REMOTE_EVENTS.bible_next, remoteActions.bibleNext)
+      await register(REMOTE_EVENTS.bible_prev, remoteActions.biblePrev)
+      await register(REMOTE_EVENTS.show, () => remoteActions.toggleOnAir(true))
+      await register(REMOTE_EVENTS.hide, () => remoteActions.toggleOnAir(false))
 
       // remote:theme — switch active theme by name
-      const u3 = await listen<string>("remote:theme", (event) => {
+      const u3 = await listen<string>(REMOTE_EVENTS.theme, (event) => {
         if (cancelled) return
         const payload = parsePayload(event.payload)
         const name = payload?.name as string | undefined
@@ -68,7 +55,7 @@ export function useRemoteControl() {
       unlisteners.push(u3)
 
       // remote:opacity — set broadcast output opacity
-      const u4 = await listen<string>("remote:opacity", (event) => {
+      const u4 = await listen<string>(REMOTE_EVENTS.opacity, (event) => {
         if (cancelled) return
         const payload = parsePayload(event.payload)
         const value = payload?.value as number | undefined
@@ -81,31 +68,17 @@ export function useRemoteControl() {
       unlisteners.push(u4)
 
       // remote:on_air — toggle live broadcast state
-      const u5 = await listen<string>("remote:on_air", (event) => {
+      const u5 = await listen<string>(REMOTE_EVENTS.on_air, (event) => {
         if (cancelled) return
         const payload = parsePayload(event.payload)
         const active = payload?.active as boolean | undefined
         if (active === undefined) return
-        useBroadcastStore.getState().setLive(active)
+        remoteActions.toggleOnAir(active)
       })
       unlisteners.push(u5)
 
-      // remote:show — show broadcast output
-      const u6 = await listen("remote:show", () => {
-        if (cancelled) return
-        useBroadcastStore.getState().setLive(true)
-      })
-      unlisteners.push(u6)
-
-      // remote:hide — hide broadcast output
-      const u7 = await listen("remote:hide", () => {
-        if (cancelled) return
-        useBroadcastStore.getState().setLive(false)
-      })
-      unlisteners.push(u7)
-
       // remote:confidence — set detection confidence threshold
-      const u8 = await listen<string>("remote:confidence", (event) => {
+      const u8 = await listen<string>(REMOTE_EVENTS.confidence, (event) => {
         if (cancelled) return
         const payload = parsePayload(event.payload)
         const value = payload?.value as number | undefined
@@ -128,32 +101,6 @@ export function useRemoteControl() {
       clearInterval(statusInterval)
     }
   }, [])
-}
-
-/**
- * Find the index of the currently displayed verse in the queue.
- * Returns null if the live verse doesn't match any queue item.
- */
-function findCurrentVerseIndex(): number | null {
-  const { liveVerse } = useBroadcastStore.getState()
-  if (!liveVerse) return null
-
-  const { items } = useQueueStore.getState()
-  const index = items.findIndex(
-    (item) => item.reference === liveVerse.reference
-  )
-  return index >= 0 ? index : null
-}
-
-/**
- * Present a queue item at the given index to the live display.
- */
-async function presentQueueItem(index: number) {
-  const item = useQueueStore.getState().items[index]
-  if (!item) return
-  await presentVerse(item.verse).catch((e) =>
-    console.warn("[remote-control] presentQueueItem failed:", e)
-  )
 }
 
 /**

--- a/src/lib/remote-actions.test.ts
+++ b/src/lib/remote-actions.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { Verse } from "@/types"
+
+const mockInvoke = vi.fn()
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emitTo: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { remoteActions } from "./remote-actions"
+import { useBibleStore } from "@/stores/bible-store"
+import { useBroadcastStore } from "@/stores/broadcast-store"
+import { useQueueStore } from "@/stores/queue-store"
+
+const johnThreeSixteen: Verse = {
+  id: 26137,
+  translation_id: 1,
+  book_number: 43,
+  book_name: "John",
+  book_abbreviation: "Jn",
+  chapter: 3,
+  verse: 16,
+  text: "For God so loved the world",
+}
+
+const genesisOneOne: Verse = {
+  id: 1,
+  translation_id: 1,
+  book_number: 1,
+  book_name: "Genesis",
+  book_abbreviation: "Gen",
+  chapter: 1,
+  verse: 1,
+  text: "In the beginning",
+}
+
+function queueItemFor(verse: Verse) {
+  return {
+    id: crypto.randomUUID(),
+    verse,
+    reference: `${verse.book_name} ${verse.chapter}:${verse.verse}`,
+    confidence: 1,
+    source: "manual" as const,
+    added_at: Date.now(),
+  }
+}
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+  mockInvoke.mockResolvedValue(null)
+  useBibleStore.setState({
+    selectedVerse: null,
+    activeTranslationId: 1,
+    translations: [
+      {
+        id: 1,
+        abbreviation: "KJV",
+        title: "King James Version",
+        language: "en",
+        is_copyrighted: false,
+        is_downloaded: true,
+      },
+    ],
+  })
+  useBroadcastStore.setState({ isLive: false, liveVerse: null, liveSourceVerse: null })
+  useQueueStore.setState({ items: [], activeIndex: null })
+})
+
+describe("remoteActions.sendToLive", () => {
+  it("presents the previewed verse on the live output", async () => {
+    useBibleStore.setState({ selectedVerse: johnThreeSixteen })
+
+    remoteActions.sendToLive()
+    await vi.waitFor(() =>
+      expect(useBroadcastStore.getState().liveVerse).not.toBeNull(),
+    )
+
+    expect(useBroadcastStore.getState().liveVerse?.reference).toBe(
+      "John 3:16 (KJV)",
+    )
+  })
+
+  it("does nothing when no verse is previewed", async () => {
+    remoteActions.sendToLive()
+    await Promise.resolve()
+
+    expect(useBroadcastStore.getState().liveVerse).toBeNull()
+    expect(mockInvoke).not.toHaveBeenCalledWith("get_verse", expect.anything())
+  })
+})
+
+describe("remoteActions.addToQueue", () => {
+  it("queues the previewed verse with the panel's payload", () => {
+    useBibleStore.setState({ selectedVerse: johnThreeSixteen })
+
+    remoteActions.addToQueue()
+
+    const { items } = useQueueStore.getState()
+    expect(items).toHaveLength(1)
+    expect(items[0].reference).toBe("John 3:16")
+    expect(items[0].source).toBe("manual")
+    expect(items[0].confidence).toBe(1)
+    expect(items[0].verse).toEqual(johnThreeSixteen)
+  })
+
+  it("is safe to press twice — the second press adds nothing", () => {
+    useBibleStore.setState({ selectedVerse: johnThreeSixteen })
+
+    remoteActions.addToQueue()
+    remoteActions.addToQueue()
+
+    expect(useQueueStore.getState().items).toHaveLength(1)
+  })
+
+  it("does nothing when no verse is previewed", () => {
+    remoteActions.addToQueue()
+
+    expect(useQueueStore.getState().items).toHaveLength(0)
+  })
+})
+
+describe("remoteActions queue navigation", () => {
+  it("clamps at the end of the queue", () => {
+    useQueueStore.setState({
+      items: [queueItemFor(genesisOneOne), queueItemFor(johnThreeSixteen)],
+      activeIndex: 1,
+    })
+
+    remoteActions.queueNext()
+
+    expect(useQueueStore.getState().activeIndex).toBe(1)
+  })
+
+  it("clamps at the start of the queue", () => {
+    useQueueStore.setState({
+      items: [queueItemFor(genesisOneOne), queueItemFor(johnThreeSixteen)],
+      activeIndex: 0,
+    })
+
+    remoteActions.queuePrev()
+
+    expect(useQueueStore.getState().activeIndex).toBe(0)
+  })
+
+  it("advances through the queue", () => {
+    useQueueStore.setState({
+      items: [queueItemFor(genesisOneOne), queueItemFor(johnThreeSixteen)],
+      activeIndex: 0,
+    })
+
+    remoteActions.queueNext()
+
+    expect(useQueueStore.getState().activeIndex).toBe(1)
+  })
+
+  it("does nothing on an empty queue", () => {
+    remoteActions.queueNext()
+
+    expect(useQueueStore.getState().activeIndex).toBeNull()
+  })
+})
+
+describe("remoteActions bible navigation", () => {
+  const johnThree = Array.from({ length: 10 }, (_, i) => ({
+    ...johnThreeSixteen,
+    id: 1000 + i,
+    verse: i + 1,
+  }))
+
+  beforeEach(() => {
+    useBibleStore.setState({
+      currentChapter: johnThree,
+      selectedVerse: johnThree[4], // John 3:5
+      pendingNavigation: null,
+      revealRequest: 0,
+    })
+  })
+
+  it("steps the Bible panel forward one verse", async () => {
+    await remoteActions.bibleNext()
+
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(6)
+  })
+
+  it("steps the Bible panel back one verse", async () => {
+    await remoteActions.biblePrev()
+
+    expect(useBibleStore.getState().selectedVerse?.verse).toBe(4)
+  })
+
+  it("does not move the queue — that is the whole point of RC-04", async () => {
+    useQueueStore.setState({
+      items: [queueItemFor(genesisOneOne), queueItemFor(johnThreeSixteen)],
+      activeIndex: 0,
+    })
+
+    await remoteActions.bibleNext()
+    await remoteActions.biblePrev()
+
+    expect(useQueueStore.getState().activeIndex).toBe(0)
+    expect(useQueueStore.getState().items).toHaveLength(2)
+  })
+
+  it("does nothing with no chapter loaded and nothing selected", async () => {
+    useBibleStore.setState({ currentChapter: [], selectedVerse: null })
+
+    await remoteActions.bibleNext()
+
+    expect(useBibleStore.getState().selectedVerse).toBeNull()
+    expect(useBibleStore.getState().pendingNavigation).toBeNull()
+  })
+})
+
+describe("remoteActions.toggleOnAir", () => {
+  it("sets the live flag to the value it is given", () => {
+    remoteActions.toggleOnAir(true)
+    expect(useBroadcastStore.getState().isLive).toBe(true)
+
+    remoteActions.toggleOnAir(false)
+    expect(useBroadcastStore.getState().isLive).toBe(false)
+  })
+})

--- a/src/lib/remote-actions.ts
+++ b/src/lib/remote-actions.ts
@@ -1,0 +1,84 @@
+import { presentVerse } from "@/hooks/use-broadcast"
+import { stepVerse } from "@/hooks/use-bible"
+import { useBibleStore } from "@/stores/bible-store"
+import { useBroadcastStore } from "@/stores/broadcast-store"
+import { useQueueStore } from "@/stores/queue-store"
+
+/**
+ * Find the queue index of the verse currently on the live output.
+ * Returns null when the live verse came from somewhere other than the queue.
+ */
+function findLiveQueueIndex(): number | null {
+  const { liveVerse } = useBroadcastStore.getState()
+  if (!liveVerse) return null
+
+  const index = useQueueStore
+    .getState()
+    .items.findIndex((item) => item.reference === liveVerse.reference)
+  return index >= 0 ? index : null
+}
+
+async function presentQueueItem(index: number): Promise<void> {
+  const item = useQueueStore.getState().items[index]
+  if (!item) return
+  await presentVerse(item.verse).catch((e) =>
+    console.warn("[remote-actions] presentQueueItem failed:", e),
+  )
+}
+
+function stepQueue(offset: number): void {
+  const { items, activeIndex } = useQueueStore.getState()
+  if (items.length === 0) return
+
+  const current = activeIndex ?? findLiveQueueIndex()
+  const target =
+    current === null
+      ? 0
+      : Math.min(Math.max(current + offset, 0), items.length - 1)
+
+  useQueueStore.getState().setActive(target)
+  void presentQueueItem(target)
+}
+
+/**
+ * Operator actions reachable from every control surface — OSC, the HTTP API,
+ * and (from Phase 2) the keyboard. Each surface dispatches into this registry
+ * rather than carrying its own copy of the behaviour, so the surfaces cannot
+ * drift apart.
+ *
+ * Plain functions over `getState()`, never hooks: these run from Tauri event
+ * callbacks, outside React's render cycle.
+ */
+export const remoteActions = {
+  /** Present the verse showing in Program preview on the live output. */
+  sendToLive: () => {
+    const { selectedVerse } = useBibleStore.getState()
+    if (!selectedVerse) return
+    void presentVerse(selectedVerse).catch((e) =>
+      console.warn("[remote-actions] sendToLive failed:", e),
+    )
+  },
+
+  /** Queue the verse showing in Program preview. Duplicates are dropped by the store. */
+  addToQueue: () => {
+    const { selectedVerse } = useBibleStore.getState()
+    if (!selectedVerse) return
+    useQueueStore.getState().addItem({
+      id: crypto.randomUUID(),
+      verse: selectedVerse,
+      reference: `${selectedVerse.book_name} ${selectedVerse.chapter}:${selectedVerse.verse}`,
+      confidence: 1,
+      source: "manual",
+      added_at: Date.now(),
+    })
+  },
+
+  queueNext: () => stepQueue(1),
+  queuePrev: () => stepQueue(-1),
+
+  /** Step the Bible Text panel one verse. Leaves the queue alone. */
+  bibleNext: () => stepVerse("next"),
+  biblePrev: () => stepVerse("prev"),
+
+  toggleOnAir: (active: boolean) => useBroadcastStore.getState().setLive(active),
+}

--- a/src/lib/remote-events.test.ts
+++ b/src/lib/remote-events.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { REMOTE_EVENTS } from "./remote-events"
+
+// The expected set is written out as literals on purpose. Deriving it from
+// REMOTE_EVENTS would assert nothing — the point is to fail when a name here
+// stops matching the one src-tauri/crates/api/src/dispatch.rs emits.
+const EXPECTED_EVENT_NAMES = [
+  "remote:next",
+  "remote:prev",
+  "remote:show",
+  "remote:hide",
+  "remote:theme",
+  "remote:opacity",
+  "remote:confidence",
+  "remote:on_air",
+  "remote:send_to_live",
+  "remote:bible_next",
+  "remote:bible_prev",
+  "remote:add_to_queue",
+]
+
+describe("REMOTE_EVENTS", () => {
+  it("has one entry per RemoteCommand variant", () => {
+    expect(Object.keys(REMOTE_EVENTS)).toHaveLength(12)
+  })
+
+  it("matches the event names the Rust dispatcher emits", () => {
+    expect(Object.values(REMOTE_EVENTS).sort()).toEqual(
+      [...EXPECTED_EVENT_NAMES].sort(),
+    )
+  })
+
+  it("names every key as its event minus the remote: prefix", () => {
+    for (const [key, event] of Object.entries(REMOTE_EVENTS)) {
+      expect(event).toBe(`remote:${key}`)
+    }
+  })
+})

--- a/src/lib/remote-events.ts
+++ b/src/lib/remote-events.ts
@@ -1,0 +1,29 @@
+/**
+ * Event names the Rust remote-control dispatcher emits, one per `RemoteCommand`
+ * variant.
+ *
+ * These strings are the only part of the remote-control contract that no
+ * compiler or type checker validates — `src-tauri/crates/api/src/dispatch.rs`
+ * writes them and this file reads them. A mismatch compiles, passes both test
+ * suites, and then fails silently on an operator's controller, which is how
+ * issue #146 shipped. Both sides pin the literals in tests; keep them in step.
+ *
+ * Keys are the command names as they appear on the wire (serde `snake_case`),
+ * so a key is always its value with the `remote:` prefix removed.
+ */
+export const REMOTE_EVENTS = {
+  next: "remote:next",
+  prev: "remote:prev",
+  show: "remote:show",
+  hide: "remote:hide",
+  theme: "remote:theme",
+  opacity: "remote:opacity",
+  confidence: "remote:confidence",
+  on_air: "remote:on_air",
+  send_to_live: "remote:send_to_live",
+  bible_next: "remote:bible_next",
+  bible_prev: "remote:bible_prev",
+  add_to_queue: "remote:add_to_queue",
+} as const
+
+export type RemoteEventName = (typeof REMOTE_EVENTS)[keyof typeof REMOTE_EVENTS]

--- a/src/stores/bible-store.test.ts
+++ b/src/stores/bible-store.test.ts
@@ -144,3 +144,25 @@ describe("bible store persistence", () => {
     })
   })
 })
+
+describe("requestVerseReveal", () => {
+  it("increments the counter and records the requested scroll block", async () => {
+    const { useBibleStore } = await import("./bible-store")
+    useBibleStore.setState({ revealRequest: 0, revealBlock: "nearest" })
+
+    useBibleStore.getState().requestVerseReveal("center")
+
+    expect(useBibleStore.getState().revealRequest).toBe(1)
+    expect(useBibleStore.getState().revealBlock).toBe("center")
+  })
+
+  it("fires again for an identical consecutive request", async () => {
+    const { useBibleStore } = await import("./bible-store")
+    useBibleStore.setState({ revealRequest: 0, revealBlock: "nearest" })
+
+    useBibleStore.getState().requestVerseReveal("nearest")
+    useBibleStore.getState().requestVerseReveal("nearest")
+
+    expect(useBibleStore.getState().revealRequest).toBe(2)
+  })
+})

--- a/src/stores/bible-store.ts
+++ b/src/stores/bible-store.ts
@@ -20,6 +20,17 @@ interface BibleState {
   currentChapter: Verse[]
   crossReferences: CrossReference[]
   pendingNavigation: PendingNavigation | null
+  /**
+   * Incremented to ask the Bible panel to scroll the selected verse into view.
+   * A counter rather than a flag: two identical consecutive requests must both
+   * fire, and a primitive keeps the panel's effect dependency simple.
+   *
+   * Only navigation requests a reveal. A plain `selectVerse` — which
+   * `presentVerse` calls on every auto-live detection — must not move the
+   * operator's scroll position mid-service.
+   */
+  revealRequest: number
+  revealBlock: ScrollLogicalPosition
 
   setTranslations: (translations: Translation[]) => void
   setActiveTranslation: (id: number) => void
@@ -30,6 +41,7 @@ interface BibleState {
   setCurrentChapter: (verses: Verse[]) => void
   setCrossReferences: (refs: CrossReference[]) => void
   setPendingNavigation: (nav: PendingNavigation | null) => void
+  requestVerseReveal: (block: ScrollLogicalPosition) => void
 }
 
 export const useBibleStore = create<BibleState>((set) => ({
@@ -42,6 +54,8 @@ export const useBibleStore = create<BibleState>((set) => ({
   currentChapter: [],
   crossReferences: [],
   pendingNavigation: null,
+  revealRequest: 0,
+  revealBlock: "nearest",
 
   setTranslations: (translations) => set({ translations }),
   setActiveTranslation: (activeTranslationId) => set({ activeTranslationId }),
@@ -52,6 +66,8 @@ export const useBibleStore = create<BibleState>((set) => ({
   setCurrentChapter: (currentChapter) => set({ currentChapter }),
   setCrossReferences: (crossReferences) => set({ crossReferences }),
   setPendingNavigation: (pendingNavigation) => set({ pendingNavigation }),
+  requestVerseReveal: (revealBlock) =>
+    set((s) => ({ revealRequest: s.revealRequest + 1, revealBlock })),
 }))
 
 /** Load persisted activeTranslationId from disk into Zustand, then sync to Rust backend. */

--- a/web/content/docs/features/remote-control.mdx
+++ b/web/content/docs/features/remote-control.mdx
@@ -26,29 +26,40 @@ in the repository.
 | OSC | `8000` | UDP | Stream Deck (via Companion), TouchOSC, QLab, hardware |
 | HTTP | `8080` | TCP | REST clients, dashboards, scripting, status polling |
 
-Both default to binding `0.0.0.0` so a phone, a staff laptop, or a
-hardware controller on the LAN can reach them. Bind to `127.0.0.1` in
-Settings → Remote for local-only access.
+Both bind `0.0.0.0` so a phone, a staff laptop, or a hardware controller on
+the LAN can reach them. That bind is not configurable yet, and there is no
+authentication — while a server is running, anything on your network can drive
+it, including `send_to_live`. Enable the servers only while you're using them,
+and firewall the ports to the devices that need them. A loopback-by-default
+option with an explicit opt-in is the next change scheduled here.
 
 ## What you can do remotely
 
-| Action | OSC address | HTTP body (POST `/api/v1/control`) |
+| Action | OSC address | HTTP body (POST `/api/v1/command`) |
 | --- | --- | --- |
 | Next verse in queue | `/rhema/next` | `{ "command": "next" }` |
-| Previous verse | `/rhema/prev` | `{ "command": "prev" }` |
+| Previous verse in queue | `/rhema/prev` | `{ "command": "prev" }` |
+| Next verse in the Bible panel | `/rhema/bible_next` | `{ "command": "bible_next" }` |
+| Previous verse in the Bible panel | `/rhema/bible_prev` | `{ "command": "bible_prev" }` |
+| Send the preview to Live | `/rhema/send_to_live` | `{ "command": "send_to_live" }` |
+| Add the previewed verse to the queue | `/rhema/add_to_queue` | `{ "command": "add_to_queue" }` |
 | Show / hide overlay | `/rhema/show`, `/rhema/hide` | `{ "command": "show" }` |
 | Switch theme | `/rhema/theme "Classic Dark"` | `{ "command": "theme", "value": "Classic Dark" }` |
 | Set opacity | `/rhema/opacity 0.75` | `{ "command": "opacity", "value": 0.75 }` |
 | Set confidence threshold | `/rhema/confidence 0.8` | `{ "command": "confidence", "value": 0.8 }` |
 | Toggle on-air | `/rhema/on_air true` | `{ "command": "on_air", "value": true }` |
 
-All eight commands work identically across both protocols, so any
+All twelve commands work identically across both protocols, so any
 controller you already own (or build) talks the same dialect.
+
+`bible_next` and `bible_prev` move the **Bible Text** panel, not the queue —
+that's how you read straight through a passage the AI hasn't picked up yet.
+The verse you land on goes to preview; `send_to_live` pushes it out.
 
 <Callout title="Opacity is a stub today" type="warn">
 The `opacity` command is wired through the dispatcher but currently a
 placeholder — it'll take effect when the broadcast store gains opacity
-support. The other seven commands are fully live.
+support. The other eleven commands are fully live.
 </Callout>
 
 ## OSC
@@ -82,13 +93,17 @@ controls under `/api/v1/`:
 | --- | --- | --- |
 | `/api/v1/health` | GET | Liveness check — returns service name and version |
 | `/api/v1/status` | GET | Current state snapshot — on-air, active theme, live verse, queue length, confidence threshold |
-| `/api/v1/control` | POST | Dispatch a command (table above) |
+| `/api/v1/command` | POST | Dispatch a command (table above) |
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/control \
+curl -X POST http://localhost:8080/api/v1/command \
   -H 'Content-Type: application/json' \
   -d '{"command":"theme","value":"Classic Dark"}'
 ```
+
+`POST /api/v1/control` is still accepted as an alias for the same handler, so
+integrations written against older builds keep working. Use `/api/v1/command`
+for anything new.
 
 The status endpoint returns an authoritative view from a Rust-side
 state cache that the frontend refreshes once a second:

--- a/web/content/docs/features/theme-designer.mdx
+++ b/web/content/docs/features/theme-designer.mdx
@@ -62,7 +62,7 @@ Themes can be activated from:
 
 - The theme picker in the transport bar.
 - A Stream Deck or other OSC controller (`/rhema/theme`).
-- The HTTP control endpoint (`POST /api/v1/control` with `{ "command": "theme", "value": "Classic Dark" }`).
+- The HTTP control endpoint (`POST /api/v1/command` with `{ "command": "theme", "value": "Classic Dark" }`).
 
 The currently active theme is reflected in the **preview** panel before
 it goes on-air, and committed to NDI when you toggle the on-air switch.

--- a/web/content/docs/reference/remote-control-api.mdx
+++ b/web/content/docs/reference/remote-control-api.mdx
@@ -11,12 +11,16 @@ controller-specific tips, see [Remote control](/docs/features/remote-control).
 
 ## Command catalog
 
-Eight commands are supported by both protocols:
+Twelve commands are supported by both protocols:
 
 | Command | Effect |
 | --- | --- |
 | `next` | Advance the verse queue by one |
 | `prev` | Move back one in the queue |
+| `bible_next` | Advance the Bible Text panel by one verse (does not move the queue) |
+| `bible_prev` | Move the Bible Text panel back one verse |
+| `send_to_live` | Present the previewed verse on the live output |
+| `add_to_queue` | Add the previewed verse to the queue |
 | `show` | Bring the overlay on-air |
 | `hide` | Take the overlay off-air |
 | `theme <value>` | Switch the active theme by name |
@@ -27,6 +31,22 @@ Eight commands are supported by both protocols:
 Commands are case-insensitive on input. `value` argument types vary:
 `theme` is a string, `opacity` and `confidence` are floats in `[0.0,
 1.0]`, and `on_air` is a boolean (`true` / `false`).
+
+`next`, `prev`, `bible_next`, `bible_prev`, `send_to_live`, `add_to_queue`,
+`show` and `hide` take no argument.
+
+Over OSC an extra argument is ignored, so a controller that sends a value with
+every button press works unchanged. Over HTTP the body must match exactly —
+adding a `value` key to an argument-free command returns `422`.
+
+`bible_next` and `bible_prev` step within the current chapter and continue into
+the adjacent chapter of the same book at its edges. They stop at a book
+boundary rather than rolling into the next book, and do nothing at all when
+there is no chapter on the other side.
+
+`send_to_live` and `add_to_queue` act on the verse in Program preview. With
+nothing previewed, both are no-ops — `send_to_live` will never blank the live
+output.
 
 ## OSC
 
@@ -40,6 +60,10 @@ works.
 | --- | --- | --- |
 | `/rhema/next` | none | `oscsend localhost 8000 /rhema/next` |
 | `/rhema/prev` | none | `oscsend localhost 8000 /rhema/prev` |
+| `/rhema/bible_next` | none | `oscsend localhost 8000 /rhema/bible_next` |
+| `/rhema/bible_prev` | none | `oscsend localhost 8000 /rhema/bible_prev` |
+| `/rhema/send_to_live` | none | `oscsend localhost 8000 /rhema/send_to_live` |
+| `/rhema/add_to_queue` | none | `oscsend localhost 8000 /rhema/add_to_queue` |
 | `/rhema/show` | none | `oscsend localhost 8000 /rhema/show` |
 | `/rhema/hide` | none | `oscsend localhost 8000 /rhema/hide` |
 | `/rhema/theme` | string | `oscsend localhost 8000 /rhema/theme s "Classic Dark"` |
@@ -87,23 +111,28 @@ refreshes once per second:
 `active_theme` and `live_verse` are nullable — they're `null` until a
 theme is selected or a verse is sent live.
 
-### `POST /api/v1/control`
+### `POST /api/v1/command`
 
 Dispatch any command from the catalog. The body is JSON with a
 `command` key and (for commands that take a parameter) a `value` key:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/control \
+curl -X POST http://localhost:8080/api/v1/command \
   -H 'Content-Type: application/json' \
   -d '{"command":"theme","value":"Classic Dark"}'
 ```
 
 ```json
-{ "success": true, "error": null }
+{ "success": true }
 ```
 
-Unknown commands and invalid JSON are rejected with `success: false`
-and a descriptive `error` string.
+`error` is present only on failure. Unknown commands and invalid JSON are
+rejected with `success: false` and a descriptive `error` string.
+
+`POST /api/v1/control` is mounted as an alias for the same handler. Earlier
+builds mounted only that path while the docs advertised `/api/v1/command`, so
+the alias stays to keep existing integrations working. Write new ones against
+`/api/v1/command`.
 
 <Callout title="CORS is permissive by default" type="warn">
 The Axum router attaches `CorsLayer::permissive()`, so any origin on


### PR DESCRIPTION
## Description

Adds the four remote commands requested in #144, and fixes the 404 in #146 that made them unreachable over HTTP.

Closes #144
Closes #146

**New commands** (OSC and HTTP):

| Command | OSC | What it does |
|---|---|---|
| `send_to_live` | `/rhema/send_to_live` | Puts the Program preview verse on the live output |
| `bible_next` / `bible_prev` | `/rhema/bible_next` | Steps the Bible Text panel one verse. The queue does not move |
| `add_to_queue` | `/rhema/add_to_queue` | Adds the previewed verse to the queue |

`next` and `prev` keep their current queue behaviour and are not renamed, so existing controller buttons keep working.

**#146 fix:** the docs have always said `POST /api/v1/command` while the code mounted `/api/v1/control`, so every documented request 404'd. Both paths now hit the same handler, with `/api/v1/command` as the documented one and `/api/v1/control` kept as an alias for anyone who copied the route from the source. The endpoint test now checks the documented path, so this can't drift silently again.

**Bible stepping** is one shared implementation used by both the panel's arrow keys and the remote commands. It steps within the loaded chapter without a round trip, rolls into the next or previous chapter at the edges, and does nothing at all at the start of Genesis or the end of a book. It is safe to hold a button down.

**Docs** were corrected where they described things the code doesn't do: the response body, the CORS claim, and a bind setting that doesn't exist.

**Not included:** binding to loopback by default. That would break anyone controlling Rhema from a tablet on the church network, so it deserves its own release note rather than shipping inside a feature request. The exposure is unchanged here, but `send_to_live` raises what it costs, so it should be next. The security section now says so.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

- [x] Frontend (React / TypeScript)
- [x] Backend (Rust / Tauri commands)
- [x] Rust crate: `rhema-api`
- [x] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [x] I have tested this change locally
- [x] `bun run typecheck` passes
- [x] `cargo clippy` passes without warnings
- [x] `bun run test` passes (if applicable)
- [x] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

`cargo test --workspace` 338 passed. `bun run test` 181 passed (was 144). `cargo clippy -p rhema-api` reports only warnings that already existed on `main`.

## Tested on

- [x] macOS
- [ ] Windows
- [ ] Linux

Tested against the running app over OSC:

- Three `bible_next` from Genesis 1:1 then `add_to_queue` queued Genesis 1:4.
- `bible_prev` then `send_to_live` put Genesis 1:3 on the live output.
- Thirty rapid `bible_next` advanced exactly thirty verses and crossed from Genesis 1:31 into 2:2, with none dropped.
- `add_to_queue` pressed three times on the same verse added it once.
- Stepping verses left the queue untouched.
- Settings → Remote shows all four commands in the command log.
- The `curl` from #146 returns `200`, and `/api/v1/control` still returns `200`.

**#146 was reported on Windows and has not been retested there.** The fix is a route change with nothing platform specific about it, but that check is still open.

## Screenshots / recordings

None. No visual changes beyond the Bible panel scrolling to the verse a remote command selects.
