### PR TITLE
feat(diagnostics): downloadable logs filtered by time range

### DIFF
--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -14,6 +14,9 @@ use tauri::Manager;
 /// Rotated archives are `rhema_<date>.log` alongside it.
 const LOG_STEM: &str = "rhema";
 
+/// Width of the `[YYYY-MM-DD][HH:MM:SS.mmm]` stamp the formatter writes.
+const TIMESTAMP_LEN: usize = 26;
+
 /// Timestamp prefix written by our formatter: `[YYYY-MM-DD][HH:MM:SS.mmm]`.
 /// Anything not starting with this is a continuation of the line before it.
 fn parse_line_timestamp(line: &str) -> Option<(i64, u32, u32, u32, u32, u32)> {
@@ -192,8 +195,8 @@ pub fn export_diagnostics(
         app.package_info().version.to_string().as_str(),
         &window,
         files.len(),
-        first.map(|l| &l[..l.len().min(24)]),
-        last.map(|l| &l[..l.len().min(24)]),
+        first.map(|l| &l[..l.len().min(TIMESTAMP_LEN)]),
+        last.map(|l| &l[..l.len().min(TIMESTAMP_LEN)]),
     );
 
     log::info!(
@@ -319,4 +322,13 @@ mod tests {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
+
+    #[test]
+    fn header_shows_whole_timestamps() {
+        let head = header("0.2.0", "last 60 minutes", 1, Some(T1), Some(T3));
+        assert!(
+            head.contains("[2026-08-19][10:00:00.000]"),
+            "the stamp must not be cut mid-millisecond: {head}"
+        );
+    }
 }

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -1,0 +1,322 @@
+//! Assembling a log excerpt a user can send us.
+//!
+//! Filtering happens here rather than in the frontend so that tens of
+//! megabytes never cross the IPC boundary, and so the log directory can be
+//! read without granting the webview any new filesystem scope.
+
+#![expect(clippy::needless_pass_by_value, reason = "Tauri command extractors require pass-by-value")]
+
+use std::path::{Path, PathBuf};
+
+use tauri::Manager;
+
+/// Log-file basename configured on the plugin's `LogDir` target in `lib.rs`.
+/// Rotated archives are `rhema_<date>.log` alongside it.
+const LOG_STEM: &str = "rhema";
+
+/// Timestamp prefix written by our formatter: `[YYYY-MM-DD][HH:MM:SS.mmm]`.
+/// Anything not starting with this is a continuation of the line before it.
+fn parse_line_timestamp(line: &str) -> Option<(i64, u32, u32, u32, u32, u32)> {
+    let bytes = line.as_bytes();
+    if bytes.len() < 24 || bytes[0] != b'[' {
+        return None;
+    }
+    let date = line.get(1..11)?;
+    if bytes.get(11) != Some(&b']') || bytes.get(12) != Some(&b'[') {
+        return None;
+    }
+    let time = line.get(13..21)?;
+
+    let mut date_parts = date.split('-');
+    let year: i64 = date_parts.next()?.parse().ok()?;
+    let month: u32 = date_parts.next()?.parse().ok()?;
+    let day: u32 = date_parts.next()?.parse().ok()?;
+
+    let mut time_parts = time.split(':');
+    let hour: u32 = time_parts.next()?.parse().ok()?;
+    let minute: u32 = time_parts.next()?.parse().ok()?;
+    let second: u32 = time_parts.next()?.parse().ok()?;
+
+    Some((year, month, day, hour, minute, second))
+}
+
+/// Seconds since the Unix epoch for a UTC calendar timestamp.
+///
+/// Days-from-civil, from Howard Hinnant's `chrono` algorithms — valid for any
+/// proleptic Gregorian date, and it keeps `time` out of this crate's
+/// dependencies for what is a handful of arithmetic.
+fn to_unix_seconds(year: i64, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> i64 {
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let m = i64::from(month);
+    let d = i64::from(day);
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+    days * 86_400 + i64::from(hour) * 3600 + i64::from(minute) * 60 + i64::from(second)
+}
+
+fn line_epoch_seconds(line: &str) -> Option<i64> {
+    let (year, month, day, hour, minute, second) = parse_line_timestamp(line)?;
+    Some(to_unix_seconds(year, month, day, hour, minute, second))
+}
+
+/// Keep every line at or after `cutoff`.
+///
+/// A line with no timestamp belongs to the record above it — multi-line error
+/// `Display` output and panic backtraces both look like this — so it inherits
+/// that record's verdict instead of being dropped. Leading orphan lines (a
+/// file that begins mid-record) are skipped, since nothing dates them.
+fn filter_since(contents: &str, cutoff: Option<i64>) -> Vec<&str> {
+    let Some(cutoff) = cutoff else {
+        return contents.lines().collect();
+    };
+    let mut kept = Vec::new();
+    let mut keeping = false;
+    for line in contents.lines() {
+        match line_epoch_seconds(line) {
+            Some(ts) => {
+                keeping = ts >= cutoff;
+                if keeping {
+                    kept.push(line);
+                }
+            }
+            None => {
+                if keeping {
+                    kept.push(line);
+                }
+            }
+        }
+    }
+    kept
+}
+
+/// The active log plus its rotated archives, oldest first.
+///
+/// Archives are named `rhema_<YYYY-MM-DD_HH-MM-SS>.log`, so a lexical sort of
+/// the archive names is chronological; the live file is always newest.
+fn log_files(dir: &Path) -> Vec<PathBuf> {
+    let mut archives: Vec<PathBuf> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                return false;
+            };
+            name.starts_with(concat!("rhema", "_")) && std::path::Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("log"))
+        })
+        .collect();
+    archives.sort();
+
+    let live = dir.join(format!("{LOG_STEM}.log"));
+    if live.is_file() {
+        archives.push(live);
+    }
+    archives
+}
+
+fn header(
+    version: &str,
+    window: &str,
+    files_scanned: usize,
+    first: Option<&str>,
+    last: Option<&str>,
+) -> String {
+    format!(
+        "==== Rhema diagnostic log ====\n\
+         app version : {version}\n\
+         platform    : {} {}\n\
+         window      : {window}\n\
+         files read  : {files_scanned}\n\
+         first entry : {}\n\
+         last entry  : {}\n\
+         timestamps are UTC. this file contains short fragments of speech\n\
+         picked up by transcription.\n\
+         ==============================\n\n",
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        first.unwrap_or("(none in range)"),
+        last.unwrap_or("(none in range)"),
+    )
+}
+
+/// Collect the log for the requested window as one text blob.
+///
+/// `since_minutes` of `None` means everything still on disk.
+#[tauri::command]
+pub fn export_diagnostics(
+    app: tauri::AppHandle,
+    since_minutes: Option<u64>,
+) -> Result<String, String> {
+    let dir = app.path().app_log_dir().map_err(|e| {
+        log::error!("export_diagnostics: no log dir: {e}");
+        format!("Could not locate the log directory: {e}")
+    })?;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_secs();
+    #[expect(clippy::cast_possible_wrap, reason = "seconds since 1970 fit in i64 for millennia")]
+    let cutoff = since_minutes.map(|mins| now as i64 - (mins as i64) * 60);
+
+    let files = log_files(&dir);
+    let mut body = String::new();
+    for path in &files {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                for line in filter_since(&contents, cutoff) {
+                    body.push_str(line);
+                    body.push('\n');
+                }
+            }
+            Err(e) => {
+                log::warn!("export_diagnostics: skipping {}: {e}", path.display());
+            }
+        }
+    }
+
+    let first = body.lines().find(|l| line_epoch_seconds(l).is_some());
+    let last = body.lines().rfind(|l| line_epoch_seconds(l).is_some());
+    let window = since_minutes.map_or_else(
+        || "everything on disk".to_string(),
+        |mins| format!("last {mins} minutes"),
+    );
+
+    let head = header(
+        app.package_info().version.to_string().as_str(),
+        &window,
+        files.len(),
+        first.map(|l| &l[..l.len().min(24)]),
+        last.map(|l| &l[..l.len().min(24)]),
+    );
+
+    log::info!(
+        "export_diagnostics: {} lines from {} file(s), window={window}",
+        body.lines().count(),
+        files.len()
+    );
+    Ok(head + &body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const T1: &str = "[2026-08-19][10:00:00.000][rhema][INFO] one";
+    const T2: &str = "[2026-08-19][10:30:00.000][rhema][INFO] two";
+    const T3: &str = "[2026-08-19][11:00:00.000][rhema][INFO] three";
+
+    fn epoch(h: u32, m: u32) -> i64 {
+        to_unix_seconds(2026, 8, 19, h, m, 0)
+    }
+
+    #[test]
+    fn parses_our_timestamp_format() {
+        assert_eq!(line_epoch_seconds(T1), Some(epoch(10, 0)));
+    }
+
+    #[test]
+    fn unix_conversion_matches_known_epochs() {
+        assert_eq!(to_unix_seconds(1970, 1, 1, 0, 0, 0), 0);
+        assert_eq!(to_unix_seconds(2000, 1, 1, 0, 0, 0), 946_684_800);
+        assert_eq!(to_unix_seconds(2026, 8, 19, 12, 34, 56), 1_787_142_896);
+    }
+
+    #[test]
+    fn none_cutoff_keeps_everything() {
+        let text = format!("{T1}\n{T2}\n{T3}");
+        assert_eq!(filter_since(&text, None).len(), 3);
+    }
+
+    #[test]
+    fn cutoff_is_inclusive_and_drops_older_lines() {
+        let text = format!("{T1}\n{T2}\n{T3}");
+        let kept = filter_since(&text, Some(epoch(10, 30)));
+        assert_eq!(kept, vec![T2, T3], "the boundary line itself must be kept");
+    }
+
+    #[test]
+    fn everything_older_than_the_cutoff_yields_nothing() {
+        let text = format!("{T1}\n{T2}");
+        assert!(filter_since(&text, Some(epoch(23, 0))).is_empty());
+    }
+
+    #[test]
+    fn continuation_lines_follow_the_record_above_them() {
+        // A panic backtrace under a kept record stays; one under a dropped
+        // record goes with it.
+        let text = format!("{T1}\n   at old_frame\n{T3}\n   at new_frame\n   at deeper_frame");
+        let kept = filter_since(&text, Some(epoch(11, 0)));
+        assert_eq!(kept, vec![T3, "   at new_frame", "   at deeper_frame"]);
+    }
+
+    #[test]
+    fn leading_orphan_lines_are_dropped_when_filtering() {
+        // A file that begins mid-record has nothing dating those first lines.
+        let text = format!("   dangling continuation\n{T3}");
+        assert_eq!(filter_since(&text, Some(epoch(10, 0))), vec![T3]);
+    }
+
+    #[test]
+    fn malformed_lines_do_not_panic_or_parse() {
+        for line in [
+            "",
+            "[",
+            "[not-a-date][10:00:00.000][x][INFO] hi",
+            "[2026-08-19] 10:00:00 missing bracket",
+            "[2026-08-19][aa:bb:cc.ddd][x][INFO] hi",
+            "plain text",
+        ] {
+            assert!(line_epoch_seconds(line).is_none(), "{line:?} parsed");
+        }
+    }
+
+    #[test]
+    fn header_states_version_platform_and_utc() {
+        let head = header("0.2.0", "last 60 minutes", 2, Some(T1), Some(T3));
+        assert!(head.contains("0.2.0"));
+        assert!(head.contains(std::env::consts::OS));
+        assert!(head.contains("last 60 minutes"));
+        assert!(head.contains("UTC"));
+        assert!(
+            head.contains("fragments of speech"),
+            "users must be told the file carries speech content"
+        );
+    }
+
+    #[test]
+    fn archives_are_ordered_before_the_live_log() {
+        let dir = std::env::temp_dir().join(format!("rhema-diag-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        for name in [
+            "rhema.log",
+            "rhema_2026-08-19_09-00-00.log",
+            "rhema_2026-08-19_08-00-00.log",
+            "unrelated.txt",
+        ] {
+            std::fs::write(dir.join(name), "x").unwrap();
+        }
+
+        let names: Vec<String> = log_files(&dir)
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "rhema_2026-08-19_08-00-00.log",
+                "rhema_2026-08-19_09-00-00.log",
+                "rhema.log",
+            ]
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod audio;
 pub mod bible;
 pub mod broadcast;
 pub mod detection;
+pub mod diagnostics;
 pub mod fonts;
 pub mod remote;
 pub mod stt;

--- a/src-tauri/src/commands/stt.rs
+++ b/src-tauri/src/commands/stt.rs
@@ -147,9 +147,11 @@ pub async fn start_transcription(
                 );
             }
 
+            // Never log key material: this file is exported by users for
+            // support, and a prefix is still a prefix of a secret.
             log::info!(
-                "Starting Deepgram transcription: api_key={}..., device_id={device_id:?}, gain={gain:?}",
-                truncate_safe(&resolved_api_key, 8)
+                "Starting Deepgram transcription: api_key={}, device_id={device_id:?}, gain={gain:?}",
+                if resolved_api_key.is_empty() { "missing" } else { "set" }
             );
 
             let stt_config = SttConfig {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,12 @@ pub fn run() {
                 // Memory sampling is for leak-hunting, not bug reports. Keep it
                 // on stdout in dev but out of the file users send us.
                 .level_for("rhema_lib::memstats", tauri_plugin_log::log::LevelFilter::Warn)
+                // ONNX Runtime logs one line per tensor allocation while
+                // loading the embedder ("Reserving memory in BFCArena for Cpu
+                // size: N"). That was 93% of the very first real export — 670 KB
+                // of allocator trace burying 46 KB of signal. Warnings and
+                // errors from it still come through.
+                .level_for("ort", tauri_plugin_log::log::LevelFilter::Warn)
                 .targets([
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,16 +5,41 @@ mod state;
 
 use std::sync::Mutex;
 
+/// Roll the log at 5 MB and keep ten archives — about 50 MB, which covers a
+/// full service at the ~1-2 KB/s the transcription path produces.
+const LOG_MAX_FILE_SIZE: u128 = 5_000_000;
+const LOG_ARCHIVE_COUNT: usize = 10;
+
+/// Route panics through `log` so they reach the log file.
+///
+/// Without this a panic only reaches stderr, which is discarded in a bundled
+/// app — so the single most useful thing a crash report could contain was the
+/// one thing missing from it.
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info
+            .location()
+            .map_or_else(|| "unknown location".to_string(), ToString::to_string);
+        log::error!("[PANIC] at {location}: {info}");
+        previous(info);
+    }));
+}
+
 #[expect(clippy::too_many_lines, reason = "app setup is inherently complex")]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Load .env file — try src-tauri/.env first, then project root ../.env
     dotenvy::dotenv().ok();
     dotenvy::from_filename("../.env").ok();
+    install_panic_hook();
     tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::new()
                 .level(tauri_plugin_log::log::LevelFilter::Info)
+                // Memory sampling is for leak-hunting, not bug reports. Keep it
+                // on stdout in dev but out of the file users send us.
+                .level_for("rhema_lib::memstats", tauri_plugin_log::log::LevelFilter::Warn)
                 .targets([
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
@@ -22,6 +47,35 @@ pub fn run() {
                     }),
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
                 ])
