### PR TITLE
feat(ux): send manual verse selection directly to live

### DIFF
--- a/src/components/panels/preview-panel.tsx
+++ b/src/components/panels/preview-panel.tsx
@@ -1,11 +1,9 @@
 import { useEffect } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { CanvasVerse } from "@/components/ui/canvas-verse"
-import { Button } from "@/components/ui/button"
-import { MonitorUpIcon } from "lucide-react"
 import { useBibleStore, useBroadcastStore } from "@/stores"
 import { bibleActions } from "@/hooks/use-bible"
-import { presentVerse, toVerseRenderData } from "@/hooks/use-broadcast"
+import { toVerseRenderData } from "@/hooks/use-broadcast"
 
 export function PreviewPanel() {
   const selectedVerse = useBibleStore((s) => s.selectedVerse)
@@ -37,22 +35,7 @@ export function PreviewPanel() {
       data-slot="preview-panel"
       className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card"
     >
-      <PanelHeader title="Program preview">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 px-2 text-[0.625rem] font-medium uppercase tracking-wider"
-          disabled={!selectedVerse}
-          onClick={() => {
-            const verse = useBibleStore.getState().selectedVerse
-            if (verse) void presentVerse(verse)
-          }}
-          title="Present this verse on the live display"
-        >
-          <MonitorUpIcon className="size-3" />
-          Send to live
-        </Button>
-      </PanelHeader>
+      <PanelHeader title="Program preview" />
       <div className="flex min-h-0 flex-1 items-center justify-center p-3">
         <CanvasVerse theme={activeTheme} verse={verseData} />
       </div>

--- a/src/components/panels/queue-panel.tsx
+++ b/src/components/panels/queue-panel.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react"
 import { useQueueStore } from "@/stores"
 import { presentVerse } from "@/hooks/use-broadcast"
+import { bibleActions } from "@/hooks/use-bible"
 import type { QueueItem } from "@/types"
 
 function QueueItemRow({
@@ -24,10 +25,17 @@ function QueueItemRow({
 }) {
   const handlePresent = () => {
     useQueueStore.getState().setActive(index)
+    // Navigate the Bible panel to the presented verse, as detections do
+    bibleActions.navigateToVerse(
+      item.verse.book_number,
+      item.verse.chapter,
+      item.verse.verse
+    )
     void presentVerse(item.verse)
   }
 
-  const handleRemove = () => {
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation()
     useQueueStore.getState().removeItem(item.id)
   }
 
@@ -48,8 +56,9 @@ function QueueItemRow({
   return (
     <div
       data-queue-idx={index}
+      onClick={handlePresent}
       className={cn(
-        "group flex h-10 items-center gap-2 rounded-md px-2.5 transition-colors",
+        "group flex h-10 cursor-pointer items-center gap-2 rounded-md px-2.5 transition-colors",
         isHighlighted
           ? "animate-pulse border border-amber-500/40 bg-amber-500/15"
           : isActive
@@ -68,7 +77,14 @@ function QueueItemRow({
       {sourceBadge}
 
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-        <Button variant="ghost" size="icon-xs" onClick={handlePresent}>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={(e) => {
+            e.stopPropagation()
+            handlePresent()
+          }}
+        >
           <PlayIcon className="size-2.5" />
         </Button>
         <Button variant="ghost" size="icon-xs" onClick={handleRemove}>

--- a/src/components/panels/search-panel.tsx
+++ b/src/components/panels/search-panel.tsx
@@ -30,6 +30,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useBible, bibleActions, findLoadedVerse } from "@/hooks/use-bible"
+import { presentVerse } from "@/hooks/use-broadcast"
 import { useBibleStore, useQueueStore } from "@/stores"
 import type { Book, Verse, SemanticSearchResult } from "@/types"
 import { Input } from "@/components/ui/input"
@@ -239,8 +240,8 @@ export function SearchPanel() {
         return
       }
 
-      const { bookNumber, chapter: navChapter, verse: navVerse } = pendingNavigation
-      const pendingKey = `${bookNumber}:${navChapter}:${navVerse}`
+      const { bookNumber, chapter: navChapter, verse: navVerse, present } = pendingNavigation
+      const pendingKey = `${bookNumber}:${navChapter}:${navVerse}:${present ? "live" : ""}`
       if (pendingKey === lastHandledKey) return
 
       const book = state.books.find((b) => b.book_number === bookNumber)
@@ -266,6 +267,7 @@ export function SearchPanel() {
         const target = verses.find((v) => v.verse === navVerse)
         if (target) {
           bibleActions.selectVerse(target)
+          if (present) void presentVerse(target)
           useBibleStore.getState().requestVerseReveal("center")
         }
         panelRef.current?.focus()
@@ -281,6 +283,7 @@ export function SearchPanel() {
 
   const handleVerseClick = useCallback((verse: Verse) => {
     bibleActions.selectVerse(verse)
+    void presentVerse(verse)
   }, [])
 
   // Arrow key navigation. Up and Down run the same stepping action the remote
@@ -297,10 +300,10 @@ export function SearchPanel() {
         setChapter((c) => c + 1)
       } else if (e.key === "ArrowDown") {
         e.preventDefault()
-        void bibleActions.stepVerse("next")
+        void bibleActions.stepVerse("next", { present: true })
       } else if (e.key === "ArrowUp") {
         e.preventDefault()
-        void bibleActions.stepVerse("prev")
+        void bibleActions.stepVerse("prev", { present: true })
       }
     },
     [chapter]
@@ -453,9 +456,18 @@ export function SearchPanel() {
       return
     }
 
-    // Enter clears input (verse is already showing in panel)
+    // Enter commits the typed reference: send it live and clear the input
     if (e.key === "Enter") {
       e.preventDefault()
+      const result = autocompleteResult
+      if (result.matchedBook && result.chapter && result.verse) {
+        useBibleStore.getState().setPendingNavigation({
+          bookNumber: result.matchedBook.book_number,
+          chapter: result.chapter,
+          verse: result.verse,
+          present: true,
+        })
+      }
       setQuickInput("")
       setShowQuickVerses(false)
       return
@@ -468,13 +480,14 @@ export function SearchPanel() {
       setShowQuickVerses(false)
       return
     }
-  }, [quickInput, quickSuggestion])
+  }, [quickInput, quickSuggestion, autocompleteResult])
 
   const handleQuickVerseClick = useCallback((verse: Verse) => {
     useBibleStore.getState().setPendingNavigation({
       bookNumber: verse.book_number,
       chapter: verse.chapter,
-      verse: verse.verse
+      verse: verse.verse,
+      present: true,
     })
     setQuickInput("")
     setShowQuickVerses(false)
@@ -772,7 +785,7 @@ export function SearchPanel() {
               <div
                 key={`${result.book_number}-${result.chapter}-${result.verse}-${idx}`}
                 onClick={() => {
-                  bibleActions.selectVerse({
+                  const verse: Verse = {
                     id: 0,
                     translation_id: activeTranslationId,
                     book_number: result.book_number,
@@ -781,7 +794,9 @@ export function SearchPanel() {
                     chapter: result.chapter,
                     verse: result.verse,
                     text: result.verse_text,
-                  })
+                  }
+                  bibleActions.selectVerse(verse)
+                  void presentVerse(verse)
                 }}
                 className="group flex flex-col cursor-pointer gap-1 rounded-lg p-3 transition-colors hover:bg-muted/50 relative"
               >

--- a/src/hooks/use-bible.ts
+++ b/src/hooks/use-bible.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core"
 import { useBibleStore } from "@/stores"
+import { presentVerse } from "@/hooks/use-broadcast"
 import type { Translation, Book, Verse, CrossReference } from "@/types"
 import type { SemanticSearchResult } from "@/types/detection"
 
@@ -157,8 +158,15 @@ let stepSeq = 0
  * the store: the end of a book, the start of Genesis, and a chapter missing
  * from the active translation all resolve to doing nothing at all, leaving the
  * panel showing exactly what it was showing.
+ *
+ * `options.present` sends the landed verse to the live output. The panel's
+ * arrow keys pass it; the remote `bible_next` / `bible_prev` commands don't —
+ * they stay preview-only, with the remote's `send_to_live` as the commit.
  */
-export async function stepVerse(direction: "next" | "prev"): Promise<void> {
+export async function stepVerse(
+  direction: "next" | "prev",
+  options?: { present?: boolean }
+): Promise<void> {
   // Claim the ticket before anything else. A step that resolves synchronously
   // still has to invalidate a crossing already in flight, or the operator's
   // correction lands and the crossing it replaced arrives afterwards.
@@ -181,6 +189,7 @@ export async function stepVerse(direction: "next" | "prev"): Promise<void> {
         : state.currentChapter[state.currentChapter.length - 1]
     if (!entry) return
     state.selectVerse(entry)
+    if (options?.present) void presentVerse(entry)
     state.requestVerseReveal("nearest")
     return
   }
@@ -191,6 +200,7 @@ export async function stepVerse(direction: "next" | "prev"): Promise<void> {
     const loaded = findLoadedVerse(state.currentChapter, target)
     if (loaded) {
       state.selectVerse(loaded)
+      if (options?.present) void presentVerse(loaded)
       state.requestVerseReveal("nearest")
       return
     }
@@ -201,7 +211,7 @@ export async function stepVerse(direction: "next" | "prev"): Promise<void> {
     if (ticket !== stepSeq) return
 
     if (cursorChapter.some((v) => v.verse === target.verse)) {
-      useBibleStore.getState().setPendingNavigation(target)
+      useBibleStore.getState().setPendingNavigation({ ...target, present: options?.present })
       return
     }
 
@@ -217,6 +227,7 @@ export async function stepVerse(direction: "next" | "prev"): Promise<void> {
       bookNumber: cursor.bookNumber,
       chapter: crossingChapter,
       verse: landing.verse,
+      present: options?.present,
     })
   } catch (e) {
     console.warn("[bible] stepVerse chapter lookup failed:", e)

--- a/src/hooks/use-broadcast.ts
+++ b/src/hooks/use-broadcast.ts
@@ -23,9 +23,9 @@ let presentSeq = 0
  * book/chapter/verse against the active translation. Falls back to the passed
  * verse if the lookup fails — never blanks the output on error.
  *
- * This is the ONLY path that changes the live output verse. Detections and
- * navigation update the preview (`selectedVerse`); the live output follows
- * only through an explicit present (or auto-live, which calls this).
+ * This is the ONLY path that changes the live output verse. Manual selection
+ * (verse click, arrow navigation, search) presents directly; detections update
+ * only the preview unless the Auto toggle is on.
  */
 export async function presentVerse(verse: Verse): Promise<void> {
   presentSeq += 1

--- a/src/lib/remote-actions.ts
+++ b/src/lib/remote-actions.ts
@@ -21,6 +21,12 @@ function findLiveQueueIndex(): number | null {
 async function presentQueueItem(index: number): Promise<void> {
   const item = useQueueStore.getState().items[index]
   if (!item) return
+  // Navigate the Bible panel to the presented verse, as detections do
+  useBibleStore.getState().setPendingNavigation({
+    bookNumber: item.verse.book_number,
+    chapter: item.verse.chapter,
+    verse: item.verse.verse,
+  })
   await presentVerse(item.verse).catch((e) =>
     console.warn("[remote-actions] presentQueueItem failed:", e),
   )

--- a/src/stores/bible-store.ts
+++ b/src/stores/bible-store.ts
@@ -8,6 +8,12 @@ interface PendingNavigation {
   bookNumber: number
   chapter: number
   verse: number
+  /**
+   * Present the verse to the live output once navigation lands. Set only by
+   * manual operator actions (quick search); detections leave it unset so the
+   * Auto toggle stays the sole gate for detection-driven presents.
+   */
+  present?: boolean
 }
 
 interface BibleState {


### PR DESCRIPTION
## Summary
- Manual verse selection now goes straight to the live output in one action: verse click, ArrowUp/ArrowDown stepping, context-search result click, and quick search (Enter on a typed reference, or clicking a verse in the dropdown).
- Removes the **Send to live** button from the Program preview panel — it required an extra click for every verse.
- Adds an optional `present` flag to `pendingNavigation` and a `{ present }` option to `stepVerse()` so manual sources opt in to presenting.
- **Queue (#148):** a single click anywhere on a queue row presents it, and every queue present — row click, play button, or remote `queue_next`/`queue_prev` — now navigates the Bible panel to the presented verse, matching detections.

Closes #148

## What stays the same
- **Detections** never set the `present` flag, so the **Auto** toggle remains the only gate for detection-driven presents — a detection still can't override what the operator put live.
- **Remote** `bible_next`/`bible_prev` keep their documented preview-only stepping; the remote's `send_to_live` command remains the explicit commit.
- While typing in quick search, navigation stays preview-only — only Enter or a dropdown click commits to live, so passing through "John 3:1" on the way to "3:16" never flashes the wrong verse.
- `presentVerse`'s existing ticket sequencing and empty-text guard still apply, so rapid stepping can't present out of order or blank the output.

## Testing
- `bun run typecheck` clean
- `eslint` clean on touched files
- `vitest --run`: 15 files, 181 tests passed
- Resolved on top of #147's stepVerse/requestVerseReveal refactor