### PR TITLE
docs: how to share logs when reporting a bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,12 +62,27 @@ body:
       render: markdown
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### Attaching logs
+
+        Logs are the fastest way for us to see what actually happened — they
+        carry the transcript and the detections that led to the problem.
+
+        In Rhema, open **Settings → Diagnostics**, choose a time range that
+        covers when the issue happened (**Last hour** is usually right), and
+        click **Save logs…**. Drag the saved `.log` file onto this issue.
+
+        The file contains short fragments of speech picked up by
+        transcription, so give it a glance before sharing. It never contains
+        your API keys.
   - type: textarea
     id: logs
     attributes:
       label: Logs
       description: |
-        If applicable, include relevant log output. For frontend issues, open browser dev tools (Cmd+Option+I / Ctrl+Shift+I) and copy console output. For backend issues, check the Tauri log file.
+        Attach the file from Settings → Diagnostics (see above), or paste relevant output here. If you can't reach Settings, the log file lives in `~/Library/Logs/com.openbezal.rhema/` on macOS and `%LOCALAPPDATA%\com.openbezal.rhema\logs\` on Windows.
       render: shell
   - type: textarea
     id: screenshots

--- a/web/content/docs/reference/diagnostics.mdx
+++ b/web/content/docs/reference/diagnostics.mdx
@@ -1,0 +1,76 @@
+---
+title: Diagnostics & Logs
+description: Export a log file for a bug report, what it contains, and where logs live on disk.
+icon: FileText
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Rhema keeps a rolling log of what it does — audio devices, transcripts,
+verse detections, broadcast output changes and errors. When something goes
+wrong during a service, that log is usually the difference between a bug we
+can fix and one we can only guess at.
+
+## Exporting logs for a bug report
+
+1. Open **Settings** → **Diagnostics**.
+2. Choose a **time range** that covers when the problem happened. **Last hour**
+   is usually right; use **Everything** if you are not sure.
+3. Click **Save logs…** and choose where to put the file.
+4. Attach the saved `.log` file to your
+   [GitHub issue](https://github.com/openbezal/rhema/issues/new/choose).
+
+The same screen shows your app version and the folder the logs live in.
+
+## What the file contains
+
+The export opens with a short header — app version, platform, the time range
+covered — followed by the log lines themselves, oldest first. Timestamps are
+**UTC**, so reports from different machines can be compared directly.
+
+Because verse detection works from speech, the log records **short fragments
+of what was said** (40-80 characters per line). That is deliberate: for a
+detection problem it is the only way to see why the app matched the verse it
+did. Have a look through the file before sharing it if the service content is
+sensitive.
+
+Your **API keys are never included**. Neither are your themes or settings
+files.
+
+## Where logs live
+
+<Callout type="info">
+  You only need these paths if you cannot open Settings — otherwise use the
+  export above, which also filters by time.
+</Callout>
+
+| Platform | Location |
+| --- | --- |
+| macOS | `~/Library/Logs/com.openbezal.rhema/` |
+| Windows | `%LOCALAPPDATA%\com.openbezal.rhema\logs\` |
+| Linux | `~/.local/share/com.openbezal.rhema/logs/` |
+
+The active log is `rhema.log`. Older logs are rotated alongside it as
+`rhema_<date>.log`, and the oldest are dropped once the folder reaches its
+size limit — so export while the problem is fresh rather than days later.
+
+## Reading a log line
+
+```
+[2026-08-19][17:16:51.068][rhema_lib::commands::stt][INFO] [LAT] partial "Let's open our Bibles to Psalms chapter 1"
+```
+
+| Part | Meaning |
+| --- | --- |
+| `[2026-08-19][17:16:51.068]` | UTC date and time, to the millisecond |
+| `rhema_lib::commands::stt` | which part of the app wrote it |
+| `INFO` | severity |
+
+Tags worth knowing when reporting a detection problem:
+
+- `[LAT] partial` / `[LAT] final` — what the transcriber heard. Partials update
+  live as someone speaks; finals are the settled text.
+- `[DET-DIRECT]` — a verse matched from a spoken reference, with its confidence.
+- `[DET-SEMANTIC]` — a verse matched from the sense of the words rather than a
+  citation.
+- `[READING]` — reading mode following along through a passage.

--- a/web/content/docs/reference/meta.json
+++ b/web/content/docs/reference/meta.json
@@ -1,5 +1,11 @@
 {
   "title": "Reference",
   "icon": "BookText",
-  "pages": ["scripts", "environment-variables", "security", "remote-control-api"]
+  "pages": [
+    "scripts",
+    "environment-variables",
+    "security",
+    "remote-control-api",
+    "diagnostics"
+  ]
 }


### PR DESCRIPTION
Tells people they can attach logs when reporting a bug, and explains what those logs are.

Depends on #157, which adds the Settings → Diagnostics screen this describes. Merge that first, or these instructions point at a screen that isn't there yet.

## Bug report template

The Logs field previously said "open browser dev tools and copy console output", which asks a volunteer running a service to reproduce a problem in devtools. It now points at **Settings → Diagnostics** above the field, with the time range to pick and a note that the file carries short fragments of speech but never API keys. The field itself keeps the platform log paths as a fallback for anyone who can't reach Settings.

## New reference page: Diagnostics & Logs

Covers the export flow, what the file does and doesn't contain, log locations per platform, and how to read a line — including the tags that matter when reporting a detection problem:

- `[LAT] partial` / `[LAT] final` — what the transcriber heard
- `[DET-DIRECT]` — a verse matched from a spoken reference, with confidence
- `[DET-SEMANTIC]` — a verse matched from the sense of the words
- `[READING]` — reading mode following a passage

That last part is the point of the page. The first real exported log identified two separate bugs in minutes — the ONNX noise fixed in #157, and a Psalms misparse — purely by reading those tags. A reporter who can point at the right lines saves a round trip.
