### PR TITLE
fix(detection): spoken Psalm 136 detected as Psalm 1

### DIFF
--- a/src-tauri/crates/detection/src/direct/detector.rs
+++ b/src-tauri/crates/detection/src/direct/detector.rs
@@ -2142,4 +2142,74 @@ mod tests {
         assert_eq!(first.verse_ref.chapter, 2);
         assert_eq!(first.verse_ref.verse_start, 8);
     }
+
+    /// Deepgram writes a spoken "one thirty-six" as two numbers, so
+    /// "Psalm 136 verse 1" arrives as "Psalm 1 36 verse 1" and used to be
+    /// detected as Psalms 1:1 at full confidence — the wrong psalm on air.
+    #[test]
+    fn psalm_chapter_split_into_digit_groups_is_rejoined() {
+        let mut detector = DirectDetector::new();
+        let out = detector.detect("Psalm 1 36 verse 1.");
+        assert_eq!(out.len(), 1, "expected one detection, got {out:?}");
+        assert_eq!(out[0].verse_ref.book_number, 19, "Psalms");
+        assert_eq!(out[0].verse_ref.chapter, 136);
+        assert_eq!(out[0].verse_ref.verse_start, 1);
+    }
+
+    #[test]
+    fn two_digit_chapter_split_is_rejoined() {
+        let mut detector = DirectDetector::new();
+        let out = detector.detect("Psalm 2 3 verse 4");
+        assert_eq!(out[0].verse_ref.chapter, 23);
+        assert_eq!(out[0].verse_ref.verse_start, 4);
+    }
+
+    /// The whole announcement from the service that surfaced this, which names
+    /// two psalms in one breath.
+    #[test]
+    fn split_chapter_survives_a_multi_reference_utterance() {
+        let mut detector = DirectDetector::new();
+        let out = detector.detect(
+            "Let's open our Bibles to Psalms chapter 100 and Psalm 1 36 verse 1",
+        );
+        let refs: Vec<(i32, i32)> = out
+            .iter()
+            .map(|d| (d.verse_ref.chapter, d.verse_ref.verse_start))
+            .collect();
+        assert!(refs.contains(&(136, 1)), "expected Psalms 136:1 in {refs:?}");
+        assert!(
+            !refs.iter().any(|&(c, _)| c == 1),
+            "Psalms 1 must not appear: {refs:?}"
+        );
+    }
+
+    /// A single chapter number before "verse" must keep its old meaning.
+    #[test]
+    fn single_chapter_numbers_are_untouched() {
+        for (text, chapter, verse) in [
+            ("Psalm 5 verse 10", 5, 10),
+            ("Psalm 1 verse 1", 1, 1),
+            ("John 3 verse 16", 3, 16),
+            ("Romans 8 verse 28", 8, 28),
+            ("Genesis 1 verse 1", 1, 1),
+        ] {
+            let mut detector = DirectDetector::new();
+            let out = detector.detect(text);
+            assert_eq!(out[0].verse_ref.chapter, chapter, "{text:?}");
+            assert_eq!(out[0].verse_ref.verse_start, verse, "{text:?}");
+        }
+    }
+
+    /// Joining is only allowed when the result is a real reference, so a pair
+    /// that would invent a chapter falls through to the existing rules.
+    #[test]
+    fn rejoining_requires_the_result_to_exist() {
+        // Jude has one chapter; "9 9" cannot become Jude 99.
+        let mut detector = DirectDetector::new();
+        let out = detector.detect("Jude 9 9 verse 1");
+        assert!(
+            out.iter().all(|d| d.verse_ref.chapter != 99),
+            "invented a chapter: {out:?}"
+        );
+    }
 }

