### PR TITLE
feat(detection): dismiss individual detections (#149)

### DIFF
--- a/src/components/panels/detections-panel.tsx
+++ b/src/components/panels/detections-panel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react"
 import { PanelHeader } from "@/components/ui/panel-header"
 import { ConfidenceDot } from "@/components/ui/confidence-dot"
 import { Button } from "@/components/ui/button"
-import { PlayIcon, PlusIcon } from "lucide-react"
+import { PlayIcon, PlusIcon, XIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useDetection, detectionActions } from "@/hooks/use-detection"
 import { bibleActions } from "@/hooks/use-bible"
@@ -40,12 +40,27 @@ function DetectionCard({ detection }: { detection: DetectionResult }) {
   }
 
   return (
-    <div className="border-b border-border p-3 last:border-0">
+    <div className="group border-b border-border p-3 last:border-0">
       <div className="flex items-center gap-2">
         <ConfidenceDot confidence={detection.confidence} />
-        <span className="text-sm font-semibold text-foreground">
+        <span className="flex-1 truncate text-sm font-semibold text-foreground">
           {detection.verse_ref}
         </span>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Dismiss ${detection.verse_ref}`}
+          title="Dismiss"
+          className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+          onClick={() =>
+            detectionActions.dismissDetection(
+              detection.verse_ref,
+              detection.source
+            )
+          }
+        >
+          <XIcon className="size-2.5" />
+        </Button>
       </div>
 
       {detection.verse_text && (

--- a/src/components/panels/transcript-panel.tsx
+++ b/src/components/panels/transcript-panel.tsx
@@ -17,6 +17,7 @@ import { useTranscription } from "@/hooks/use-transcription"
 import { bibleActions } from "@/hooks/use-bible"
 import { presentVerse } from "@/hooks/use-broadcast"
 import { mark, observeLongTasks } from "@/lib/latency-marks"
+import { pickAutoPresentTarget } from "@/lib/auto-present-target"
 import type { DetectionResult, ReadingAdvance } from "@/types"
 
 /**
@@ -88,19 +89,12 @@ export function TranscriptPanel() {
     useDetectionStore.getState().addDetections(detections)
     mark(`addDetections done src=${detections[0]?.source ?? "?"}`)
 
-    // Auto-navigate book search + select verse for preview/live.
-    //
-    // Take the detector's most confident reading rather than whichever
-    // landed first in the batch. One utterance can yield several direct
-    // detections, and batch order is emission order — in issue #152 a
-    // spurious match was emitted ahead of the verse the preacher actually
-    // named, so the wrong one went on air.
-    const directHit = detections
-      .filter((d) => d.source === "direct" && !d.is_chapter_only)
-      .reduce<DetectionResult | undefined>(
-        (best, d) => (best && best.confidence >= d.confidence ? best : d),
-        undefined
-      )
+    // Auto-navigate book search + select verse for preview/live. Picks the
+    // most confident direct hit and skips operator-dismissed references —
+    // see pickAutoPresentTarget for why.
+    const directHit = pickAutoPresentTarget(detections, (verseRef) =>
+      useDetectionStore.getState().isDismissed(verseRef, "direct")
+    )
     if (directHit && directHit.book_number > 0) {
       const detectedVerse = {
         id: 0,

--- a/src/hooks/use-detection.ts
+++ b/src/hooks/use-detection.ts
@@ -23,6 +23,8 @@ export const detectionActions = {
   clearDetections: () => useDetectionStore.getState().clearDetections(),
   removeDetection: (verseRef: string) =>
     useDetectionStore.getState().removeDetection(verseRef),
+  dismissDetection: (verseRef: string, source: DetectionResult["source"]) =>
+    useDetectionStore.getState().dismissDetection(verseRef, source),
 }
 
 export function useDetection() {

--- a/src/lib/auto-present-target.test.ts
+++ b/src/lib/auto-present-target.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import { pickAutoPresentTarget } from "./auto-present-target"
+import type { DetectionResult } from "@/types"
+
+function detection(overrides: Partial<DetectionResult>): DetectionResult {
+  return {
+    verse_ref: "John 3:16",
+    verse_text: "For God so loved the world",
+    book_name: "John",
+    book_number: 43,
+    chapter: 3,
+    verse: 16,
+    confidence: 0.9,
+    source: "direct",
+    auto_queued: false,
+    transcript_snippet: "",
+    is_chapter_only: false,
+    ...overrides,
+  }
+}
+
+const nothingDismissed = () => false
+
+describe("pickAutoPresentTarget", () => {
+  it("picks the most confident direct detection, not the first emitted", () => {
+    const target = pickAutoPresentTarget(
+      [
+        detection({ verse_ref: "Psalm 1:1", confidence: 0.82 }),
+        detection({ verse_ref: "Psalm 136:1", confidence: 0.97 }),
+      ],
+      nothingDismissed
+    )
+
+    expect(target?.verse_ref).toBe("Psalm 136:1")
+  })
+
+  it("ignores semantic detections", () => {
+    const target = pickAutoPresentTarget(
+      [detection({ verse_ref: "Isaiah 53:5", source: "semantic", confidence: 1.0 })],
+      nothingDismissed
+    )
+
+    expect(target).toBeUndefined()
+  })
+
+  it("ignores chapter-only detections", () => {
+    const target = pickAutoPresentTarget(
+      [detection({ verse_ref: "Psalm 23", is_chapter_only: true, confidence: 1.0 })],
+      nothingDismissed
+    )
+
+    expect(target).toBeUndefined()
+  })
+
+  it("skips a dismissed reference and falls back to the next best", () => {
+    const target = pickAutoPresentTarget(
+      [
+        detection({ verse_ref: "Psalm 136:1", confidence: 0.97 }),
+        detection({ verse_ref: "Psalm 1:1", confidence: 0.82 }),
+      ],
+      (verseRef) => verseRef === "Psalm 136:1"
+    )
+
+    expect(target?.verse_ref).toBe("Psalm 1:1")
+  })
+
+  it("returns nothing when every direct detection is dismissed", () => {
+    const target = pickAutoPresentTarget(
+      [detection({ verse_ref: "Psalm 136:1", confidence: 0.97 })],
+      () => true
+    )
+
+    expect(target).toBeUndefined()
+  })
+
+  it("returns nothing for an empty batch", () => {
+    expect(pickAutoPresentTarget([], nothingDismissed)).toBeUndefined()
+  })
+})

--- a/src/lib/auto-present-target.ts
+++ b/src/lib/auto-present-target.ts
@@ -1,0 +1,27 @@
+import type { DetectionResult } from "@/types"
+
+/**
+ * Choose which detection in a batch drives the preview / auto-live display.
+ *
+ * Takes the detector's most confident reading rather than whichever landed
+ * first in the batch. One utterance can yield several direct detections, and
+ * batch order is emission order — in issue #152 a spurious match was emitted
+ * ahead of the verse the preacher actually named, so the wrong one went on air.
+ *
+ * References the operator has dismissed are skipped (issue #149): a dismissed
+ * detection that still auto-presents would make the dismiss cosmetic.
+ */
+export function pickAutoPresentTarget(
+  detections: DetectionResult[],
+  isDismissed: (verseRef: string) => boolean
+): DetectionResult | undefined {
+  return detections
+    .filter(
+      (d) =>
+        d.source === "direct" && !d.is_chapter_only && !isDismissed(d.verse_ref)
+    )
+    .reduce<DetectionResult | undefined>(
+      (best, d) => (best && best.confidence >= d.confidence ? best : d),
+      undefined
+    )
+}

--- a/src/stores/detection-store.test.ts
+++ b/src/stores/detection-store.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest"
-import { useDetectionStore } from "./detection-store"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DISMISS_SUPPRESSION_MS, useDetectionStore } from "./detection-store"
 import type { DetectionResult } from "@/types"
 
 function detection(overrides: Partial<DetectionResult>): DetectionResult {
@@ -95,5 +95,110 @@ describe("detection store addDetections", () => {
       .detections.filter((d) => d.source === "direct")
     expect(direct.map((d) => d.verse_ref)).toEqual(["Hebrews 12:14", "John 3:16"])
     expect(direct[0].confidence).toBe(1.0)
+  })
+})
+
+describe("detection store dismissDetection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useDetectionStore.setState({ detections: [], dismissed: {} })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("removes the dismissed detection from the list", () => {
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Psalm 23:1", source: "direct", confidence: 1.0 }),
+      detection({ verse_ref: "John 3:16", source: "direct", confidence: 0.9 }),
+    ])
+
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    const refs = useDetectionStore.getState().detections.map((d) => d.verse_ref)
+    expect(refs).toEqual(["John 3:16"])
+  })
+
+  it("leaves the same reference in the other source column", () => {
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Psalm 23:1", source: "direct", confidence: 1.0 }),
+      detection({ verse_ref: "Psalm 23:1", source: "semantic", confidence: 0.7 }),
+    ])
+
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    const remaining = useDetectionStore.getState().detections
+    expect(remaining.map((d) => d.source)).toEqual(["semantic"])
+  })
+
+  it("suppresses a re-detection of a dismissed reference", () => {
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Psalm 23:1", source: "direct", confidence: 1.0 }),
+    ])
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    vi.advanceTimersByTime(1000)
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Psalm 23:1", source: "direct", confidence: 1.0 }),
+    ])
+
+    expect(useDetectionStore.getState().detections).toEqual([])
+  })
+
+  it("allows the reference again once the suppression window expires", () => {
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    vi.advanceTimersByTime(DISMISS_SUPPRESSION_MS)
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Psalm 23:1", source: "direct", confidence: 1.0 }),
+    ])
+
+    const refs = useDetectionStore.getState().detections.map((d) => d.verse_ref)
+    expect(refs).toEqual(["Psalm 23:1"])
+  })
+
+  it("suppresses only the dismissed source, not the same ref from elsewhere", () => {
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Psalm 23:1", source: "semantic", confidence: 0.7 }),
+    ])
+
+    const refs = useDetectionStore.getState().detections.map((d) => d.verse_ref)
+    expect(refs).toEqual(["Psalm 23:1"])
+  })
+
+  it("reports whether a reference is currently dismissed", () => {
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    expect(useDetectionStore.getState().isDismissed("Psalm 23:1", "direct")).toBe(true)
+    expect(useDetectionStore.getState().isDismissed("Psalm 23:1", "semantic")).toBe(false)
+
+    vi.advanceTimersByTime(DISMISS_SUPPRESSION_MS)
+    expect(useDetectionStore.getState().isDismissed("Psalm 23:1", "direct")).toBe(false)
+  })
+
+  it("clears suppression when all detections are cleared", () => {
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    useDetectionStore.getState().clearDetections()
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "Psalm 23:1", source: "direct", confidence: 1.0 }),
+    ])
+
+    const refs = useDetectionStore.getState().detections.map((d) => d.verse_ref)
+    expect(refs).toEqual(["Psalm 23:1"])
+  })
+
+  it("drops expired entries from the suppression map", () => {
+    useDetectionStore.getState().dismissDetection("Psalm 23:1", "direct")
+
+    vi.advanceTimersByTime(DISMISS_SUPPRESSION_MS)
+    useDetectionStore.getState().addDetections([
+      detection({ verse_ref: "John 3:16", source: "direct", confidence: 1.0 }),
+    ])
+
+    expect(useDetectionStore.getState().dismissed).toEqual({})
   })
 })

--- a/src/stores/detection-store.ts
+++ b/src/stores/detection-store.ts
@@ -1,8 +1,41 @@
 import { create } from "zustand"
 import type { DetectionResult } from "@/types"
 
+/**
+ * How long a dismissed reference stays suppressed (issue #149).
+ *
+ * Direct detection re-runs on every changed partial and again on the final, so
+ * a plain removal would be undone a second later by the same utterance. The
+ * window outlives that re-emit burst but still lets the verse show up if the
+ * speaker genuinely returns to it later.
+ */
+export const DISMISS_SUPPRESSION_MS = 10_000
+
+type DetectionSource = DetectionResult["source"]
+
+// Suppression key: dismissing a direct hit must not also hide the semantic
+// card for the same verse.
+function dismissKey(verseRef: string, source: DetectionSource): string {
+  return `${source}|${verseRef}`
+}
+
+// Drop entries whose window has passed. Expiry is checked lazily on write —
+// no timers to schedule or clean up.
+function pruneDismissed(
+  dismissed: Record<string, number>,
+  now: number
+): Record<string, number> {
+  const live: Record<string, number> = {}
+  for (const [key, expiresAt] of Object.entries(dismissed)) {
+    if (expiresAt > now) live[key] = expiresAt
+  }
+  return live
+}
+
 interface DetectionState {
   detections: DetectionResult[]
+  // Dismissed `source|verse_ref` keys → the time their suppression expires.
+  dismissed: Record<string, number>
   autoMode: boolean
   confidenceThreshold: number
 
@@ -10,36 +43,48 @@ interface DetectionState {
   addDetections: (detections: DetectionResult[]) => void
   setDetections: (detections: DetectionResult[]) => void
   removeDetection: (verseRef: string) => void
+  dismissDetection: (verseRef: string, source: DetectionSource) => void
+  isDismissed: (verseRef: string, source: DetectionSource) => boolean
   clearDetections: () => void
   setAutoMode: (auto: boolean) => void
   setConfidenceThreshold: (threshold: number) => void
 }
 
-export const useDetectionStore = create<DetectionState>((set) => ({
+export const useDetectionStore = create<DetectionState>((set, get) => ({
   detections: [],
+  dismissed: {},
   autoMode: false,
   confidenceThreshold: 0.8,
 
   addDetection: (detection) =>
     set((state) => {
+      const dismissed = pruneDismissed(state.dismissed, Date.now())
+      // Dismissed by the operator — stay out of the list until the window ends
+      if (dismissed[dismissKey(detection.verse_ref, detection.source)]) {
+        return { dismissed }
+      }
       // Deduplicate: if same verse_ref exists, keep higher confidence at top
       const filtered = state.detections.filter(
         (d) => d.verse_ref !== detection.verse_ref || d.confidence > detection.confidence,
       )
       // If we filtered one out, the new one has higher (or equal) confidence
       if (filtered.length < state.detections.length) {
-        return { detections: [detection, ...filtered].slice(0, 50) }
+        return { detections: [detection, ...filtered].slice(0, 50), dismissed }
       }
       // Check if it was already there with higher confidence
       if (state.detections.some((d) => d.verse_ref === detection.verse_ref)) {
-        return state // existing has higher confidence, keep it
+        return { dismissed } // existing has higher confidence, keep it
       }
-      return { detections: [detection, ...state.detections].slice(0, 50) }
+      return { detections: [detection, ...state.detections].slice(0, 50), dismissed }
     }),
   addDetections: (incoming) =>
     set((state) => {
-      const incomingSemantic = incoming.filter((d) => d.source === "semantic")
-      const incomingDirect = incoming.filter((d) => d.source !== "semantic")
+      const dismissed = pruneDismissed(state.dismissed, Date.now())
+      const accepted = incoming.filter(
+        (d) => !dismissed[dismissKey(d.verse_ref, d.source)]
+      )
+      const incomingSemantic = accepted.filter((d) => d.source === "semantic")
+      const incomingDirect = accepted.filter((d) => d.source !== "semantic")
 
       // Semantic detections are a fresh ranking for the LATEST utterance —
       // a new batch replaces the previous one outright, in backend rank
@@ -64,14 +109,31 @@ export const useDetectionStore = create<DetectionState>((set) => ({
         }
       }
 
-      return { detections: [...direct.slice(0, 25), ...semantic] }
+      return { detections: [...direct.slice(0, 25), ...semantic], dismissed }
     }),
   setDetections: (detections) => set({ detections }),
   removeDetection: (verseRef) =>
     set((state) => ({
       detections: state.detections.filter((d) => d.verse_ref !== verseRef),
     })),
-  clearDetections: () => set({ detections: [] }),
+  dismissDetection: (verseRef, source) =>
+    set((state) => {
+      const now = Date.now()
+      return {
+        detections: state.detections.filter(
+          (d) => d.verse_ref !== verseRef || d.source !== source
+        ),
+        dismissed: {
+          ...pruneDismissed(state.dismissed, now),
+          [dismissKey(verseRef, source)]: now + DISMISS_SUPPRESSION_MS,
+        },
+      }
+    }),
+  isDismissed: (verseRef, source) => {
+    const expiresAt = get().dismissed[dismissKey(verseRef, source)]
+    return expiresAt !== undefined && expiresAt > Date.now()
+  },
+  clearDetections: () => set({ detections: [], dismissed: {} }),
   setAutoMode: (autoMode) => set({ autoMode }),
   setConfidenceThreshold: (confidenceThreshold) =>
     set({ confidenceThreshold }),


### PR DESCRIPTION
Closes #149.

## Problem

The Queue lets operators remove individual items, but detections could only be cleared all at once — a misheard reference sat in the staging area until the whole list was wiped.

## What changed

- **Dismiss button on each detection card** — hover-revealed ghost `X`, mirroring the queue row's remove affordance. The card is shared, so semantic detections get it too.
- **10s suppression window.** A plain removal wouldn't stick: direct detection re-runs on every changed partial and again on the final (`stt.rs:370-401`), so the same utterance would resurrect the card within a second. Dismissing remembers `source|verse_ref` for 10s and filters it out of incoming batches. After the window a genuine later mention shows up again; **Clear all** resets suppression immediately. Expiry is pruned lazily on write — no timers to leak.
- **Scoped by source**, so dismissing a direct hit leaves the semantic card for the same verse alone (the pre-existing `removeDetection(verseRef)` would have killed both).
- **Auto-present respects dismissal.** Target selection moved out of the event handler into `pickAutoPresentTarget()` and now skips dismissed refs — otherwise a dismissed verse would keep going on air with auto-live on, making the dismiss purely cosmetic. Existing issue #152 behavior (most confident hit wins, not first emitted) is preserved and now unit-tested.

## Verification

- `bunx vitest run` — 220 passed, including 8 new store tests (removal, cross-source isolation, suppression inside the window, expiry, `clearDetections` reset, prune) and 6 for `pickAutoPresentTarget`.
- `bun run typecheck` clean; `eslint` clean on all changed files.
- Not yet exercised in the running app — worth a live check that the dismissed card stays gone while the speaker is still mid-sentence.