### PR TITLE
Opens broadcast window in fullscreen mode

### DIFF
--- a/src-tauri/src/commands/broadcast.rs
+++ b/src-tauri/src/commands/broadcast.rs
@@ -144,6 +144,9 @@ pub async fn open_broadcast_window(
         .always_on_top(false)
         .skip_taskbar(false)
         .focused(false)
+        .decorations(false)
+        .fullscreen(true)
+        .minimizable(false)
         .build()
         .map_err(|e| {
             log::error!("open_broadcast_window: window build failed: {e}");


### PR DESCRIPTION
## Description

Fixes #137

Update the external broadcast display window to launch as a fullscreen, borderless window. This removes the window decorations/top bar from the projector display so the broadcast output uses the full screen.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

- [ ] Frontend (React / TypeScript)
- [x] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [x] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT

## Checklist

- [x] I have tested this change locally
- [ ] `bun run typecheck` passes
- [ ] `cargo clippy` passes without warnings
- [ ] `bun run test` passes (if applicable)
- [ ] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

- [x] macOS
- [ ] Windows
- [ ] Linux

## Screenshots / recordings

Before:
<img width="1726" height="236" alt="fullscreen_before" src="https://github.com/user-attachments/assets/0764d46e-7039-4171-9929-0dcded751edf" />

After:
<img width="1624" height="208" alt="fullscreen_after" src="https://github.com/user-attachments/assets/1ba517c6-96ed-488b-9735-a8f616edf852" />