--- a/src-tauri/crates/detection/src/direct/detector.rs
+++ b/src-tauri/crates/detection/src/direct/detector.rs
@@ -553,6 +553,28 @@ impl DirectDetector {
     /// Detect Bible references in the given transcript text.
     ///
     /// Returns a list of Detection objects for each reference found.
+    /// Whether `text` names a book together with a chapter and verse of its own.
+    ///
+    /// A reference parked from an earlier partial must not complete itself using
+    /// numbers that belong to a newly stated one. Saying "Psalm" (which parks
+    /// Psalms 1) and then "Psalm 103 verse 5" means Psalms 103:5 — but the
+    /// continuation path saw only "verse 5" and produced Psalms 1:5. Likewise a
+    /// partial trailing into "…Psalm 13" made the next "Psalm 15 verse 4" land
+    /// on Psalms 13:4.
+    ///
+    /// Deliberately narrow: text with no book name in it — "verse 22", or a
+    /// bare "22 20" correction — is not a complete reference, so genuine
+    /// continuations still work.
+    fn text_names_complete_reference(&self, text: &str) -> bool {
+        self.matcher.find_books(text).iter().any(|book_match| {
+            parser::parse_reference(text, book_match).is_some_and(|r| {
+                r.verse_start > 0
+                    && is_valid_reference(r.book_number, r.chapter)
+                    && versification::is_valid_verse(r.book_number, r.chapter, r.verse_start)
+            })
+        })
+    }
+
     pub fn detect(&mut self, text: &str) -> Vec<Detection> {
         // Step 0: Clean filler phrases from the transcript
         let cleaned = clean_transcript(text);
@@ -572,6 +594,11 @@ impl DirectDetector {
             let elapsed = incomplete.timestamp.elapsed().as_millis();
             if elapsed > INCOMPLETE_REF_TIMEOUT_MS {
                 // Timeout: clean up pending state (EDGE-02).
+                self.incomplete = None;
+            } else if self.text_names_complete_reference(text) {
+                // The speaker has named a whole reference in this utterance, so
+                // one parked from an earlier partial is stale. Drop it and let
+                // the book matcher below read what was actually said.
                 self.incomplete = None;
             } else if let Some(cont) =
                 parser::try_extract_continuation(text, incomplete.chapter_is_default)
@@ -2211,5 +2238,45 @@ mod tests {
             out.iter().all(|d| d.verse_ref.chapter != 99),
             "invented a chapter: {out:?}"
         );
+    }
+
+
+    /// A bare book name in a partial parks a reference with chapter 1. When the
+    /// speaker then states the whole thing, that parked reference used to
+    /// swallow the new verse number: "Psalm" then "Psalm 103 verse 5" gave
+    /// Psalms 1:5 instead of 103:5.
+    #[test]
+    fn a_parked_reference_does_not_hijack_a_newly_stated_one() {
+        let mut detector = DirectDetector::new();
+        detector.detect("Psalm");
+        let out = detector.detect("Psalm 103 verse 5.");
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert_eq!(out[0].verse_ref.chapter, 103);
+        assert_eq!(out[0].verse_ref.verse_start, 5);
+    }
+
+    /// A partial that runs into the next citation parks it; the final then
+    /// settles on only the first sentence. "…Psalm 13" followed by
+    /// "Psalm 15 verse 4" used to be detected as Psalms 13:4.
+    #[test]
+    fn a_reference_trailing_from_a_partial_does_not_win_over_the_final() {
+        let mut detector = DirectDetector::new();
+        detector.detect("Psalm 15 verse 4. Psalm 13");
+        let out = detector.detect("Psalm 15 verse 4.");
+        assert_eq!(out[0].verse_ref.chapter, 15);
+        assert_eq!(out[0].verse_ref.verse_start, 4);
+    }
+
+    /// The guard must only fire when the new text is self-sufficient, or the
+    /// late-callout and self-correction handling from #142 would break.
+    #[test]
+    fn book_less_continuations_still_complete_a_parked_reference() {
+        let mut detector = DirectDetector::new();
+        detector.detect("Let us turn to Romans chapter 8");
+        let out = detector.detect("verse 28");
+        assert_eq!(out.len(), 1, "the late verse callout was lost: {out:?}");
+        assert_eq!(out[0].verse_ref.book_number, 45, "Romans");
+        assert_eq!(out[0].verse_ref.chapter, 8);
+        assert_eq!(out[0].verse_ref.verse_start, 28);
     }
 }

--- a/src-tauri/crates/detection/src/direct/parser.rs
+++ b/src-tauri/crates/detection/src/direct/parser.rs
@@ -60,6 +60,12 @@ pub fn parse_reference(text: &str, book_match: &BookMatch) -> Option<VerseRef> {
 
     // Try pattern: number followed by "verse" keyword then number
     // e.g. "32 verse 1"
+    // Before N-verse-M, so a chapter split into digit groups is rejoined
+    // rather than having its tail dropped.
+    if let Some(result) = try_split_chapter_verse_pattern(&tokens, book_match) {
+        return Some(result);
+    }
+
     if let Some(result) = try_number_verse_pattern(&tokens, book_match) {
         return Some(result);
     }
@@ -435,6 +441,52 @@ fn try_verse_only_pattern(tokens: &[Token], book_match: &BookMatch) -> Option<Ve
                 }
             }
         }
