### PR TITLE
feat(designer): fill the text container with a colour or image

### DIFF
--- a/src/broadcast-output.tsx
+++ b/src/broadcast-output.tsx
@@ -3,6 +3,7 @@ import { useRef, useEffect, useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow"
 import { onThemeFontsLoaded, renderVerse } from "@/lib/verse-renderer"
+import { preloadThemeImages, themeImageCache } from "@/lib/theme-image-cache"
 import { normalizeTheme } from "@/lib/theme-migrations"
 import "./broadcast-fonts.css"
 import type { BroadcastTheme, VerseRenderData } from "@/types/broadcast"
@@ -34,7 +35,6 @@ interface BroadcastPayload {
 function BroadcastCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const latestData = useRef<BroadcastPayload | null>(null)
-  const imageCacheRef = useRef<Map<string, HTMLImageElement>>(new Map())
   const ndiConfigRef = useRef<NdiConfigEventPayload>({
     active: false,
     fps: 24,
@@ -44,6 +44,7 @@ function BroadcastCanvas() {
   const ndiCanvasRef = useRef<HTMLCanvasElement | null>(null)
   const lastPushRef = useRef(0)
   const pushingRef = useRef(false)
+  const pushNdiBurstRef = useRef<(() => void) | null>(null)
 
   const logDebug = useCallback((message: string, meta?: unknown) => {
     if (!import.meta.env.DEV) return
@@ -73,7 +74,7 @@ function BroadcastCanvas() {
     canvas.height = theme.resolution.height
     const result = renderVerse(ctx, theme, verse, {
       scale: 1,
-      imageCache: imageCacheRef.current,
+      imageCache: themeImageCache(),
     })
     if (!result) {
       ctx.fillStyle = "#000"
@@ -82,24 +83,14 @@ function BroadcastCanvas() {
     }
   }, [logDebug])
 
-  const preloadBackgroundImage = useCallback((theme: BroadcastTheme) => {
-    const bg = theme.background
-    if (bg.type !== "image" || !bg.image?.url) return
-
-    const url = bg.image.url
-    const cache = imageCacheRef.current
-    if (cache.has(url)) return
-
-    const img = new Image()
-    img.onload = () => {
-      cache.set(url, img)
-      logDebug("Background image loaded", { url })
+  // Redraw once a theme's images land. The burst matters: without it NDI
+  // receivers keep the flat fallback frame until the 2s keepalive fires.
+  const preloadThemeAssets = useCallback((theme: BroadcastTheme) => {
+    preloadThemeImages(theme, () => {
+      logDebug("Theme images loaded")
       draw()
-    }
-    img.onerror = () => {
-      console.warn("[broadcast-output] failed to load background image", { url })
-    }
-    img.src = url
+      pushNdiBurstRef.current?.()
+    })
   }, [draw, logDebug])
 
   const pushNdiFrame = useCallback(async () => {
@@ -159,6 +150,13 @@ function BroadcastCanvas() {
     setTimeout(() => void pushNdiFrame(), 300)
   }, [pushNdiFrame])
 
+  // Image loads finish after the burst that followed their theme update, and
+  // the preload callback is defined above this — go through a ref so it can
+  // re-burst without a definition cycle.
+  useEffect(() => {
+    pushNdiBurstRef.current = pushNdiBurst
+  }, [pushNdiBurst])
+
   useEffect(() => {
     // Set initial canvas size
     const canvas = canvasRef.current
@@ -179,7 +177,7 @@ function BroadcastCanvas() {
         ...event.payload,
         theme: normalizeTheme(event.payload.theme),
       }
-      preloadBackgroundImage(event.payload.theme)
+      preloadThemeAssets(event.payload.theme)
       logDebug("Received broadcast:verse-update", {
         hasVerse: Boolean(event.payload.verse),
         themeId: event.payload.theme.id,
@@ -231,7 +229,7 @@ function BroadcastCanvas() {
       unlisten.then((fn) => fn())
       unlistenNdiConfig.then((fn) => fn())
     }
-  }, [draw, logDebug, preloadBackgroundImage, pushNdiFrame, pushNdiBurst])
+  }, [draw, logDebug, preloadThemeAssets, pushNdiFrame, pushNdiBurst])
 
   // Slow keepalive: push one frame every 2s if idle (prevents NDI receivers from dropping the source)
   useEffect(() => {

--- a/src/components/broadcast/background-properties.tsx
+++ b/src/components/broadcast/background-properties.tsx
@@ -10,26 +10,8 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
-
-function parseColorOpacity(color: string): { hex: string; opacity: number } {
-  if (color.length === 9 && color.startsWith("#")) {
-    const alphaHex = color.slice(7, 9)
-    const alpha = parseInt(alphaHex, 16) / 255
-    return { hex: color.slice(0, 7), opacity: Math.round(alpha * 100) }
-  }
-  if (color.length === 7 && color.startsWith("#")) {
-    return { hex: color, opacity: 100 }
-  }
-  return { hex: color || "#000000", opacity: 100 }
-}
-
-function buildColorWithOpacity(hex: string, opacity: number): string {
-  if (opacity >= 100) return hex
-  const alphaHex = Math.round((opacity / 100) * 255)
-    .toString(16)
-    .padStart(2, "0")
-  return `${hex}${alphaHex}`
-}
+import { SurfaceControls } from "@/components/broadcast/surface-properties"
+import { buildColorWithOpacity, parseColorOpacity } from "@/lib/color-utils"
 
 function SolidSection() {
   const draftTheme = useBroadcastStore((s) => s.draftTheme)
@@ -331,107 +313,6 @@ function TransparentSection() {
   )
 }
 
-function TextBoxSection() {
-  const draftTheme = useBroadcastStore((s) => s.draftTheme)
-  const update = useBroadcastStore((s) => s.updateDraftNested)
-
-  if (!draftTheme) return null
-
-  const textBox = draftTheme.textBox
-  const { hex: boxColorHex } = parseColorOpacity(textBox.color)
-
-  return (
-    <div className="flex flex-col gap-3 border-t pt-3">
-      <div className="flex items-center justify-between">
-        <h4 className="text-xs font-semibold">Text Box</h4>
-        <input
-          type="checkbox"
-          checked={textBox.enabled}
-          onChange={(e) => {
-            update("textBox.enabled", e.target.checked)
-            if (e.target.checked && textBox.opacity === 0) {
-              update("textBox.opacity", 0.5)
-            }
-          }}
-          className="h-4 w-4 rounded border-input accent-primary"
-        />
-      </div>
-
-      {textBox.enabled && (
-        <div className="flex flex-col gap-3">
-          {/* Color */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-muted-foreground">Color</label>
-            <div className="flex items-center gap-2">
-              <input
-                type="color"
-                value={boxColorHex}
-                onChange={(e) => update("textBox.color", e.target.value)}
-                className="h-7 w-8 cursor-pointer rounded border border-input bg-transparent p-0.5"
-              />
-              <Input
-                value={boxColorHex}
-                onChange={(e) => {
-                  const v = e.target.value
-                  if (/^#[0-9a-fA-F]{6}$/.test(v)) {
-                    update("textBox.color", v)
-                  }
-                }}
-                className="w-20 font-mono"
-              />
-            </div>
-          </div>
-
-          {/* Opacity */}
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center justify-between">
-              <label className="text-xs font-medium text-muted-foreground">Opacity</label>
-              <span className="text-xs tabular-nums text-muted-foreground">{Math.round(textBox.opacity * 100)}%</span>
-            </div>
-            <Slider
-              min={0}
-              max={100}
-              step={1}
-              value={[Math.round(textBox.opacity * 100)]}
-              onValueChange={([v]) => update("textBox.opacity", v / 100)}
-            />
-          </div>
-
-          {/* Border Radius */}
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center justify-between">
-              <label className="text-xs font-medium text-muted-foreground">Border Radius</label>
-              <span className="text-xs tabular-nums text-muted-foreground">{textBox.borderRadius}px</span>
-            </div>
-            <Slider
-              min={0}
-              max={50}
-              step={1}
-              value={[textBox.borderRadius]}
-              onValueChange={([v]) => update("textBox.borderRadius", v)}
-            />
-          </div>
-
-          {/* Padding */}
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center justify-between">
-              <label className="text-xs font-medium text-muted-foreground">Padding</label>
-              <span className="text-xs tabular-nums text-muted-foreground">{textBox.padding}px</span>
-            </div>
-            <Slider
-              min={0}
-              max={100}
-              step={1}
-              value={[textBox.padding]}
-              onValueChange={([v]) => update("textBox.padding", v)}
-            />
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
 export function BackgroundProperties() {
   const draftTheme = useBroadcastStore((s) => s.draftTheme)
   const update = useBroadcastStore((s) => s.updateDraftNested)
@@ -489,8 +370,12 @@ export function BackgroundProperties() {
       {bgType === "image" && <ImageSection />}
       {bgType === "transparent" && <TransparentSection />}
 
-      {/* Text Box - always visible */}
-      <TextBoxSection />
+      {/* The container the reference + verse sit in — always available. */}
+      <SurfaceControls
+        prefix="textBox"
+        title="Text Container"
+        description="The box the reference and verse sit in"
+      />
     </div>
   )
 }

--- a/src/components/broadcast/design-canvas.tsx
+++ b/src/components/broadcast/design-canvas.tsx
@@ -7,6 +7,7 @@ import {
   type VerseLayoutMetrics,
 } from "@/lib/verse-renderer"
 import { seedFreeBoxesFromMetrics, SAMPLE_VERSE } from "@/lib/theme-migrations"
+import { preloadThemeImages, themeImageCache } from "@/lib/theme-image-cache"
 import { Button } from "@/components/ui/button"
 import {
   SearchIcon,
@@ -27,8 +28,6 @@ export function DesignCanvas() {
   const fabricRef = useRef<fabric.Canvas | null>(null)
   const latestThemeRef = useRef<BroadcastTheme | null>(null)
   const rafIdRef = useRef<number | null>(null)
-  const imageCacheRef = useRef<Map<string, HTMLImageElement>>(new Map())
-  const imageRequestsRef = useRef<Map<string, Promise<HTMLImageElement>>>(new Map())
   const objectsRef = useRef<{
     workspace: fabric.Rect | null
     referenceRegion: fabric.Rect | null
@@ -50,8 +49,6 @@ export function DesignCanvas() {
       latestTheme,
       objectsRef,
       canvas,
-      imageCacheRef.current,
-      imageRequestsRef.current,
       undefined,
       latestMetricsRef,
       draggingRef.current
@@ -285,8 +282,6 @@ export function DesignCanvas() {
         latest,
         objectsRef,
         latestCanvas,
-        imageCacheRef.current,
-        imageRequestsRef.current,
         () => {
           const current = latestThemeRef.current
           const currentCanvas = fabricRef.current
@@ -295,8 +290,6 @@ export function DesignCanvas() {
             current,
             objectsRef,
             currentCanvas,
-            imageCacheRef.current,
-            imageRequestsRef.current,
             undefined,
             latestMetricsRef,
             draggingRef.current
@@ -410,8 +403,6 @@ async function syncThemeToCanvas(
     verseRegion: fabric.Rect | null
   }>,
   canvas: fabric.Canvas,
-  imageCache: Map<string, HTMLImageElement>,
-  imageRequests: Map<string, Promise<HTMLImageElement>>,
   onImageReady?: () => void,
   metricsRef?: React.MutableRefObject<VerseLayoutMetrics | null>,
   dragging?: "reference" | "verse" | null
@@ -421,19 +412,10 @@ async function syncThemeToCanvas(
   const verseRegion = objectsRef.current.verseRegion
   if (!ws || !refRegion || !verseRegion) return
 
-  if (theme.background.type === "image" && theme.background.image?.url) {
-    const img = imageCache.get(theme.background.image.url)
-    if (!img) {
-      ensureImage(
-        theme.background.image.url,
-        imageCache,
-        imageRequests,
-        onImageReady
-      )
-    }
-  }
+  // Covers the frame background and every surface fill.
+  preloadThemeImages(theme, onImageReady)
 
-  const { bitmap, metrics } = renderThemeBitmap(theme, imageCache)
+  const { bitmap, metrics } = renderThemeBitmap(theme)
   ws.set({
     fill: new fabric.Pattern({
       source: bitmap,
@@ -524,38 +506,6 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value))
 }
 
-function ensureImage(
-  url: string,
-  cache: Map<string, HTMLImageElement>,
-  pending: Map<string, Promise<HTMLImageElement>>,
-  onReady?: () => void
-) {
-  if (cache.has(url) || pending.has(url)) return
-  const request = loadImage(url)
-    .then((img) => {
-      cache.set(url, img)
-      onReady?.()
-      return img
-    })
-    .catch((error) => {
-      console.warn("[theme-designer] failed to load background image", { url: url.slice(0, 100), error })
-      throw error
-    })
-    .finally(() => {
-      pending.delete(url)
-    })
-  pending.set(url, request)
-}
-
-function loadImage(url: string): Promise<HTMLImageElement> {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
-    img.onload = () => resolve(img)
-    img.onerror = () => reject(new Error(`Failed to load image: ${url}`))
-    img.src = url
-  })
-}
-
 /** Editor-only checkerboard so transparent backgrounds read as such (output stays truly transparent). */
 function drawTransparencyCheckerboard(ctx: CanvasRenderingContext2D): void {
   const size = 40
@@ -576,7 +526,6 @@ function drawTransparencyCheckerboard(ctx: CanvasRenderingContext2D): void {
 
 function renderThemeBitmap(
   theme: BroadcastTheme,
-  imageCache: Map<string, HTMLImageElement>
 ): { bitmap: HTMLCanvasElement; metrics: ReturnType<typeof renderVerse> } {
   const offscreen = document.createElement("canvas")
   offscreen.width = WS_WIDTH
@@ -584,7 +533,9 @@ function renderThemeBitmap(
   const ctx = offscreen.getContext("2d")
   if (!ctx) return { bitmap: offscreen, metrics: null }
 
-  const metrics = renderVerse(ctx, theme, SAMPLE_VERSE, { imageCache })
+  const metrics = renderVerse(ctx, theme, SAMPLE_VERSE, {
+    imageCache: themeImageCache(),
+  })
   if (theme.background.type === "transparent") {
     drawTransparencyCheckerboard(ctx)
   }

--- a/src/components/broadcast/layout-properties.tsx
+++ b/src/components/broadcast/layout-properties.tsx
@@ -88,8 +88,11 @@ export function LayoutProperties() {
 
   const bgWidthPx = Math.round((layout.backgroundWidth / 100) * resolution.width)
   const bgHeightPx = Math.round((layout.backgroundHeight / 100) * resolution.height)
-  const textWidthPx = Math.round((layout.textAreaWidth / 100) * resolution.width)
-  const textHeightPx = Math.round((layout.textAreaHeight / 100) * resolution.height)
+  // The text area is a percentage of the background region, not of the frame
+  // (verse-renderer.ts computes it against bgW/bgH), so the readout has to
+  // nest the same way or it lies whenever the background is not full-bleed.
+  const textWidthPx = Math.round((layout.textAreaWidth / 100) * bgWidthPx)
+  const textHeightPx = Math.round((layout.textAreaHeight / 100) * bgHeightPx)
 
   const toggleFreeMode = (enabled: boolean) => {
     if (!enabled) {

--- a/src/components/broadcast/surface-properties.tsx
+++ b/src/components/broadcast/surface-properties.tsx
@@ -1,0 +1,307 @@
+import { useBroadcastStore } from "@/stores/broadcast-store"
+import { pickThemeBackgroundImage } from "@/lib/theme-designer-files"
+import { buildColorWithOpacity, parseColorOpacity } from "@/lib/color-utils"
+import { Slider } from "@/components/ui/slider"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Button } from "@/components/ui/button"
+import type { BroadcastTheme, SurfaceFill, ThemeImageFill } from "@/types/broadcast"
+
+/** Dotted path to a SurfaceFill within a theme. */
+export type SurfacePrefix = "textBox" | "reference.surface" | "verseText.surface"
+
+const DEFAULT_IMAGE: ThemeImageFill = {
+  url: "",
+  fit: "cover",
+  blur: 0,
+  brightness: 100,
+  tint: null,
+}
+
+const NEW_SURFACE: SurfaceFill = {
+  enabled: true,
+  color: "#000000",
+  opacity: 0.7,
+  borderRadius: 12,
+  padding: 24,
+  image: null,
+}
+
+function surfaceAt(
+  theme: BroadcastTheme,
+  prefix: SurfacePrefix
+): SurfaceFill | undefined {
+  switch (prefix) {
+    case "textBox":
+      return theme.textBox
+    case "reference.surface":
+      return theme.reference.surface
+    case "verseText.surface":
+      return theme.verseText.surface
+  }
+}
+
+/**
+ * Controls for one surface — the filled container a block of text sits in.
+ * Parameterised by dotted prefix so the same panel drives the shared
+ * container and each element's own plate.
+ */
+export function SurfaceControls({
+  prefix,
+  title,
+  description,
+}: {
+  prefix: SurfacePrefix
+  title: string
+  description?: string
+}) {
+  const draftTheme = useBroadcastStore((s) => s.draftTheme)
+  const update = useBroadcastStore((s) => s.updateDraftNested)
+
+  if (!draftTheme) return null
+
+  const surface = surfaceAt(draftTheme, prefix)
+  const enabled = surface?.enabled ?? false
+  const image = surface?.image ?? null
+  const { hex: colorHex } = parseColorOpacity(surface?.color ?? "#000000")
+  const tint = image?.tint
+    ? parseColorOpacity(image.tint)
+    : { hex: "#000000", opacity: 50 }
+
+  const toggle = (on: boolean) => {
+    // The whole object must be written at once — setNestedValue creates
+    // missing intermediates but fills in no defaults.
+    if (!surface) {
+      update(prefix, { ...NEW_SURFACE, enabled: on })
+    } else {
+      update(`${prefix}.enabled`, on)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 border-t pt-3">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <h4 className="text-xs font-semibold">{title}</h4>
+          {description && (
+            <p className="text-[0.625rem] text-muted-foreground">{description}</p>
+          )}
+        </div>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => toggle(e.target.checked)}
+          className="h-4 w-4 rounded border-input accent-primary"
+          aria-label={`${title} enabled`}
+        />
+      </div>
+
+      {enabled && surface && (
+        <div className="flex flex-col gap-3">
+          {/* Fill type */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Fill</label>
+            <Select
+              value={image ? "image" : "color"}
+              onValueChange={(v) =>
+                update(`${prefix}.image`, v === "image" ? { ...DEFAULT_IMAGE } : null)
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="color">Solid Color</SelectItem>
+                <SelectItem value="image">Image</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {image ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => {
+                  void (async () => {
+                    const dataUrl = await pickThemeBackgroundImage()
+                    if (dataUrl) update(`${prefix}.image.url`, dataUrl)
+                  })()
+                }}
+              >
+                {image.url ? "Change Image" : "Choose Image"}
+              </Button>
+
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-muted-foreground">Fit</label>
+                <Select
+                  value={image.fit}
+                  onValueChange={(v) => update(`${prefix}.image.fit`, v)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cover">Cover</SelectItem>
+                    <SelectItem value="contain">Contain</SelectItem>
+                    <SelectItem value="stretch">Stretch</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <SliderRow
+                label="Blur"
+                suffix="px"
+                value={image.blur}
+                max={50}
+                onChange={(v) => update(`${prefix}.image.blur`, v)}
+              />
+              <SliderRow
+                label="Brightness"
+                suffix="%"
+                value={image.brightness}
+                max={200}
+                onChange={(v) => update(`${prefix}.image.brightness`, v)}
+              />
+
+              <div className="flex items-center justify-between">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Color Overlay
+                </label>
+                <input
+                  type="checkbox"
+                  checked={image.tint !== null}
+                  onChange={(e) =>
+                    update(
+                      `${prefix}.image.tint`,
+                      e.target.checked ? buildColorWithOpacity("#000000", 50) : null
+                    )
+                  }
+                  className="h-4 w-4 rounded border-input accent-primary"
+                />
+              </div>
+              {image.tint !== null && (
+                <ColorRow
+                  hex={tint.hex}
+                  opacity={tint.opacity}
+                  onChange={(hex, opacity) =>
+                    update(`${prefix}.image.tint`, buildColorWithOpacity(hex, opacity))
+                  }
+                />
+              )}
+            </>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">Color</label>
+              <ColorRow
+                hex={colorHex}
+                opacity={Math.round(surface.opacity * 100)}
+                onChange={(hex, opacity) => {
+                  update(`${prefix}.color`, hex)
+                  update(`${prefix}.opacity`, opacity / 100)
+                }}
+              />
+            </div>
+          )}
+
+          <SliderRow
+            label="Corner Radius"
+            suffix="px"
+            value={surface.borderRadius}
+            max={80}
+            onChange={(v) => update(`${prefix}.borderRadius`, v)}
+          />
+          <SliderRow
+            label="Padding"
+            suffix="px"
+            value={surface.padding}
+            max={120}
+            onChange={(v) => update(`${prefix}.padding`, v)}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SliderRow({
+  label,
+  suffix,
+  value,
+  max,
+  onChange,
+}: {
+  label: string
+  suffix: string
+  value: number
+  max: number
+  onChange: (value: number) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-muted-foreground">{label}</label>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {value}
+          {suffix}
+        </span>
+      </div>
+      <Slider
+        min={0}
+        max={max}
+        step={1}
+        value={[value]}
+        onValueChange={([v]) => onChange(v)}
+      />
+    </div>
+  )
+}
+
+function ColorRow({
+  hex,
+  opacity,
+  onChange,
+}: {
+  hex: string
+  opacity: number
+  onChange: (hex: string, opacity: number) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={hex}
+          onChange={(e) => onChange(e.target.value, opacity)}
+          className="h-7 w-8 cursor-pointer rounded border border-input bg-transparent p-0.5"
+        />
+        <Input
+          value={hex}
+          onChange={(e) => {
+            const v = e.target.value
+            if (/^#[0-9a-fA-F]{6}$/.test(v)) onChange(v, opacity)
+          }}
+          className="w-20 font-mono"
+        />
+      </div>
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-muted-foreground">Opacity</label>
+        <span className="text-xs tabular-nums text-muted-foreground">{opacity}%</span>
+      </div>
+      <Slider
+        min={0}
+        max={100}
+        step={1}
+        value={[opacity]}
+        onValueChange={([v]) => onChange(hex, v)}
+      />
+    </div>
+  )
+}

--- a/src/components/broadcast/text-properties.tsx
+++ b/src/components/broadcast/text-properties.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { ChevronsUpDownIcon, CheckIcon } from "lucide-react"
 import { useBroadcastStore } from "@/stores/broadcast-store"
+import { SurfaceControls } from "@/components/broadcast/surface-properties"
 import { Slider } from "@/components/ui/slider"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -401,6 +402,12 @@ function ReferenceProperties() {
         />
       </div>
 
+      <SurfaceControls
+        prefix="reference.surface"
+        title="Reference Plate"
+        description="A chip behind the reference alone"
+      />
+
       {/* Reference Position (stacked mode only — free mode positions by box) */}
       {draftTheme.layout.mode !== "free" && (
         <div className="flex flex-col gap-1.5">
@@ -714,6 +721,12 @@ function VerseProperties() {
           </div>
         )}
       </div>
+
+      <SurfaceControls
+        prefix="verseText.surface"
+        title="Verse Plate"
+        description="A plate behind the verse text alone"
+      />
     </div>
   )
 }

--- a/src/components/ui/canvas-verse.tsx
+++ b/src/components/ui/canvas-verse.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState, useCallback, memo } from "react"
 import { onThemeFontsLoaded, renderVerse } from "@/lib/verse-renderer"
+import { preloadThemeImages, themeImageCache } from "@/lib/theme-image-cache"
 import type { BroadcastTheme, VerseRenderData } from "@/types"
 import { cn } from "@/lib/utils"
 
@@ -16,7 +17,6 @@ export const CanvasVerse = memo(function CanvasVerse({
 }: CanvasVerseProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const imageCacheRef = useRef<Map<string, HTMLImageElement>>(new Map())
   const [containerWidth, setContainerWidth] = useState(0)
 
   // Measure container width with ResizeObserver
@@ -52,30 +52,14 @@ export const CanvasVerse = memo(function CanvasVerse({
     const scale = displayW / theme.resolution.width
     renderVerse(ctx, theme, verse, {
       scale,
-      imageCache: imageCacheRef.current,
+      imageCache: themeImageCache(),
     })
   }, [theme, verse, containerWidth])
 
-  // Preload background image so the renderer can find it in the cache.
+  // Preload every image the theme uses so the renderer finds them in the cache.
   useEffect(() => {
-    const bg = theme.background
-    if (bg.type !== "image" || !bg.image?.url) return
-    const url = bg.image.url
-    const cache = imageCacheRef.current
-    if (cache.has(url)) return
-
-    const img = new Image()
-    img.onload = () => {
-      cache.set(url, img)
-      draw()
-    }
-    img.onerror = () => {
-      console.warn("[canvas-verse] failed to load background image", {
-        url: url.slice(0, 100),
-      })
-    }
-    img.src = url
-  }, [theme.background, draw])
+    preloadThemeImages(theme, draw)
+  }, [theme, draw])
 
   // Redraw whenever theme, verse, or container size changes.
   useEffect(() => {

--- a/src/lib/builtin-themes.ts
+++ b/src/lib/builtin-themes.ts
@@ -231,7 +231,9 @@ const LOWER_THIRDS: BroadcastTheme = {
     backgroundHeight: 100,
     // Full-bleed: a lower third spans the frame, so no side margins.
     textAreaWidth: 100,
-    textAreaHeight: 40,
+    // Bottom-anchored, so shrinking this lowers the band's top edge and
+    // leaves it sitting on the bottom of the frame.
+    textAreaHeight: 32,
     referenceGap: 24,
   },
   transition: {

--- a/src/lib/builtin-themes.ts
+++ b/src/lib/builtin-themes.ts
@@ -229,7 +229,8 @@ const LOWER_THIRDS: BroadcastTheme = {
     textAlign: "left",
     backgroundWidth: 100,
     backgroundHeight: 100,
-    textAreaWidth: 90,
+    // Full-bleed: a lower third spans the frame, so no side margins.
+    textAreaWidth: 100,
     textAreaHeight: 40,
     referenceGap: 24,
   },

--- a/src/lib/builtin-themes.ts
+++ b/src/lib/builtin-themes.ts
@@ -37,6 +37,7 @@ const CLASSIC_DARK: BroadcastTheme = {
     opacity: 0,
     borderRadius: 0,
     padding: 0,
+    image: null,
   },
   verseText: {
     fontFamily: "Source Serif 4 Variable",
@@ -107,6 +108,7 @@ const MODERN_LIGHT: BroadcastTheme = {
     opacity: 0,
     borderRadius: 0,
     padding: 0,
+    image: null,
   },
   verseText: {
     fontFamily: "Geist Variable",
@@ -176,12 +178,15 @@ const LOWER_THIRDS: BroadcastTheme = {
     gradient: null,
     image: null,
   },
+  // The container: the band the reference and verse both live in. Swap its
+  // colour for an image in the designer to use band artwork.
   textBox: {
     enabled: true,
     color: "#000000",
     opacity: 0.7,
     borderRadius: 12,
     padding: 24,
+    image: null,
   },
   verseText: {
     fontFamily: "Geist Variable",
@@ -254,6 +259,7 @@ const BANNER_SPLIT: BroadcastTheme = {
     opacity: 0,
     borderRadius: 0,
     padding: 0,
+    image: null,
   },
   verseText: {
     fontFamily: "Geist Variable",

--- a/src/lib/theme-image-cache.ts
+++ b/src/lib/theme-image-cache.ts
@@ -1,0 +1,74 @@
+/**
+ * One decoded image per URL for the whole window.
+ *
+ * Theme images are base64 data URIs embedded in the theme, and the same theme
+ * is drawn by every preview, thumbnail, the designer and the output window.
+ * A cache per component meant each of those decoded its own copy of the same
+ * multi-megabyte picture.
+ */
+const cache = new Map<string, HTMLImageElement>()
+const inFlight = new Map<string, Promise<HTMLImageElement | null>>()
+
+/** The map handed to `renderVerse` via `RenderOptions.imageCache`. */
+export function themeImageCache(): Map<string, HTMLImageElement> {
+  return cache
+}
+
+/**
+ * Ensure `url` is decoded and cached. Resolves to the image, or null if it
+ * failed to load. Concurrent callers share one decode.
+ */
+export function loadThemeImage(url: string): Promise<HTMLImageElement | null> {
+  if (!url) return Promise.resolve(null)
+  const cached = cache.get(url)
+  if (cached) return Promise.resolve(cached)
+
+  const pending = inFlight.get(url)
+  if (pending) return pending
+
+  const request = new Promise<HTMLImageElement | null>((resolve) => {
+    const img = new Image()
+    img.onload = () => {
+      cache.set(url, img)
+      inFlight.delete(url)
+      resolve(img)
+    }
+    img.onerror = () => {
+      inFlight.delete(url)
+      console.warn("[theme-image] failed to load image")
+      resolve(null)
+    }
+    img.src = url
+  })
+  inFlight.set(url, request)
+  return request
+}
+
+/** Every image URL a theme references, across the frame and all surfaces. */
+export function themeImageUrls(theme: {
+  background?: { image?: { url: string } | null }
+  textBox?: { image?: { url: string } | null }
+  reference?: { surface?: { image?: { url: string } | null } }
+  verseText?: { surface?: { image?: { url: string } | null } }
+}): string[] {
+  const urls = [
+    theme.background?.image?.url,
+    theme.textBox?.image?.url,
+    theme.reference?.surface?.image?.url,
+    theme.verseText?.surface?.image?.url,
+  ]
+  return urls.filter((url): url is string => Boolean(url))
+}
+
+/**
+ * Load every image a theme needs. `onReady` fires once if anything had to be
+ * fetched, so the caller can redraw.
+ */
+export function preloadThemeImages(
+  theme: Parameters<typeof themeImageUrls>[0],
+  onReady?: () => void
+): void {
+  const missing = themeImageUrls(theme).filter((url) => !cache.has(url))
+  if (missing.length === 0) return
+  void Promise.all(missing.map(loadThemeImage)).then(() => onReady?.())
+}

--- a/src/lib/theme-image-cache.ts
+++ b/src/lib/theme-image-cache.ts
@@ -44,6 +44,78 @@ export function loadThemeImage(url: string): Promise<HTMLImageElement | null> {
   return request
 }
 
+export interface ImageContentBox {
+  sx: number
+  sy: number
+  sw: number
+  sh: number
+}
+
+const contentBoxes = new WeakMap<HTMLImageElement, ImageContentBox>()
+
+/**
+ * The bounds of an image's non-transparent pixels.
+ *
+ * Artwork is often exported on a full-frame canvas with the graphic in one
+ * corner and the rest transparent. Fitting the whole canvas would shrink the
+ * visible art into a corner of its container, so fitting uses these bounds
+ * instead. Fully opaque images return their natural bounds unchanged.
+ */
+export function imageContentBox(img: HTMLImageElement): ImageContentBox {
+  const cached = contentBoxes.get(img)
+  if (cached) return cached
+
+  const width = img.naturalWidth
+  const height = img.naturalHeight
+  const full: ImageContentBox = { sx: 0, sy: 0, sw: width, sh: height }
+  if (!width || !height) return full
+
+  let box = full
+  try {
+    // Measure at a capped resolution: margins only need to be located, and
+    // scanning 4K of pixels on every theme load is not worth the precision.
+    const maxSide = 512
+    const ratio = Math.min(1, maxSide / Math.max(width, height))
+    const w = Math.max(1, Math.round(width * ratio))
+    const h = Math.max(1, Math.round(height * ratio))
+    const canvas = document.createElement("canvas")
+    canvas.width = w
+    canvas.height = h
+    const ctx = canvas.getContext("2d", { willReadFrequently: true })
+    if (ctx) {
+      ctx.drawImage(img, 0, 0, w, h)
+      const { data } = ctx.getImageData(0, 0, w, h)
+      let minX = w
+      let minY = h
+      let maxX = -1
+      let maxY = -1
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          if (data[(y * w + x) * 4 + 3] > 8) {
+            if (x < minX) minX = x
+            if (x > maxX) maxX = x
+            if (y < minY) minY = y
+            if (y > maxY) maxY = y
+          }
+        }
+      }
+      if (maxX >= minX && maxY >= minY) {
+        box = {
+          sx: Math.floor((minX / w) * width),
+          sy: Math.floor((minY / h) * height),
+          sw: Math.ceil(((maxX - minX + 1) / w) * width),
+          sh: Math.ceil(((maxY - minY + 1) / h) * height),
+        }
+      }
+    }
+  } catch {
+    // Tainted canvas or no 2d context — fit the whole image.
+  }
+
+  contentBoxes.set(img, box)
+  return box
+}
+
 /** Every image URL a theme references, across the frame and all surfaces. */
 export function themeImageUrls(theme: {
   background?: { image?: { url: string } | null }

--- a/src/lib/theme-migrations.test.ts
+++ b/src/lib/theme-migrations.test.ts
@@ -6,6 +6,55 @@ import type { VerseLayoutMetrics } from "./verse-renderer"
 
 const stackedBase = BUILTIN_THEMES[0]
 
+describe("normalizeTheme — surfaces", () => {
+  it("fills in the container's image key for themes saved before surfaces", () => {
+    const legacy = {
+      ...stackedBase,
+      textBox: {
+        enabled: true,
+        color: "#111111",
+        opacity: 0.5,
+        borderRadius: 8,
+        padding: 12,
+      },
+    } as unknown as BroadcastTheme
+
+    const normalized = normalizeTheme(legacy)
+    expect(normalized.textBox.image).toBeNull()
+    // Everything the theme did specify survives.
+    expect(normalized.textBox).toMatchObject({
+      enabled: true,
+      color: "#111111",
+      opacity: 0.5,
+      borderRadius: 8,
+      padding: 12,
+    })
+  })
+
+  it("leaves per-element surfaces undefined when absent", () => {
+    const normalized = normalizeTheme(stackedBase)
+    expect(normalized.reference.surface).toBeUndefined()
+    expect(normalized.verseText.surface).toBeUndefined()
+  })
+
+  it("fills defaults into a partially specified element surface", () => {
+    const theme = {
+      ...stackedBase,
+      reference: {
+        ...stackedBase.reference,
+        surface: { enabled: true, color: "#222222" },
+      },
+    } as unknown as BroadcastTheme
+
+    const surface = normalizeTheme(theme).reference.surface!
+    expect(surface.enabled).toBe(true)
+    expect(surface.color).toBe("#222222")
+    expect(surface.image).toBeNull()
+    expect(typeof surface.borderRadius).toBe("number")
+    expect(typeof surface.padding).toBe("number")
+  })
+})
+
 describe("normalizeTheme", () => {
   it("defaults layout.mode to stacked for legacy themes", () => {
     const legacy = {

--- a/src/lib/theme-migrations.ts
+++ b/src/lib/theme-migrations.ts
@@ -1,6 +1,7 @@
 import type {
   BroadcastTheme,
   ElementBox,
+  SurfaceFill,
   VerseRenderData,
 } from "@/types/broadcast"
 import {
@@ -24,6 +25,27 @@ const DEFAULT_VERSE_NUMBERS: BroadcastTheme["verseNumbers"] = {
   fontSize: 18,
   color: "#ffffff",
   superscript: true,
+}
+
+/**
+ * Surfaces gained an `image` fill after the first themes were saved; spread
+ * this so the renderer never has to guess whether the key exists.
+ */
+const DEFAULT_SURFACE: SurfaceFill = {
+  enabled: false,
+  color: "#000000",
+  opacity: 0.7,
+  borderRadius: 0,
+  padding: 0,
+  image: null,
+}
+
+/** Fill surface defaults, preserving whatever the saved theme already set. */
+export function normalizeSurface(
+  surface: SurfaceFill | undefined
+): SurfaceFill | undefined {
+  if (!surface) return undefined
+  return { ...DEFAULT_SURFACE, ...surface }
 }
 
 function isValidBox(box: ElementBox | undefined): box is ElementBox {
@@ -54,6 +76,15 @@ export function normalizeTheme(theme: BroadcastTheme): BroadcastTheme {
   return {
     ...theme,
     verseNumbers: { ...DEFAULT_VERSE_NUMBERS, ...theme.verseNumbers },
+    textBox: { ...DEFAULT_SURFACE, ...theme.textBox },
+    verseText: {
+      ...theme.verseText,
+      surface: normalizeSurface(theme.verseText?.surface),
+    },
+    reference: {
+      ...theme.reference,
+      surface: normalizeSurface(theme.reference?.surface),
+    },
     layout,
   }
 }

--- a/src/lib/verse-renderer.test.ts
+++ b/src/lib/verse-renderer.test.ts
@@ -186,10 +186,13 @@ describe("computeVerseLayoutMetrics — stacked mode", () => {
     expect(lowerThirds.name).toBe("Lower Thirds")
     const metrics = computeVerseLayoutMetrics(stubCtx(), lowerThirds, VERSE)
     expect(metrics.referenceRect!.y).toBeLessThan(metrics.verseRect!.y)
-    // Both share one left edge, inset from the band by the layout padding.
+    // Both share one left edge, inset from the band by the layout padding
+    // plus the container surface's own padding.
     expect(metrics.referenceRect!.x).toBe(metrics.verseRect!.x)
     expect(metrics.referenceRect!.x).toBe(
-      metrics.textAreaRect.x + lowerThirds.layout.padding.left
+      metrics.textAreaRect.x +
+        lowerThirds.layout.padding.left +
+        lowerThirds.textBox.padding
     )
   })
 

--- a/src/lib/verse-renderer.test.ts
+++ b/src/lib/verse-renderer.test.ts
@@ -78,6 +78,17 @@ function stubCtx(): CanvasRenderingContext2D {
   } as unknown as CanvasRenderingContext2D
 }
 
+// Lower Thirds' band, derived from the theme so tuning the builtin's
+// proportions doesn't invalidate what these tests actually check: that the
+// backdrop sits at the anchored text area and never follows element boxes.
+const LOWER_THIRDS = BUILTIN_THEMES[2]
+const ANCHORED_BAND = {
+  x: 0,
+  y: 1080 - (LOWER_THIRDS.layout.textAreaHeight / 100) * 1080,
+  width: (LOWER_THIRDS.layout.textAreaWidth / 100) * 1920,
+  height: (LOWER_THIRDS.layout.textAreaHeight / 100) * 1080,
+}
+
 const VERSE: VerseRenderData = {
   reference: "Genesis 1:1 (KJV)",
   segments: [
@@ -266,9 +277,6 @@ function overlayFreeTheme(): BroadcastTheme {
 }
 
 describe("computeVerseLayoutMetrics — text box backdrop", () => {
-  // Lower Thirds: textArea 100% × 40%, anchored bottom-center → a
-  // full-bleed band {x: 0, y: 648, width: 1920, height: 432}.
-  const ANCHORED_BAND = { x: 0, y: 648, width: 1920, height: 432 }
 
   it("equals the anchored text area in stacked mode", () => {
     const metrics = computeVerseLayoutMetrics(stubCtx(), BUILTIN_THEMES[2], VERSE)
@@ -300,7 +308,11 @@ describe("computeVerseLayoutMetrics — text box backdrop", () => {
     renderVerse(ctx, overlayFreeTheme(), VERSE)
     // roundRect starts with moveTo(x + radius, y); Lower Thirds radius = 12.
     const moveTos = calls.filter((c) => c.method === "moveTo")
-    expect(moveTos.some((c) => c.args[0] === 0 + 12 && c.args[1] === 648)).toBe(
+    expect(
+      moveTos.some(
+        (c) => c.args[0] === ANCHORED_BAND.x + 12 && c.args[1] === ANCHORED_BAND.y
+      )
+    ).toBe(
       true
     )
   })
@@ -343,10 +355,10 @@ describe("surface fills", () => {
     // artwork's own bounds, the destination is the container.
     const [, sx, sy, sw, sh, , , dw, dh] = draws[0].args as number[]
     expect([sx, sy, sw, sh]).toEqual([0, 0, 1920, 300])
-    // "cover" on a 1920x300 image in the 1920x432 band: scaled to the band's
-    // height and centred horizontally, so it overflows the band's width.
-    expect(dh).toBe(432)
-    expect(dw).toBeCloseTo(432 * (1920 / 300), 5)
+    // "cover" on a 1920x300 image in the band: scaled to the band's height
+    // and centred horizontally, so it overflows the band's width.
+    expect(dh).toBe(ANCHORED_BAND.height)
+    expect(dw).toBeCloseTo(ANCHORED_BAND.height * (1920 / 300), 5)
   })
 
   it("fits the artwork's bounds, ignoring transparent margins", async () => {
@@ -375,7 +387,11 @@ describe("surface fills", () => {
     expect(calls.some((c) => c.method === "clip")).toBe(true)
     // The rounded clip path starts at the band's own corner radius.
     const moveTos = calls.filter((c) => c.method === "moveTo")
-    expect(moveTos.some((c) => c.args[0] === 0 + 12 && c.args[1] === 648)).toBe(
+    expect(
+      moveTos.some(
+        (c) => c.args[0] === ANCHORED_BAND.x + 12 && c.args[1] === ANCHORED_BAND.y
+      )
+    ).toBe(
       true
     )
   })

--- a/src/lib/verse-renderer.test.ts
+++ b/src/lib/verse-renderer.test.ts
@@ -266,9 +266,9 @@ function overlayFreeTheme(): BroadcastTheme {
 }
 
 describe("computeVerseLayoutMetrics — text box backdrop", () => {
-  // Lower Thirds: textArea 90% × 40%, anchored bottom-center →
-  // {x: 96, y: 648, width: 1728, height: 432}.
-  const ANCHORED_BAND = { x: 96, y: 648, width: 1728, height: 432 }
+  // Lower Thirds: textArea 100% × 40%, anchored bottom-center → a
+  // full-bleed band {x: 0, y: 648, width: 1920, height: 432}.
+  const ANCHORED_BAND = { x: 0, y: 648, width: 1920, height: 432 }
 
   it("equals the anchored text area in stacked mode", () => {
     const metrics = computeVerseLayoutMetrics(stubCtx(), BUILTIN_THEMES[2], VERSE)
@@ -300,7 +300,7 @@ describe("computeVerseLayoutMetrics — text box backdrop", () => {
     renderVerse(ctx, overlayFreeTheme(), VERSE)
     // roundRect starts with moveTo(x + radius, y); Lower Thirds radius = 12.
     const moveTos = calls.filter((c) => c.method === "moveTo")
-    expect(moveTos.some((c) => c.args[0] === 96 + 12 && c.args[1] === 648)).toBe(
+    expect(moveTos.some((c) => c.args[0] === 0 + 12 && c.args[1] === 648)).toBe(
       true
     )
   })
@@ -343,7 +343,7 @@ describe("surface fills", () => {
     // artwork's own bounds, the destination is the container.
     const [, sx, sy, sw, sh, , , dw, dh] = draws[0].args as number[]
     expect([sx, sy, sw, sh]).toEqual([0, 0, 1920, 300])
-    // "cover" on a 1920x300 image in the 1728x432 band: scaled to the band's
+    // "cover" on a 1920x300 image in the 1920x432 band: scaled to the band's
     // height and centred horizontally, so it overflows the band's width.
     expect(dh).toBe(432)
     expect(dw).toBeCloseTo(432 * (1920 / 300), 5)
@@ -375,7 +375,7 @@ describe("surface fills", () => {
     expect(calls.some((c) => c.method === "clip")).toBe(true)
     // The rounded clip path starts at the band's own corner radius.
     const moveTos = calls.filter((c) => c.method === "moveTo")
-    expect(moveTos.some((c) => c.args[0] === 96 + 12 && c.args[1] === 648)).toBe(
+    expect(moveTos.some((c) => c.args[0] === 0 + 12 && c.args[1] === 648)).toBe(
       true
     )
   })

--- a/src/lib/verse-renderer.test.ts
+++ b/src/lib/verse-renderer.test.ts
@@ -306,6 +306,136 @@ describe("computeVerseLayoutMetrics — text box backdrop", () => {
   })
 })
 
+describe("surface fills", () => {
+  const BAND_IMAGE = "data:image/png;base64,band"
+
+  function stubImage(): HTMLImageElement {
+    return { naturalWidth: 1920, naturalHeight: 300 } as HTMLImageElement
+  }
+
+  function themeWithContainerImage(): BroadcastTheme {
+    const base = BUILTIN_THEMES[2] // Lower Thirds
+    return {
+      ...base,
+      textBox: {
+        ...base.textBox,
+        image: {
+          url: BAND_IMAGE,
+          fit: "cover",
+          blur: 0,
+          brightness: 100,
+          tint: null,
+        },
+      },
+    }
+  }
+
+  it("draws a container image into the container rect, not the background rect", () => {
+    const { ctx, calls } = recordingCtx()
+    const theme = themeWithContainerImage()
+    renderVerse(ctx, theme, VERSE, {
+      imageCache: new Map([[BAND_IMAGE, stubImage()]]),
+    })
+
+    const draws = calls.filter((c) => c.method === "drawImage")
+    expect(draws).toHaveLength(1)
+    // "cover" on a 1920x300 image in the 1728x432 band: scaled to the band's
+    // height and centred horizontally, so it starts left of the band's x.
+    const [, , , width, height] = draws[0].args as number[]
+    expect(height).toBe(432)
+    expect(width).toBeCloseTo(432 * (1920 / 300), 5)
+  })
+
+  it("clips the container image to the surface, not the whole frame", () => {
+    const { ctx, calls } = recordingCtx()
+    renderVerse(ctx, themeWithContainerImage(), VERSE, {
+      imageCache: new Map([[BAND_IMAGE, stubImage()]]),
+    })
+    expect(calls.some((c) => c.method === "clip")).toBe(true)
+    // The rounded clip path starts at the band's own corner radius.
+    const moveTos = calls.filter((c) => c.method === "moveTo")
+    expect(moveTos.some((c) => c.args[0] === 96 + 12 && c.args[1] === 648)).toBe(
+      true
+    )
+  })
+
+  it("insets the text by the container's padding", () => {
+    const base = BUILTIN_THEMES[2]
+    const padded = computeVerseLayoutMetrics(stubCtx(), base, VERSE)
+    const unpadded = computeVerseLayoutMetrics(
+      stubCtx(),
+      { ...base, textBox: { ...base.textBox, padding: 0 } },
+      VERSE
+    )
+    expect(padded.textRect.x - unpadded.textRect.x).toBe(base.textBox.padding)
+    expect(padded.textRect.width).toBe(
+      unpadded.textRect.width - base.textBox.padding * 2
+    )
+  })
+
+  it("ignores container padding when the container is disabled", () => {
+    const base = BUILTIN_THEMES[2]
+    const off = computeVerseLayoutMetrics(
+      stubCtx(),
+      { ...base, textBox: { ...base.textBox, enabled: false } },
+      VERSE
+    )
+    const zeroPad = computeVerseLayoutMetrics(
+      stubCtx(),
+      { ...base, textBox: { ...base.textBox, enabled: false, padding: 0 } },
+      VERSE
+    )
+    expect(off.textRect).toEqual(zeroPad.textRect)
+  })
+
+  it("leaves per-element surfaces off when the theme does not define them", () => {
+    const metrics = computeVerseLayoutMetrics(stubCtx(), BUILTIN_THEMES[2], VERSE)
+    expect(metrics.referenceSurfaceRect).toBeNull()
+    expect(metrics.verseSurfaceRect).toBeNull()
+  })
+
+  it("hugs the reference text when the reference has its own plate", () => {
+    const base = BUILTIN_THEMES[2]
+    const theme: BroadcastTheme = {
+      ...base,
+      reference: {
+        ...base.reference,
+        surface: {
+          enabled: true,
+          color: "#000000",
+          opacity: 1,
+          borderRadius: 4,
+          padding: 10,
+          image: null,
+        },
+      },
+    }
+    const metrics = computeVerseLayoutMetrics(stubCtx(), theme, VERSE)
+    const chip = metrics.referenceSurfaceRect!
+    const text = metrics.referenceRect!
+    expect(chip.x).toBe(text.x - 10)
+    expect(chip.width).toBe(text.width + 20)
+    // A chip hugs its text, so it must be narrower than the whole band.
+    expect(chip.width).toBeLessThan(metrics.textBoxRect.width)
+  })
+
+  it("scales surface radius, padding and image blur with the render scale", () => {
+    const base = themeWithContainerImage()
+    const theme: BroadcastTheme = {
+      ...base,
+      textBox: { ...base.textBox, image: { ...base.textBox.image!, blur: 8 } },
+    }
+    const metrics = computeVerseLayoutMetrics(stubCtx(), theme, VERSE, {
+      scale: 0.5,
+    })
+    expect(metrics.scaledTheme.textBox.borderRadius).toBe(
+      theme.textBox.borderRadius * 0.5
+    )
+    expect(metrics.scaledTheme.textBox.padding).toBe(theme.textBox.padding * 0.5)
+    expect(metrics.scaledTheme.textBox.image!.blur).toBe(4)
+  })
+})
+
 describe("computeVerseLayoutMetrics — background region", () => {
   it("covers the full canvas at 100% × 100%", () => {
     const metrics = computeVerseLayoutMetrics(stubCtx(), BUILTIN_THEMES[0], VERSE)

--- a/src/lib/verse-renderer.test.ts
+++ b/src/lib/verse-renderer.test.ts
@@ -339,11 +339,32 @@ describe("surface fills", () => {
 
     const draws = calls.filter((c) => c.method === "drawImage")
     expect(draws).toHaveLength(1)
+    // drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh): the source is the
+    // artwork's own bounds, the destination is the container.
+    const [, sx, sy, sw, sh, , , dw, dh] = draws[0].args as number[]
+    expect([sx, sy, sw, sh]).toEqual([0, 0, 1920, 300])
     // "cover" on a 1920x300 image in the 1728x432 band: scaled to the band's
-    // height and centred horizontally, so it starts left of the band's x.
-    const [, , , width, height] = draws[0].args as number[]
-    expect(height).toBe(432)
-    expect(width).toBeCloseTo(432 * (1920 / 300), 5)
+    // height and centred horizontally, so it overflows the band's width.
+    expect(dh).toBe(432)
+    expect(dw).toBeCloseTo(432 * (1920 / 300), 5)
+  })
+
+  it("fits the artwork's bounds, ignoring transparent margins", async () => {
+    // Artwork exported in the corner of a big transparent canvas: fitting the
+    // whole canvas would shrink the visible band into a corner of the band.
+    const { imageContentBox } = await import("./theme-image-cache")
+    const wideCanvasArtwork = {
+      naturalWidth: 1920,
+      naturalHeight: 1080,
+    } as HTMLImageElement
+    // Without a real 2d context the measurement degrades to the full image
+    // rather than throwing, which is what the renderer relies on.
+    expect(imageContentBox(wideCanvasArtwork)).toEqual({
+      sx: 0,
+      sy: 0,
+      sw: 1920,
+      sh: 1080,
+    })
   })
 
   it("clips the container image to the surface, not the whole frame", () => {

--- a/src/lib/verse-renderer.ts
+++ b/src/lib/verse-renderer.ts
@@ -10,6 +10,8 @@ import {
 } from "@chenglou/pretext/rich-inline"
 import type {
   BroadcastTheme,
+  SurfaceFill,
+  ThemeImageFill,
   VerseRenderData,
   RenderOptions,
 } from "@/types/broadcast"
@@ -104,6 +106,47 @@ export interface VerseLayoutMetrics {
   /** Free-mode element boxes in canvas px. Only set when layout.mode === "free". */
   referenceBoxRect?: VerseLayoutRect | null
   verseBoxRect?: VerseLayoutRect | null
+  /** Rect the reference's own chip is drawn at — hugs the reference text. */
+  referenceSurfaceRect?: VerseLayoutRect | null
+  /** Rect the verse's own plate is drawn at — fills the verse's area. */
+  verseSurfaceRect?: VerseLayoutRect | null
+}
+
+/** Grow a rect outwards by `padding` on every side, never past zero size. */
+function inflateRect(rect: VerseLayoutRect, padding: number): VerseLayoutRect {
+  return {
+    x: rect.x - padding,
+    y: rect.y - padding,
+    width: Math.max(0, rect.width + padding * 2),
+    height: Math.max(0, rect.height + padding * 2),
+  }
+}
+
+/**
+ * Where an element's own plate is drawn: its box when it has one (free mode),
+ * otherwise hugging the text plus the surface's padding.
+ */
+function surfaceRectFor(
+  surface: SurfaceFill | undefined,
+  textRect: VerseLayoutRect | null,
+  boxRect: VerseLayoutRect | null | undefined
+): VerseLayoutRect | null {
+  if (!surface?.enabled) return null
+  if (boxRect) return boxRect
+  if (!textRect) return null
+  return inflateRect(textRect, surface.padding)
+}
+
+/** Shrink a rect inwards by `padding` on every side, never past zero size. */
+function deflateRect(rect: VerseLayoutRect, padding: number): VerseLayoutRect {
+  const width = Math.max(0, rect.width - padding * 2)
+  const height = Math.max(0, rect.height - padding * 2)
+  return {
+    x: rect.x + Math.min(padding, rect.width / 2),
+    y: rect.y + Math.min(padding, rect.height / 2),
+    width,
+    height,
+  }
 }
 
 export function wrapText(
@@ -437,80 +480,126 @@ function drawBackground(
       break
     }
 
-    case "image": {
-      if (!bg.image) {
-        ctx.fillStyle = "#000"
-        ctx.fillRect(rect.x, rect.y, rect.width, rect.height)
-        break
-      }
-      const img = imageCache?.get(bg.image.url)
-      if (!img) {
-        // Use a deterministic fallback while image is still loading.
-        ctx.fillStyle = bg.image.tint ?? "#000"
-        ctx.fillRect(rect.x, rect.y, rect.width, rect.height)
-        break
-      }
-
-      ctx.save()
-      ctx.beginPath()
-      ctx.rect(rect.x, rect.y, rect.width, rect.height)
-      ctx.clip()
-
-      if (bg.image.blur > 0) {
-        ctx.filter = `blur(${bg.image.blur}px) brightness(${bg.image.brightness / 100})`
-      } else if (bg.image.brightness !== 100) {
-        ctx.filter = `brightness(${bg.image.brightness / 100})`
-      }
-
-      let drawX = rect.x
-      let drawY = rect.y
-      let drawW = rect.width
-      let drawH = rect.height
-
-      const imgRatio = img.naturalWidth / img.naturalHeight
-      const rectRatio = rect.width / rect.height
-
-      switch (bg.image.fit) {
-        case "cover":
-          if (imgRatio > rectRatio) {
-            drawH = rect.height
-            drawW = rect.height * imgRatio
-            drawX = rect.x + (rect.width - drawW) / 2
-          } else {
-            drawW = rect.width
-            drawH = rect.width / imgRatio
-            drawY = rect.y + (rect.height - drawH) / 2
-          }
-          break
-        case "contain":
-          if (imgRatio > rectRatio) {
-            drawW = rect.width
-            drawH = rect.width / imgRatio
-            drawY = rect.y + (rect.height - drawH) / 2
-          } else {
-            drawH = rect.height
-            drawW = rect.height * imgRatio
-            drawX = rect.x + (rect.width - drawW) / 2
-          }
-          break
-        case "stretch":
-          break
-      }
-
-      ctx.drawImage(img, drawX, drawY, drawW, drawH)
-      ctx.restore()
-
-      if (bg.image.tint) {
-        ctx.fillStyle = bg.image.tint
-        ctx.fillRect(rect.x, rect.y, rect.width, rect.height)
-      }
+    case "image":
+      drawImageFill(ctx, bg.image, rect, 0, imageCache)
       break
-    }
 
     case "transparent":
       ctx.clearRect(0, 0, width, height)
       break
   }
+}
+
+/**
+ * Paint an image so it fills `rect`, clipped to `radius`. Shared by the frame
+ * background and every surface fill, so a picture behaves the same wherever it
+ * is used. While the image is still loading a deterministic flat fill stands in.
+ */
+function drawImageFill(
+  ctx: CanvasRenderingContext2D,
+  image: ThemeImageFill | null,
+  rect: VerseLayoutRect,
+  radius: number,
+  imageCache?: Map<string, HTMLImageElement>
+): void {
+  if (!image) {
+    ctx.fillStyle = "#000"
+    fillRoundRect(ctx, rect, radius)
+    return
+  }
+  const img = imageCache?.get(image.url)
+  if (!img) {
+    ctx.fillStyle = image.tint ?? "#000"
+    fillRoundRect(ctx, rect, radius)
+    return
+  }
+
+  ctx.save()
+  // Rounded clip so an image respects the surface's corner radius, and so the
+  // tint below can be painted inside it rather than over the rect's edges.
+  roundRect(ctx, rect.x, rect.y, rect.width, rect.height, radius)
+  ctx.clip()
+
+  if (image.blur > 0) {
+    ctx.filter = `blur(${image.blur}px) brightness(${image.brightness / 100})`
+  } else if (image.brightness !== 100) {
+    ctx.filter = `brightness(${image.brightness / 100})`
+  }
+
+  let drawX = rect.x
+  let drawY = rect.y
+  let drawW = rect.width
+  let drawH = rect.height
+
+  const imgRatio = img.naturalWidth / img.naturalHeight
+  const rectRatio = rect.width / rect.height
+
+  switch (image.fit) {
+    case "cover":
+      if (imgRatio > rectRatio) {
+        drawH = rect.height
+        drawW = rect.height * imgRatio
+        drawX = rect.x + (rect.width - drawW) / 2
+      } else {
+        drawW = rect.width
+        drawH = rect.width / imgRatio
+        drawY = rect.y + (rect.height - drawH) / 2
+      }
+      break
+    case "contain":
+      if (imgRatio > rectRatio) {
+        drawW = rect.width
+        drawH = rect.width / imgRatio
+        drawY = rect.y + (rect.height - drawH) / 2
+      } else {
+        drawH = rect.height
+        drawW = rect.height * imgRatio
+        drawX = rect.x + (rect.width - drawW) / 2
+      }
+      break
+    case "stretch":
+      break
+  }
+
+  ctx.drawImage(img, drawX, drawY, drawW, drawH)
+  ctx.filter = "none"
+
+  if (image.tint) {
+    ctx.fillStyle = image.tint
+    ctx.fillRect(rect.x, rect.y, rect.width, rect.height)
+  }
+  ctx.restore()
+}
+
+function fillRoundRect(
+  ctx: CanvasRenderingContext2D,
+  rect: VerseLayoutRect,
+  radius: number
+): void {
+  roundRect(ctx, rect.x, rect.y, rect.width, rect.height, radius)
+  ctx.fill()
+}
+
+/**
+ * Paint one surface — the container behind a block of text: a colour wash and
+ * then, if set, an image filling the same rect.
+ */
+function drawSurface(
+  ctx: CanvasRenderingContext2D,
+  surface: SurfaceFill | undefined,
+  rect: VerseLayoutRect,
+  baseOpacity: number,
+  imageCache?: Map<string, HTMLImageElement>
+): void {
+  if (!surface?.enabled) return
+  ctx.save()
+  ctx.globalAlpha = baseOpacity * surface.opacity
+  ctx.fillStyle = surface.color
+  fillRoundRect(ctx, rect, surface.borderRadius)
+  if (surface.image) {
+    drawImageFill(ctx, surface.image, rect, surface.borderRadius, imageCache)
+  }
+  ctx.restore()
 }
 
 function drawReference(
@@ -712,6 +801,12 @@ function buildScaledTheme(
       width: theme.resolution.width * scale,
       height: theme.resolution.height * scale,
     },
+    background: {
+      ...theme.background,
+      image: theme.background.image
+        ? { ...theme.background.image, blur: theme.background.image.blur * scale }
+        : null,
+    },
     verseText: {
       ...theme.verseText,
       fontSize: theme.verseText.fontSize * scale,
@@ -730,6 +825,7 @@ function buildScaledTheme(
             width: theme.verseText.outline.width * scale,
           }
         : null,
+      surface: scaleSurface(theme.verseText.surface, scale),
     },
     verseNumbers: {
       ...theme.verseNumbers,
@@ -739,12 +835,28 @@ function buildScaledTheme(
       ...theme.reference,
       fontSize: theme.reference.fontSize * scale,
       letterSpacing: theme.reference.letterSpacing * scale,
+      surface: scaleSurface(theme.reference.surface, scale),
     },
-    textBox: {
-      ...theme.textBox,
-      borderRadius: theme.textBox.borderRadius * scale,
-      padding: theme.textBox.padding * scale,
-    },
+    textBox: scaleSurface(theme.textBox, scale)!,
+  }
+}
+
+/**
+ * Scale a surface's px-valued fields. Image blur counts: it is an absolute px
+ * radius, so an unscaled value over-blurs thumbnails relative to the output.
+ */
+function scaleSurface(
+  surface: SurfaceFill | undefined,
+  scale: number
+): SurfaceFill | undefined {
+  if (!surface) return undefined
+  return {
+    ...surface,
+    borderRadius: surface.borderRadius * scale,
+    padding: surface.padding * scale,
+    image: surface.image
+      ? { ...surface.image, blur: surface.image.blur * scale }
+      : null,
   }
 }
 
@@ -933,10 +1045,13 @@ export function computeVerseLayoutMetrics(
   const pos = { x: bgPos.x + innerPos.x, y: bgPos.y + innerPos.y }
 
   const pad = layout.padding
-  const textRectX = pos.x + pad.left
-  const textRectY = pos.y + pad.top
-  const textRectW = textAreaW - pad.left - pad.right
-  const textRectH = textAreaH - pad.top - pad.bottom
+  // The container's own padding insets the text too, so content wraps inside
+  // the surface rather than running to its edges.
+  const surfacePad = scaledTheme.textBox.enabled ? scaledTheme.textBox.padding : 0
+  const textRectX = pos.x + pad.left + surfacePad
+  const textRectY = pos.y + pad.top + surfacePad
+  const textRectW = textAreaW - pad.left - pad.right - surfacePad * 2
+  const textRectH = textAreaH - pad.top - pad.bottom - surfacePad * 2
   const textAreaRect: VerseLayoutRect = {
     x: pos.x,
     y: pos.y,
@@ -972,6 +1087,8 @@ export function computeVerseLayoutMetrics(
       verseRect: null,
       referenceBoxRect,
       verseBoxRect,
+      referenceSurfaceRect: null,
+      verseSurfaceRect: null,
     }
   }
 
@@ -1004,71 +1121,93 @@ export function computeVerseLayoutMetrics(
     return width
   }
 
+  // A plate on an element insets that element's text, so content sits inside
+  // the fill instead of running to its edges.
+  const referenceContentRect =
+    referenceBoxRect && scaledTheme.reference.surface?.enabled
+      ? deflateRect(referenceBoxRect, scaledTheme.reference.surface.padding)
+      : referenceBoxRect
+  const verseContentRect =
+    verseBoxRect && scaledTheme.verseText.surface?.enabled
+      ? deflateRect(verseBoxRect, scaledTheme.verseText.surface.padding)
+      : verseBoxRect
+
   if (freeMode && referenceBoxRect && verseBoxRect) {
     const fittedVerseFontSize = calculateScaledFontSize(
       ctx,
       scaledTheme,
       verse,
-      verseBoxRect.width,
-      verseBoxRect.height
+      verseContentRect!.width,
+      verseContentRect!.height
     )
     const verseMetrics = measureVerseHeight(
       ctx,
       scaledTheme,
       verse,
-      verseBoxRect.width,
+      verseContentRect!.width,
       fittedVerseFontSize
     )
     const verseY = alignY(
       resolveVerticalAlign(scaledTheme.verseText.verticalAlign),
-      verseBoxRect.y,
-      verseBoxRect.height,
+      verseContentRect!.y,
+      verseContentRect!.height,
       verseMetrics.height
     )
     const verseRect = rectForAlignedText(
       verseAlign === "justify" ? "left" : verseAlign,
       alignX(
         verseAlign === "justify" ? "left" : verseAlign,
-        verseBoxRect.x,
-        verseBoxRect.width
+        verseContentRect!.x,
+        verseContentRect!.width
       ),
       verseY,
       verseMetrics.maxLineWidth,
       verseMetrics.height,
-      verseBoxRect
+      verseContentRect!
     )
 
-    const referenceWidth = measureReferenceWidth(referenceBoxRect.width)
+    const referenceWidth = measureReferenceWidth(referenceContentRect!.width)
     const refY = alignY(
       resolveVerticalAlign(scaledTheme.reference.verticalAlign),
-      referenceBoxRect.y,
-      referenceBoxRect.height,
+      referenceContentRect!.y,
+      referenceContentRect!.height,
       referenceHeight
     )
     const referenceRect = rectForAlignedText(
       referenceAlign === "justify" ? "left" : referenceAlign,
       alignX(
         referenceAlign === "justify" ? "left" : referenceAlign,
-        referenceBoxRect.x,
-        referenceBoxRect.width
+        referenceContentRect!.x,
+        referenceContentRect!.width
       ),
       refY,
       referenceWidth,
       referenceHeight,
-      referenceBoxRect
+      referenceContentRect!
     )
 
     return {
       scaledTheme,
       backgroundRect,
       textBoxRect: textAreaRect,
-      textAreaRect: verseBoxRect,
-      textRect: verseBoxRect,
+      textAreaRect: verseContentRect!,
+      textRect: verseContentRect!,
       referenceRect,
       verseRect,
       fittedVerseFontSize,
       referenceBoxRect,
       verseBoxRect,
+      // In free mode each element owns a box, so its plate fills that box.
+      referenceSurfaceRect: surfaceRectFor(
+        scaledTheme.reference.surface,
+        referenceRect,
+        referenceBoxRect
+      ),
+      verseSurfaceRect: surfaceRectFor(
+        scaledTheme.verseText.surface,
+        verseRect,
+        verseBoxRect
+      ),
     }
   }
 
@@ -1195,6 +1334,17 @@ export function computeVerseLayoutMetrics(
     fittedVerseFontSize,
     referenceBoxRect: null,
     verseBoxRect: null,
+    // Stacked mode has no per-element boxes, so each plate hugs its own text.
+    referenceSurfaceRect: surfaceRectFor(
+      scaledTheme.reference.surface,
+      referenceRect,
+      null
+    ),
+    verseSurfaceRect: surfaceRectFor(
+      scaledTheme.verseText.surface,
+      verseRect,
+      null
+    ),
   }
 }
 
@@ -1231,21 +1381,33 @@ function renderVerseImpl(
   // Draw background
   drawBackground(ctx, scaledTheme, metrics.backgroundRect, options?.imageCache)
 
-  // Draw text box if enabled
-  if (scaledTheme.textBox.enabled) {
-    ctx.save()
-    ctx.globalAlpha = (options?.opacity ?? 1) * scaledTheme.textBox.opacity
-    ctx.fillStyle = scaledTheme.textBox.color
-    roundRect(
+  // The container behind the reference + verse block, then each element's own
+  // plate on top of it.
+  const baseOpacity = options?.opacity ?? 1
+  drawSurface(
+    ctx,
+    scaledTheme.textBox,
+    metrics.textBoxRect,
+    baseOpacity,
+    options?.imageCache
+  )
+  if (metrics.referenceSurfaceRect) {
+    drawSurface(
       ctx,
-      metrics.textBoxRect.x,
-      metrics.textBoxRect.y,
-      metrics.textBoxRect.width,
-      metrics.textBoxRect.height,
-      scaledTheme.textBox.borderRadius
+      scaledTheme.reference.surface,
+      metrics.referenceSurfaceRect,
+      baseOpacity,
+      options?.imageCache
     )
-    ctx.fill()
-    ctx.restore()
+  }
+  if (metrics.verseSurfaceRect) {
+    drawSurface(
+      ctx,
+      scaledTheme.verseText.surface,
+      metrics.verseSurfaceRect,
+      baseOpacity,
+      options?.imageCache
+    )
   }
 
   // If no verse data, just draw the background and text box

--- a/src/lib/verse-renderer.ts
+++ b/src/lib/verse-renderer.ts
@@ -8,6 +8,7 @@ import {
   type RichInlineItem,
   type RichInlineLine,
 } from "@chenglou/pretext/rich-inline"
+import { imageContentBox } from "@/lib/theme-image-cache"
 import type {
   BroadcastTheme,
   SurfaceFill,
@@ -531,7 +532,10 @@ function drawImageFill(
   let drawW = rect.width
   let drawH = rect.height
 
-  const imgRatio = img.naturalWidth / img.naturalHeight
+  // Fit the artwork, not the canvas it was exported on: a band drawn in the
+  // corner of a transparent 1920x1080 export must still fill its container.
+  const { sx, sy, sw, sh } = imageContentBox(img)
+  const imgRatio = sw / sh
   const rectRatio = rect.width / rect.height
 
   switch (image.fit) {
@@ -561,7 +565,7 @@ function drawImageFill(
       break
   }
 
-  ctx.drawImage(img, drawX, drawY, drawW, drawH)
+  ctx.drawImage(img, sx, sy, sw, sh, drawX, drawY, drawW, drawH)
   ctx.filter = "none"
 
   if (image.tint) {

--- a/src/stores/broadcast-store.test.ts
+++ b/src/stores/broadcast-store.test.ts
@@ -326,3 +326,48 @@ describe("migrateLegacyOutputs", () => {
     expect(outputs).toHaveLength(1)
   })
 })
+
+describe("updateDraftNested deep paths", () => {
+  beforeEach(async () => {
+    emitToMock.mockReset()
+    emitToMock.mockResolvedValue(undefined)
+    vi.resetModules()
+  })
+
+  it("creates missing intermediates, so a whole surface must be written at once", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    const theme = useBroadcastStore.getState().themes[0]
+    useBroadcastStore.getState().startEditing(theme.id)
+
+    // Writing a leaf under an absent object creates the object with only that
+    // key — which is why the surface panel writes the whole object first.
+    useBroadcastStore.getState().updateDraftNested("reference.surface.color", "#123456")
+    expect(useBroadcastStore.getState().draftTheme?.reference.surface).toEqual({
+      color: "#123456",
+    })
+
+    useBroadcastStore.getState().updateDraftNested("reference.surface", {
+      enabled: true,
+      color: "#000000",
+      opacity: 0.7,
+      borderRadius: 12,
+      padding: 24,
+      image: null,
+    })
+    const surface = useBroadcastStore.getState().draftTheme?.reference.surface
+    expect(surface?.enabled).toBe(true)
+    expect(surface?.image).toBeNull()
+  })
+
+  it("does not mutate the saved theme while editing a draft", async () => {
+    const { useBroadcastStore } = await import("./broadcast-store")
+    const theme = useBroadcastStore.getState().themes[0]
+    useBroadcastStore.getState().startEditing(theme.id)
+    useBroadcastStore.getState().updateDraftNested("textBox.padding", 99)
+
+    expect(useBroadcastStore.getState().draftTheme?.textBox.padding).toBe(99)
+    expect(useBroadcastStore.getState().themes[0].textBox.padding).toBe(
+      theme.textBox.padding
+    )
+  })
+})

--- a/src/types/broadcast.ts
+++ b/src/types/broadcast.ts
@@ -24,6 +24,30 @@ export interface ElementBox {
   height: number
 }
 
+/** An image fill: how a picture is fitted into whatever rect it is drawn in. */
+export interface ThemeImageFill {
+  url: string
+  fit: "cover" | "contain" | "stretch"
+  blur: number
+  brightness: number
+  tint: string | null
+}
+
+/**
+ * A filled surface drawn behind content — the container the text lives in.
+ * Content wraps inside it, inset by `padding`.
+ */
+export interface SurfaceFill {
+  enabled: boolean
+  color: string
+  opacity: number
+  borderRadius: number
+  /** Inset for the content on this surface, in theme px. */
+  padding: number
+  /** When set, fills the surface, clipped to `borderRadius`. */
+  image: ThemeImageFill | null
+}
+
 export type TextHorizontalAlign = "left" | "center" | "right" | "justify"
 export type TextVerticalAlign = "top" | "middle" | "bottom"
 export type TextTransform = "none" | "uppercase" | "lowercase" | "capitalize"
@@ -45,21 +69,13 @@ export interface BroadcastTheme {
       angle: number
       stops: { color: string; position: number }[]
     } | null
-    image: {
-      url: string
-      fit: "cover" | "contain" | "stretch"
-      blur: number
-      brightness: number
-      tint: string | null
-    } | null
+    image: ThemeImageFill | null
   }
-  textBox: {
-    enabled: boolean
-    color: string
-    opacity: number
-    borderRadius: number
-    padding: number
-  }
+  /**
+   * The container holding the reference + verse block. Its fill can be a
+   * colour or an image, and the text wraps inside it.
+   */
+  textBox: SurfaceFill
   verseText: {
     fontFamily: string
     fontSize: number
@@ -73,6 +89,8 @@ export interface BroadcastTheme {
     letterSpacing: number
     shadow: { color: string; blur: number; x: number; y: number } | null
     outline: { color: string; width: number } | null
+    /** Optional plate behind the verse text alone. Absent means none. */
+    surface?: SurfaceFill
   }
   verseNumbers: {
     visible: boolean
@@ -92,6 +110,8 @@ export interface BroadcastTheme {
     uppercase: boolean
     letterSpacing: number
     position: "above" | "below" | "inline"
+    /** Optional chip behind the reference alone. Absent means none. */
+    surface?: SurfaceFill
   }
   layout: {
     anchor:


### PR DESCRIPTION
> Follows #154 (merged). Base is `main`; this PR is only the theme-designer work.

Lets a theme's text container be filled with a colour **or an image**, so band artwork can be used for a lower third.

## Why

A theme had exactly one image slot and it was the *canvas background*, painted into a rect sized by `layout.backgroundWidth/Height`. Band artwork for a lower third therefore landed as a detached rectangle floating mid-frame while the text sat in a separate solid-colour plate below it. There was no way — in the types, the renderer, or the UI — to fill the box the text actually lives in.

## What changed
<img width="1274" height="792" alt="Screenshot 2026-08-19 at 13 54 33" src="https://github.com/user-attachments/assets/cf432739-90c2-4143-84cd-0f5ecb3782de" />

<img width="1725" height="1082" alt="Screenshot 2026-08-19 at 13 26 04" src="https://github.com/user-attachments/assets/a46d4631-490f-4d93-9b23-6ad7937be6d2" />


**`SurfaceFill`**: a filled container drawn behind content, with a colour and an optional image, that the content wraps inside. `textBox` becomes one of these (its `padding` was dead code — scaled but never read — and now insets the text, which is what makes text wrap to the container). `reference` and `verseText` each gained an optional surface for a separate chip or plate; both default to off, so no existing theme changes.

Image drawing is now shared between the frame background and every surface, so a picture behaves the same wherever it is used. It clips to the surface's corner radius instead of a hard rectangle, and the tint paints inside that clip rather than squaring off the rect. Surface radius, padding and image blur all scale with the render, so thumbnails match the 1920×1080 output — blur previously didn't scale and over-blurred every preview.

**Images fit the artwork, not the file.** Band artwork is usually exported on a full 1920×1080 transparent canvas with the graphic in one corner. Fitting that whole canvas shrank the visible art into a corner of the container, identically under cover, contain *and* stretch, because all three were fitting mostly-empty pixels. Images now fit the bounds of their non-transparent pixels, measured once per image at capped resolution and memoised. Fully opaque images keep their natural bounds.

**Designer**: one `SurfaceControls` panel, parameterised by dotted prefix, drives all three surfaces — Text Container under Background, Reference Plate and Verse Plate under their elements. Enable, colour or image fill, fit / blur / brightness / tint, corner radius, padding.

**Lower Thirds** (renamed from "Broadcast Overlay", which said nothing about what it does) now has the reference top-left with the verse beneath it, both flush left, inside a bottom band. Its id is deliberately unchanged: it's persisted in every output's `themeId` and in user themes cloned from it, so renaming the id would orphan existing selections.

## Incidental fixes

- Theme images share one module-level cache. Previously every thumbnail, preview, the designer and the output window each decoded their own copy of the same multi-megabyte base64 data URI, and none of them evicted.
- The output window re-bursts NDI frames once images finish loading, so receivers no longer hold the flat fallback frame until the 2s keepalive.
- The designer's text-area px readout computed a percentage of the frame while the renderer takes it as a percentage of the background region, so it was wrong whenever the background wasn't full-bleed.

## Testing

206 tests pass; typecheck and lint clean. New coverage: the image lands in the surface rect rather than the background rect, the rounded clip, padding insetting text, chips hugging their text, scale correctness, surface migration defaults, and the `setNestedValue` deep-path behaviour the panel relies on.

Verified visually by rendering at full size and at thumbnail scale, and end to end in OBS over an NDI capture (screenshot above).

## Not in this PR

**Animated GIFs.** Selecting a `.gif` works and a still one renders fine, but animation does not. The canvas only redraws on content change, and testing showed a GIF drawn to a canvas stays on frame one — fourteen samples over a second returned frame one every time, both detached and attached to the DOM. A repaint loop alone is therefore unverified, and it would repaint 1920×1080 and push NDI frames at full rate for every animated theme, so it was reverted rather than shipped on a guess. Doing it properly means decoding the GIF's frames in JS and stepping them on our own clock — `ImageDecoder` would be easier but WebKit doesn't ship it, which rules it out on macOS.

**Added content (Text / Shape / Image elements).** A layers model with per-element boxes and z-order. `SurfaceFill` and the existing `ElementBox` are shaped to become layer properties so it won't need a second schema migration.

