### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rhema",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "rhema"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "crossbeam-channel",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ missing_panics_doc = "allow"
 
 [package]
 name = "rhema"
-version = "0.1.0"
+version = "0.2.0"
 description = "Rhema - Real-Time AI Bible Verse Detection"
 authors = ["Faithful"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rhema",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.openbezal.rhema",
   "build": {
     "frontendDist": "../build",

--- a/web/app/_lib/site.ts
+++ b/web/app/_lib/site.ts
@@ -17,10 +17,10 @@ export const SITE = {
     name: "rhema",
     url: "https://github.com/openbezal/rhema",
     releases: "https://github.com/openbezal/rhema/releases",
-    // Rolling prerelease published by .github/workflows/release-windows.yml on
-    // every merge to main. The tag and filename are set by RELEASE_TAG and
-    // ASSET_NAME in that workflow — change them together or this link breaks.
-    // `/releases/latest` cannot be used here: GitHub excludes prereleases from it.
+    // `nightly` is a hand-refreshed pointer to the newest Windows installer.
+    // Whatever is uploaded there must keep this exact filename or this link
+    // breaks. `/releases/latest` is not used here: GitHub excludes
+    // prereleases from it.
     downloadWindows:
       "https://github.com/openbezal/rhema/releases/download/nightly/Rhema-windows-x64-setup.exe",
     discussions: "https://github.com/openbezal/rhema/discussions",


### PR DESCRIPTION
## Description

Bumps the app version to 0.2.0 so the release tag `v0.2.0` can be cut.

`.github/workflows/build-release.yml` reads the release tag from `version` in `src-tauri/Cargo.toml`, not from the pushed git tag. If the two disagree, the workflow writes to the wrong release, so all four version files have to read 0.2.0 before the tag goes up. `package.json` was on 0.0.1 and is now in line with the rest.

Also corrects the comment above `downloadWindows` in `web/app/_lib/site.ts`. It credited `release-windows.yml`, which was deleted in 2895e00. Nothing in CI writes to the `nightly` tag any more, so that asset is refreshed by hand. The URL itself is unchanged.

## Type of change

- [x] Build / CI

## Areas affected

- [x] Frontend (React / TypeScript)
- [x] Backend (Rust / Tauri commands)

Version literals and one comment. No code paths touched.

## Checklist

- [x] I have tested this change locally
- [x] `bun run typecheck` passes — ran `bun run build` (`tsc -b && vite build`) and `cd web && bun run build`, both clean
- [ ] `cargo clippy` passes without warnings — not run locally. No Rust source changed, only the `[package]` version and its `Cargo.lock` entry. CI compiles all three targets from the tag.
- [ ] `bun run test` passes (if applicable)
- [ ] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

- [x] macOS