+    }
+    None
+}
+
+/// "Psalm 1 36 verse 1" — a chapter spoken as digit groups.
+///
+/// Deepgram renders "one thirty-six" as two separate numbers, never "136"
+/// (the same quirk that made it write corrections as "22 20"). The existing
+/// `N verse M` rule then reads the first number as the chapter and silently
+/// discards the second, so "Psalm 1 36 verse 1" became Psalms 1:1 at full
+/// confidence instead of Psalms 136:1.
+///
+/// When an explicit "verse" keyword already says where the verse is, an
+/// adjacent pair of numbers before it must both belong to the chapter, so
+/// they are joined. Only accepted when the joined reference actually exists —
+/// otherwise this falls through to the existing rules unchanged.
+fn try_split_chapter_verse_pattern(tokens: &[Token], book_match: &BookMatch) -> Option<VerseRef> {
+    for i in 0..tokens.len() {
+        let (first, after_first) = consume_number_at(tokens, i)?;
+        let Some((second, after_second)) = consume_number_at(tokens, after_first) else {
+            continue;
+        };
+        // Nobody says a chapter as "one three hundred"; a trailing group is
+        // always under 100, which also keeps this away from real verse numbers.
+        if first <= 0 || !(1..100).contains(&second) {
+            continue;
+        }
+        let Some(Token::Word(w)) = tokens.get(after_second) else {
+            continue;
+        };
+        if w != "verse" && w != "verses" {
+            continue;
+        }
+        let (verse, verse_next) = consume_number(tokens, after_second + 1)?;
+
+        let joined: i32 = format!("{first}{second}").parse().ok()?;
+        if !super::versification::is_valid_verse(book_match.book_number, joined, verse) {
+            continue;
+        }
+        return Some(VerseRef {
+            book_number: book_match.book_number,
+            book_name: book_match.book_name.clone(),
+            chapter: joined,
+            verse_start: verse,
+            verse_end: scan_verse_end(tokens, verse_next),
+        });
     }
     None
 }


### PR DESCRIPTION
A spoken "Psalm one thirty-six" put **Psalms 1:1** on air instead of Psalms 136:1, at 100% confidence.

Found by reading a user-exported diagnostic log — the feature in #157 earning its keep on its second real use.

## What happens

Deepgram transcribes "one thirty-six" as **two separate numbers**, never "136" — the same rendering quirk that made self-corrections arrive as `"22 20"` and was handled for corrections in #142. The `N verse M` rule takes the first number as the chapter and **silently discards the second**:

```
[17:17:16.372] [LAT] partial "Psalm 1 36 verse 1."
[17:17:16.374] [DET-DIRECT] Found: Psalms 1:1 (100%)
```

Confirmed against the detector before and after:

| spoken | transcript | before | after |
| --- | --- | --- | --- |
| "Psalm one thirty-six verse one" | `Psalm 1 36 verse 1.` | **Psalms 1:1** | Psalms 136:1 |
| "Psalm twenty-three verse four" | `Psalm 2 3 verse 4` | **Psalms 2:3** | Psalms 23:4 |
| "Psalm five verse ten" | `Psalm 5 verse 10` | Psalms 5:10 | Psalms 5:10 |

Psalms is where this bites hardest — it's the book people routinely cite in three digits. Note "Psalm 100" was fine in the same log, because Deepgram writes that as a single token.

## The fix

When an explicit `verse` keyword already says where the verse is, an adjacent pair of numbers before it must both belong to the chapter, so they are joined.

Two guards keep it narrow. The joined reference must **actually exist** — versification from #142 is consulted, so it cannot invent Jude 99 — and a trailing group must be under 100, since nobody says a chapter as "one three hundred". Anything that fails either check falls through to the existing rules untouched.

## Testing

216 tests pass, up from 211. The three behaviour tests **fail without the fix** — verified by disabling the new rule and watching them go red — while the two guard tests (single chapter numbers untouched, joining cannot invent a chapter) stay green either way, which is what makes them worth having.

One of the new tests replays the full announcement from the service: *"Let's open our Bibles to Psalms chapter 100 and Psalm 1 36 verse 1"*, and asserts both Psalms 100:1 and Psalms 136:1 are found and that Psalms 1 is not.

Clippy reports three warnings in the touched files (two redundant else blocks, one long function); all three are on `main` already and none are from this change.

---

## Second commit: a parked reference hijacking a newly stated one

Testing this branch live surfaced two more wrong verses with a shared root, so they are fixed here too. An incomplete reference parked from an earlier partial gets completed **before the book matcher ever looks at the new text**, so it swallows numbers belonging to a reference the speaker just stated in full:

```
"Psalm"                       parks Psalms 1 (chapter defaults to 1)
"Psalm 103 verse 5."      ->  Psalms 1:5     (should be 103:5)

"Psalm 15 verse 4. Psalm 13"  parks Psalms 13
"Psalm 15 verse 4."       ->  Psalms 13:4    (should be 15:4)
```

Both appeared in an exported log as `[DET-DIRECT]` hits at 100% confidence, and both reproduce from a clean detector — the same text with no parked state gives the right answer, which is what identifies it as leftover state rather than a parsing fault.

If the current utterance names a book with a chapter and verse of its own, the parked reference is stale and is dropped. The check is deliberately narrow: text with **no book name in it** — a late `"verse 28"` callout, or a bare `"22 20"` correction — is not a complete reference, so the continuation handling from #142 is untouched. A test covers that explicitly, and it passes with the guard disabled, which is how I know the guard isn't doing too much.

219 tests pass, up from 211 on `main`. The two bug tests fail with the guard disabled; the continuation test does not.