+                // The stock 40 KB / KeepOne default *deletes* the previous file,
+                // which left well under an hour of history — useless for
+                // diagnosing a service that went wrong. Roll at 5 MB and keep
+                // ten archives (~50 MB) so a whole service stays exportable.
+                .max_file_size(LOG_MAX_FILE_SIZE)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(
+                    LOG_ARCHIVE_COUNT,
+                ))
+                // Our own formatter rather than `.timezone_strategy()`, which
+                // installs one that also swaps the field order. Milliseconds
+                // matter: the [LAT] marks measure detection latency, and whole
+                // seconds throw that away. Times are UTC so reports from
+                // different machines line up.
+                .format(|out, message, record| {
+                    let now = tauri_plugin_log::TimezoneStrategy::UseUtc.get_now();
+                    out.finish(format_args!(
+                        "[{:04}-{:02}-{:02}][{:02}:{:02}:{:02}.{:03}][{}][{}] {}",
+                        now.year(),
+                        u8::from(now.month()),
+                        now.day(),
+                        now.hour(),
+                        now.minute(),
+                        now.second(),
+                        now.millisecond(),
+                        record.target(),
+                        record.level(),
+                        message
+                    ));
+                })
                 .build(),
         )
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
@@ -46,6 +100,7 @@ pub fn run() {
             commands::bible::get_cross_references,
             commands::bible::get_active_translation,
             commands::bible::set_active_translation,
+            commands::diagnostics::export_diagnostics,
             commands::detection::detect_verses,
             commands::detection::detection_status,
             commands::detection::ui_mark,

--- a/src-tauri/src/memstats.rs
+++ b/src-tauri/src/memstats.rs
@@ -9,7 +9,10 @@ use std::time::Duration;
 
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 
-const INTERVAL: Duration = Duration::from_secs(5);
+/// Sampled for leak-hunting during development. Once a minute at debug
+/// level, so it stays out of the log file users export (see the
+/// `level_for` filter in `lib.rs`) instead of drowning it.
+const INTERVAL: Duration = Duration::from_secs(60);
 
 pub fn spawn() {
     tauri::async_runtime::spawn(async move {
@@ -27,7 +30,7 @@ pub fn spawn() {
             if let Some(proc_) = sys.process(pid) {
                 let rss_mb = proc_.memory() as f64 / 1024.0 / 1024.0;
                 let virt_mb = proc_.virtual_memory() as f64 / 1024.0 / 1024.0;
-                log::info!(
+                log::debug!(
                     "[MEM] rss={:.1}MB virt={:.0}MB",
                     rss_mb,
                     virt_mb,

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react"
 import { invoke } from "@tauri-apps/api/core"
 
 import { Button } from "@/components/ui/button"
+import { DiagnosticsSection } from "@/components/settings/diagnostics-section"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import {
@@ -38,6 +39,7 @@ import {
   CheckIcon,
   BookOpenIcon,
   RadioIcon,
+  FileTextIcon,
   HelpCircleIcon,
   GraduationCapIcon,
   BrainCircuitIcon,
@@ -55,7 +57,15 @@ import type { DeviceInfo } from "@/types/audio"
 /*  Nav definition                                                            */
 /* -------------------------------------------------------------------------- */
 
-type NavSection = "audio" | "speech" | "bible" | "display" | "api-keys" | "remote" | "help"
+type NavSection =
+  | "audio"
+  | "speech"
+  | "bible"
+  | "display"
+  | "api-keys"
+  | "remote"
+  | "diagnostics"
+  | "help"
 
 const navItems: { name: string; id: NavSection; icon: React.ReactNode }[] = [
   {
@@ -87,6 +97,11 @@ const navItems: { name: string; id: NavSection; icon: React.ReactNode }[] = [
     name: "API Keys",
     id: "api-keys",
     icon: <KeyIcon strokeWidth={2} />,
+  },
+  {
+    name: "Diagnostics",
+    id: "diagnostics",
+    icon: <FileTextIcon strokeWidth={2} />,
   },
   {
     name: "Help",
@@ -479,6 +494,7 @@ const sectionTitles: Record<NavSection, string> = {
   display: "Display Mode",
   remote: "Remote Control",
   "api-keys": "API Keys",
+  diagnostics: "Diagnostics",
   help: "Help",
 }
 
@@ -905,6 +921,7 @@ const sectionComponents: Record<NavSection, React.FC> = {
   display: DisplayModeSection,
   remote: RemoteControlSection,
   "api-keys": ApiKeysSection,
+  diagnostics: DiagnosticsSection,
   help: HelpSection,
 }
 

--- a/src/components/settings/diagnostics-section.tsx
+++ b/src/components/settings/diagnostics-section.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react"
+import { DownloadIcon, LoaderCircleIcon } from "lucide-react"
+import { toast } from "sonner"
+import { invoke } from "@tauri-apps/api/core"
+import { getVersion } from "@tauri-apps/api/app"
+import { appLogDir } from "@tauri-apps/api/path"
+import { save } from "@tauri-apps/plugin-dialog"
+import { writeTextFile } from "@tauri-apps/plugin-fs"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+/** `null` means everything still on disk. */
+const RANGES: { value: string; label: string; minutes: number | null }[] = [
+  { value: "15", label: "Last 15 minutes", minutes: 15 },
+  { value: "60", label: "Last hour", minutes: 60 },
+  { value: "180", label: "Last 3 hours", minutes: 180 },
+  { value: "all", label: "Everything", minutes: null },
+]
+
+/** `2026-08-19T14-05-33Z` — safe in a filename, sorts chronologically. */
+function fileStamp(): string {
+  return new Date().toISOString().replace(/:/g, "-").replace(/\.\d+Z$/, "Z")
+}
+
+export function DiagnosticsSection() {
+  const [range, setRange] = useState("60")
+  const [saving, setSaving] = useState(false)
+  const [version, setVersion] = useState("")
+  const [logDir, setLogDir] = useState("")
+
+  useEffect(() => {
+    void getVersion().then(setVersion).catch(() => {})
+    void appLogDir().then(setLogDir).catch(() => {})
+  }, [])
+
+  const handleSave = async () => {
+    const selected = RANGES.find((r) => r.value === range)
+    setSaving(true)
+    try {
+      const contents = await invoke<string>("export_diagnostics", {
+        sinceMinutes: selected?.minutes ?? null,
+      })
+      const path = await save({
+        defaultPath: `rhema-logs-${fileStamp()}.log`,
+        filters: [{ name: "Log", extensions: ["log", "txt"] }],
+      })
+      // The user cancelled the save dialog.
+      if (!path) return
+      await writeTextFile(path, contents)
+      toast.success("Logs saved", { description: path })
+    } catch (error) {
+      toast.error("Could not save logs", { description: String(error) })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <p className="text-sm text-muted-foreground">
+          Save a copy of the app&apos;s logs to send with a bug report.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+          <div className="flex flex-col gap-1.5">
+            <label
+              id="log-range-label"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Time range
+            </label>
+            <Select value={range} onValueChange={setRange}>
+              <SelectTrigger aria-labelledby="log-range-label" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RANGES.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            disabled={saving}
+            onClick={() => void handleSave()}
+          >
+            {saving ? (
+              <LoaderCircleIcon className="mr-1.5 size-3.5 animate-spin" />
+            ) : (
+              <DownloadIcon className="mr-1.5 size-3.5" />
+            )}
+            {saving ? "Saving…" : "Save logs…"}
+          </Button>
+
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            The file records what the app did, including short fragments of
+            speech picked up by transcription. It never contains your API keys.
+          </p>
+        </div>
+
+        <div className="space-y-1.5 rounded-lg border border-border bg-card p-4">
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="text-xs text-muted-foreground">Version</span>
+            <span className="font-mono text-xs">{version || "—"}</span>
+          </div>
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="shrink-0 text-xs text-muted-foreground">Log folder</span>
+            <span className="truncate font-mono text-[0.6875rem]" title={logDir}>
+              {logDir || "—"}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/console-to-log.ts
+++ b/src/lib/console-to-log.ts
@@ -1,0 +1,54 @@
+import { warn as logWarn, error as logError } from "@tauri-apps/plugin-log"
+
+/**
+ * Forward frontend failures into the log file.
+ *
+ * Note this is the opposite direction to the plugin's `attachConsole()`, which
+ * pipes *Rust* logs into the browser console — useful in devtools, useless in
+ * a bug report. Without this, every `console.error` and every uncaught React
+ * error exists only in a devtools panel nobody has open, so the logs a user
+ * sends us are silent about frontend faults.
+ *
+ * Only warnings and errors are forwarded. `console.log`/`debug` are far too
+ * chatty to put in a file that has to stay readable.
+ */
+export function forwardConsoleToLog(): void {
+  const originalWarn = console.warn.bind(console)
+  const originalError = console.error.bind(console)
+
+  const render = (args: unknown[]) =>
+    args
+      .map((arg) => {
+        if (typeof arg === "string") return arg
+        if (arg instanceof Error) return `${arg.name}: ${arg.message}`
+        try {
+          return JSON.stringify(arg)
+        } catch {
+          return String(arg)
+        }
+      })
+      .join(" ")
+
+  console.warn = (...args: unknown[]) => {
+    originalWarn(...args)
+    void logWarn(render(args)).catch(() => {})
+  }
+
+  console.error = (...args: unknown[]) => {
+    originalError(...args)
+    void logError(render(args)).catch(() => {})
+  }
+
+  window.addEventListener("error", (event) => {
+    const where = event.filename ? ` (${event.filename}:${event.lineno})` : ""
+    void logError(`[uncaught] ${event.message}${where}`).catch(() => {})
+  })
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason =
+      event.reason instanceof Error
+        ? `${event.reason.name}: ${event.reason.message}`
+        : String(event.reason)
+    void logError(`[unhandled rejection] ${reason}`).catch(() => {})
+  })
+}

--- a/src/lib/settings-dialog.ts
+++ b/src/lib/settings-dialog.ts
@@ -1,6 +1,14 @@
 import { create } from "zustand"
 
-type SettingsSection = "audio" | "speech" | "bible" | "display" | "api-keys" | "remote" | "help"
+type SettingsSection =
+  | "audio"
+  | "speech"
+  | "bible"
+  | "display"
+  | "api-keys"
+  | "remote"
+  | "diagnostics"
+  | "help"
 
 interface SettingsDialogState {
   isOpen: boolean

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { invoke } from "@tauri-apps/api/core"
+import { forwardConsoleToLog } from "@/lib/console-to-log"
 
 import "./index.css"
 import App from "./App.tsx"
@@ -9,6 +10,10 @@ import { TooltipProvider } from "@/components/ui/tooltip.tsx"
 import { hydrateSettings } from "@/stores/settings-store"
 import { hydrateBibleStore, initBiblePersistence } from "@/stores/bible-store"
 import { hydrateBroadcastThemes } from "@/stores/broadcast-store"
+
+// Frontend warnings, errors and uncaught rejections only exist in devtools
+// otherwise, so the logs a user sends us would say nothing about them.
+forwardConsoleToLog()
 
 // Webview reloads do NOT restart the Rust backend, so any STT pipeline
 // left running from the previous webview session still has


### PR DESCRIPTION
Gives users a way to show us what the app actually did. Diagnosing #152 took a code trace and a reproduction because the transcript that triggered it was never recoverable — this makes that a file attachment instead.

Settings gains a **Diagnostics** section: pick a window (15 minutes / 1 hour / 3 hours / everything), save one text file, attach it to an issue. It also shows the app version and log folder, neither of which appeared anywhere in the UI before.

<img width="1728" height="1091" alt="Screenshot 2026-08-19 at 18 19 47" src="https://github.com/user-attachments/assets/3b410203-7584-4edd-981b-b2392ec99706" />


## Four things had to change before an export was worth having

**The log destroyed itself.** No size or rotation was configured, so the crate defaults applied: a **40 KB** cap with `RotationStrategy::KeepOne`, which *deletes* the previous file rather than archiving it. With a `[MEM]` line every 5s that was ~41 minutes of pure noise when idle, and **under a minute** while transcribing. "Last 1 hour" was not achievable. Now 5 MB per file, ten archives kept (~50 MB), which covers a full service.

**Panics never reached it.** There was no `std::panic::set_hook`, so crashes went to stderr and vanished in a bundled app — the single most useful thing a crash report could carry was the one thing missing. They now route through `log::error!` with their location.

**Frontend faults never reached it either.** `console.warn`/`error`, uncaught errors and unhandled rejections now forward into the log. Worth knowing for review: this is the *opposite* direction to the plugin's `attachConsole()`, which pipes **Rust logs into devtools** — I wired that first, checked it, and found it would never have put a single frontend error in the file.

**It leaked a secret.** `stt.rs` logged the first 8 characters of the real Deepgram API key on every transcription start — into the file users are about to email us. It now logs `api_key=set|missing`.

## Also

- `[MEM]` sampling moved to once a minute at `debug`, and filtered out of the file by `level_for`. It was **100% of the lines** in the idle log I sampled.
- Log lines now carry **milliseconds**. The existing `[LAT]` marks measure detection latency and whole seconds threw that away. Times stay UTC so reports from different machines line up. This uses a custom `.format()` rather than `.timezone_strategy()`, which quietly installs its own formatter that also swaps the field order.

## Design notes

Filtering runs in Rust, so tens of megabytes never cross the IPC boundary and the log directory is read without granting the webview new filesystem scope. **No capability changes** were needed — `dialog:default` and `fs:allow-write-text-file` are already granted, and the dialog plugin scopes fs access to the picked path. (A real `.zip` would need `fs:allow-write-file`, which is not granted — hence one text file.)

A line with no timestamp is a **continuation** — panic backtraces and multi-line error `Display` both look like this — so it inherits the verdict of the record above it instead of being dropped.

**Never exported:** `settings.json`, which holds Deepgram, OpenAI and Claude keys in plaintext, and `broadcast-themes.json`, which is 125 KB of base64 image data. Nothing is uploaded anywhere; the user saves a file and sends it themselves.

Spoken-transcript snippets **are** included — they are what made #152 diagnosable — and both the export screen and the file header say so plainly, so users know what they're sharing.

## Testing

14 Rust tests for the filter and header (cutoff boundaries, continuation inheritance, leading orphans, malformed lines, multi-file ordering, epoch conversion against known values); 206 frontend tests, clippy and typecheck clean.

Verified against the running app rather than only fixtures:

- New format confirmed live, with milliseconds and **0 `[MEM]` lines** out of 1297.
- Console forwarding proved end to end by triggering an error and finding it in the file with its source location:
  `[2026-08-19][16:50:45.565][webview:main.tsx:14:14][ERROR] PROBE console-to-log wiring {"probe":true}`
- The filter run against the real log: **2606 of 2606 lines parsed**, and a 60-second window correctly narrowed to 1299.

One epoch constant in my own test was wrong by 600 seconds; the test caught it.

## Not covered

Rotation into archives hasn't been exercised on a real 5 MB roll — reaching it needs a long transcribing session. The archive naming and ordering are covered by a unit test against synthetic files.
