### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rhema",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "rhema"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "crossbeam-channel",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ missing_panics_doc = "allow"
 
 [package]
 name = "rhema"
-version = "0.2.0"
+version = "0.3.0"
 description = "Rhema - Real-Time AI Bible Verse Detection"
 authors = ["Faithful"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rhema",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.openbezal.rhema",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
Version bump ahead of cutting release tag `v0.3.0`. `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock` all read `0.3.0`.

Minor rather than patch — four user-facing features landed since `v0.2.0`:

| PR | Change |
|---|---|
| #154 | Multiple broadcast outputs managed from a card grid |
| #155 | Designer: fill the text container with a colour or image |
| #157 | Downloadable diagnostics logs filtered by time range |
| #164 | Dismiss individual verse detections (#149) |

Fixes in the same window: #156 ("is" matching Isaiah and putting the wrong verse on air), #159 (spoken Psalm 136 detected as Psalm 1), #160, plus #161 reverted by #162.

Once this merges, pushing `v0.3.0` runs `build-release.yml` across macOS/Linux/Windows and opens a **draft** release for review.