### PR TITLE
fix(detection): "is" matched Isaiah and put the wrong verse on air

### DIFF
--- a/src-tauri/crates/detection/src/direct/automaton.rs
+++ b/src-tauri/crates/detection/src/direct/automaton.rs
@@ -1,6 +1,6 @@
 use aho_corasick::{AhoCorasick, MatchKind};
 
-use super::books::BOOKS;
+use super::books::{BookInfo, BOOKS};
 
 /// A match of a Bible book name found in text.
 #[derive(Debug, Clone)]
@@ -24,22 +24,42 @@ impl Default for BookMatcher {
     }
 }
 
+/// Whether a book pattern is safe to match against speech.
+///
+/// Two-letter abbreviations ("Is", "So", "Am", "Ac", "Ho", "Na") are a
+/// *written* citation convention. In a transcript they collide with ordinary
+/// English words: "is" matched Isaiah and put Isaiah 2:8 on air for "our text
+/// is Ephesians 2:8", and poisoned the context book so a later "verse sixteen"
+/// resolved to Isaiah 1:16 over the operator's manual selection (issue #152).
+/// Nobody speaks these aloud, so they cost nothing and cause everything.
+///
+/// Digit-bearing forms like "1 Sa" keep working — the number disambiguates them.
+fn is_speech_safe(pattern: &str) -> bool {
+    pattern.chars().any(|c| c.is_ascii_digit()) || pattern.chars().count() > 2
+}
+
 impl BookMatcher {
     /// Build the automaton from all book names, abbreviations, and aliases.
     pub fn new() -> Self {
         let mut patterns: Vec<String> = Vec::new();
         let mut pattern_map: Vec<(i32, String)> = Vec::new();
 
+        let mut add = |pattern: String, book: &BookInfo| {
+            if !is_speech_safe(&pattern) {
+                return;
+            }
+            patterns.push(pattern);
+            pattern_map.push((book.number, book.name.to_string()));
+        };
+
         for book in BOOKS {
             // Add the canonical name
-            patterns.push(book.name.to_lowercase());
-            pattern_map.push((book.number, book.name.to_string()));
+            add(book.name.to_lowercase(), book);
 
             // Add the abbreviation (if different from name)
             let abbr_lower = book.abbreviation.to_lowercase();
             if abbr_lower != book.name.to_lowercase() {
-                patterns.push(abbr_lower);
-                pattern_map.push((book.number, book.name.to_string()));
+                add(abbr_lower, book);
             }
 
             // Add all aliases
@@ -49,8 +69,7 @@ impl BookMatcher {
                 if alias_lower != book.name.to_lowercase()
                     && alias_lower != book.abbreviation.to_lowercase()
                 {
-                    patterns.push(alias_lower);
-                    pattern_map.push((book.number, book.name.to_string()));
+                    add(alias_lower, book);
                 }
             }
         }
@@ -164,5 +183,69 @@ mod tests {
         let matches = matcher.find_books("Paul wrote in 1 Corinthians 13");
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].book_name, "1 Corinthians");
+    }
+
+    #[test]
+    fn two_letter_abbreviations_do_not_match_english_words() {
+        // Every one of these is a real book alias that is also a common word:
+        // Is/Isaiah, So/Song, Am/Amos, Ac/Acts, Na/Nahum, Ho/Hosea, Da/Daniel,
+        // Ge/Genesis, Le/Leviticus, Ne/Nehemiah, Re/Revelation, Ob/Obadiah.
+        let matcher = BookMatcher::new();
+        let sentences = [
+            "our text this morning is Ephesians 2:8",
+            "he hath given again that which is lawful and right",
+            "so am I to go on, or no",
+            "he did not do anything, ac we all know",
+            "na na na, that is not how it goes",
+            "the ho ho ho of it all",
+        ];
+        for sentence in sentences {
+            let books: Vec<i32> = matcher
+                .find_books(sentence)
+                .iter()
+                .map(|m| m.book_number)
+                .collect();
+            let unexpected: Vec<i32> = books.iter().copied().filter(|&b| b != 49).collect();
+            assert!(
+                unexpected.is_empty(),
+                "{sentence:?} matched unexpected books {unexpected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn full_book_names_and_long_abbreviations_still_match() {
+        let matcher = BookMatcher::new();
+        for (text, expected) in [
+            ("Isaiah 1:16", 23),
+            ("Isa 1:16", 23),
+            ("turn to Song of Solomon 2", 22),
+            ("Amos chapter 5", 30),
+            ("the book of Acts 2:38", 44),
+            ("Hosea 6:6", 28),
+            ("Genesis 1:1", 1),
+        ] {
+            let books: Vec<i32> = matcher
+                .find_books(text)
+                .iter()
+                .map(|m| m.book_number)
+                .collect();
+            assert!(
+                books.contains(&expected),
+                "{text:?} should match book {expected}, got {books:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn digit_prefixed_short_aliases_survive() {
+        // "1 Sa" is unambiguous because of the number, unlike a bare "Sa".
+        let matcher = BookMatcher::new();
+        let books: Vec<i32> = matcher
+            .find_books("1 Sa 3:10")
+            .iter()
+            .map(|m| m.book_number)
+            .collect();
+        assert!(books.contains(&9), "expected 1 Samuel, got {books:?}");
     }
 }

--- a/src-tauri/crates/detection/src/direct/detector.rs
+++ b/src-tauri/crates/detection/src/direct/detector.rs
@@ -2096,4 +2096,50 @@ mod tests {
         assert_eq!(results[0].verse_ref.verse_start, 16);
         assert_eq!(results[0].verse_ref.verse_end, None);
     }
+
+    /// Issue #152: the operator manually put Ezekiel 33:15-16 on air; while the
+    /// preacher read v16 the app switched itself to Isaiah 1:16.
+    ///
+    /// Ezekiel 33:14-16 contains "that which is lawful and right", so a partial
+    /// ending on "is" matched the Isaiah alias, parked an incomplete Isaiah
+    /// reference and rewrote the context book. The next "verse sixteen"
+    /// completed it to Isaiah 1:16 at full confidence.
+    #[test]
+    fn issue_152_reading_a_verse_containing_is_does_not_become_isaiah() {
+        let mut detector = DirectDetector::new();
+        detector.detect("he hath given again that which is");
+        let after = detector.detect("verse sixteen");
+        let isaiah: Vec<_> = after
+            .iter()
+            .filter(|d| d.verse_ref.book_number == 23)
+            .collect();
+        assert!(
+            isaiah.is_empty(),
+            "the word \"is\" resolved to Isaiah: {after:?}"
+        );
+    }
+
+    /// Issue #152: announcing "our text is Ephesians 2:8" jumped to Isaiah 2.
+    ///
+    /// "is" matched Isaiah, and the parser then scanned the rest of the
+    /// utterance for numbers — finding Ephesians' own "2:8" — so Isaiah 2:8 was
+    /// emitted at confidence 1.00 *before* Ephesians 2:8. The UI presents the
+    /// first detection in the batch.
+    #[test]
+    fn issue_152_announcing_a_text_does_not_emit_isaiah_first() {
+        let mut detector = DirectDetector::new();
+        let detections = detector.detect("our text this morning is Ephesians 2:8");
+        assert!(
+            !detections.is_empty(),
+            "Ephesians 2:8 should still be detected"
+        );
+        assert!(
+            detections.iter().all(|d| d.verse_ref.book_number != 23),
+            "Isaiah leaked into the batch: {detections:?}"
+        );
+        let first = &detections[0];
+        assert_eq!(first.verse_ref.book_number, 49, "expected Ephesians");
+        assert_eq!(first.verse_ref.chapter, 2);
+        assert_eq!(first.verse_ref.verse_start, 8);
+    }
 }

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -88,10 +88,19 @@ export function TranscriptPanel() {
     useDetectionStore.getState().addDetections(detections)
     mark(`addDetections done src=${detections[0]?.source ?? "?"}`)
 
-    // Auto-navigate book search + select verse for preview/live
-    const directHit = detections.find(
-      (d) => d.source === "direct" && !d.is_chapter_only
-    )
+    // Auto-navigate book search + select verse for preview/live.
+    //
+    // Take the detector's most confident reading rather than whichever
+    // landed first in the batch. One utterance can yield several direct
+    // detections, and batch order is emission order — in issue #152 a
+    // spurious match was emitted ahead of the verse the preacher actually
+    // named, so the wrong one went on air.
+    const directHit = detections
+      .filter((d) => d.source === "direct" && !d.is_chapter_only)
+      .reduce<DetectionResult | undefined>(
+        (best, d) => (best && best.confidence >= d.confidence ? best : d),
+        undefined
+      )
     if (directHit && directHit.book_number > 0) {
       const detectedVerse = {
         id: 0,


### PR DESCRIPTION
Closes #152.

`"Is"` is a registered alias for Isaiah, so the ordinary English word **is** matched a book. Both incidents in that service came from it — which is why both wrong verses were Isaiah.

## The two incidents

**Reading Ezekiel 33:16 → Isaiah 1:16, over a manual selection.** Ezekiel 33:14-16 reads *"…that which **is** lawful and right"*. Detection runs on every changed partial, so a partial arrives ending exactly on `"is"`. With no numbers after the book match the parser returns chapter 1 verse 0, which parks an incomplete Isaiah reference and rewrites the 90-second context book. The next utterance containing "verse sixteen" completes it to **Isaiah 1:16 at confidence 1.00**, replacing the verse the operator had manually put on air.

**"Our text is Ephesians 2:8" → Isaiah 2.** `"is"` matched Isaiah, and `try_colon_pattern` then scans the *entire rest of the utterance* for numbers with no proximity limit — finding Ephesians' own "2:8". Both readings were emitted at confidence 1.00, Isaiah first:

```
mentioned_books("our text this morning is Ephesians 2:8") = [23, 49]
  detection: book=23 ch=2 v=8 conf=1.00   ← Isaiah, first in the batch
  detection: book=49 ch=2 v=8 conf=1.00   ← Ephesians
```

The UI took the first element, so Isaiah went to air.

Neither was caught by the existing guards: 69e8d80's versification check passes because Isaiah 1:16 and Isaiah 2:8 both genuinely exist, and `test_contraction_is_not_a_book` only covers apostrophes (`we're` → `Re`), not whole words.

Confirmed as direct detection by the reporter, and by the code — `transcript-panel.tsx` only auto-presents `source === "direct"`, so a semantic hit could never have reached the output.

## The fix

The automaton now skips any book pattern of two characters or fewer that contains no digit. Two-letter abbreviations are a *written* citation convention: nobody says "Is one sixteen" aloud, so against a speech transcript they earn nothing while colliding with **is, so, am, ac, na, ho, da, ge, le, ne, re, ob**. Digit-bearing forms like `"1 Sa"` are unambiguous and still match.

Second, smaller change: the UI now auto-presents the **most confident** direct detection instead of whichever was first in the batch. That is defence in depth — it does not rescue a genuinely wrong detection, but it stops emission order deciding what the congregation sees.

## Testing

211 Rust tests (up from 206) and 206 frontend tests pass; clippy and typecheck clean.

Two new tests reproduce the reporter's exact scenarios, plus alias-collision coverage across the whole class and a guard that full names and digit-prefixed forms still match. **I verified the regression tests fail without the fix** by temporarily disabling the guard:

```
issue_152_reading_a_verse_containing_is_does_not_become_isaiah ... FAILED
issue_152_announcing_a_text_does_not_emit_isaiah_first ... FAILED
```

## Not fixed here

Nothing protects a manual send-to-live — `autoLive` is the only gate in the app, which is exactly why the reporter's workaround (toggle Auto off while the right verse is up) works. This PR removes the cause of *this* hijack, but any wrong detection can still overwrite a verse the operator deliberately put on air. Closing that properly means marking detections that came from remembered context rather than a spoken book name, so a context-derived guess can never displace an explicit operator choice. Worth its own PR, and it would let the workaround be retired.
