### PR TITLE
chore(release): stop hand-fixing release titles and download links

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -274,18 +274,51 @@ jobs:
             \) \
             -exec cp {} release-assets/ \;
 
+          # The site's download button links to a fixed filename under
+          # /releases/latest/download (web/app/_lib/site.ts). Tauri stamps the
+          # version into every bundle name, so ship a stable-named copy of the
+          # Windows installer alongside the versioned one — otherwise that link
+          # needs a hand re-upload after every release.
+          setup=$(find release-assets -maxdepth 1 -name "*_x64-setup.exe" | head -1)
+
+          if [[ -n "$setup" ]]; then
+            cp "$setup" release-assets/Rhema-windows-x64-setup.exe
+            echo "Stable alias: Rhema-windows-x64-setup.exe -> $(basename "$setup")"
+          elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            echo "::error::No Windows x64 setup .exe among the artifacts. The site's" \
+                 "download link would 404. Fix the Windows build and re-run this" \
+                 "workflow — the build artifacts are retained for 7 days."
+            exit 1
+          else
+            echo "::warning::No Windows x64 setup .exe found; skipping the stable alias."
+          fi
+
           echo "Release assets:"
           ls -lh release-assets
 
       - name: Generate release metadata
+        id: metadata
         shell: bash
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
+          # A tag push is a real release; workflow_dispatch builds whatever the
+          # chosen ref happens to be, so they are labelled as dev builds rather
+          # than inheriting a release title someone then edits by hand.
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            RELEASE_NAME="Rhema v${VERSION}"
+            SUMMARY="Desktop release build for macOS, Linux, and Windows."
+          else
+            RELEASE_NAME="Rhema v${VERSION} (dev build)"
+            SUMMARY="Unreleased development build from \`${GITHUB_REF_NAME}\`."
+          fi
+
+          echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
           {
-            echo "## Rhema v${VERSION}"
+            echo "## ${RELEASE_NAME}"
             echo ""
-            echo "Automated nightly build of Rhema."
+            echo "${SUMMARY}"
             echo ""
             echo "**Commit:** [\`${GITHUB_SHA:0:7}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
             echo ""
@@ -327,7 +360,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
-          name: Rhema v${{ steps.version.outputs.version }} (nightly)
+          name: ${{ steps.metadata.outputs.release_name }}
           body_path: release-notes.md
           draft: true
           prerelease: false

--- a/web/app/_lib/site.ts
+++ b/web/app/_lib/site.ts
@@ -17,12 +17,13 @@ export const SITE = {
     name: "rhema",
     url: "https://github.com/openbezal/rhema",
     releases: "https://github.com/openbezal/rhema/releases",
-    // `nightly` is a hand-refreshed pointer to the newest Windows installer.
-    // Whatever is uploaded there must keep this exact filename or this link
-    // breaks. `/releases/latest` is not used here: GitHub excludes
-    // prereleases from it.
+    // `/releases/latest` resolves to the newest published, non-prerelease
+    // release, so this tracks each tagged release with no hand re-upload. The
+    // release workflow ships a copy of the Windows installer under this exact
+    // stable filename (Tauri's own bundle names carry the version); keep the
+    // two in sync or this link 404s.
     downloadWindows:
-      "https://github.com/openbezal/rhema/releases/download/nightly/Rhema-windows-x64-setup.exe",
+      "https://github.com/openbezal/rhema/releases/latest/download/Rhema-windows-x64-setup.exe",
     discussions: "https://github.com/openbezal/rhema/discussions",
     stars: { fallback: 221 },
   },


### PR DESCRIPTION
Two manual steps after every release, both now handled by `build-release.yml`.

## Release title

Every run titled its release `Rhema vX.Y.Z (nightly)`, so the suffix got edited away by hand — the live v0.2.0 release is titled `Rhema v0.2.0`. Now:

| Trigger | Title |
|---|---|
| tag push (`v*`) | `Rhema v0.3.0` |
| `workflow_dispatch` | `Rhema v0.3.0 (dev build)` |

Dispatch runs build whatever ref they're handed, so they say so instead of borrowing a release title. The notes body follows the same split ("Desktop release build for macOS, Linux, and Windows." vs "Unreleased development build from `<ref>`.").

## Download link

Tauri stamps the version into every bundle name (`Rhema_0.2.0_x64-setup.exe`), so the site's Windows button couldn't point at a release asset directly — it pointed at `Rhema-windows-x64-setup.exe`, hand-uploaded to the `nightly` prerelease after each release.

The release job now copies the Windows installer to that stable name alongside the versioned one, and `site.ts` points at `/releases/latest/download/Rhema-windows-x64-setup.exe`. `/releases/latest` resolves to the newest **published, non-prerelease** release, so it tracks each tag with no re-upload, and the `nightly` prerelease no longer shadows it.

If a tag build produces no Windows installer, the release job now fails loudly instead of publishing a release whose download button 404s (build artifacts are retained 7 days, so a re-run recovers). A dispatch run just warns.

## Verification

YAML parses; both edited `run` blocks pass `bash -n`; and I exercised them against a fake artifact tree:

| Case | Result |
|---|---|
| tag, installer present | alias created → `Rhema-windows-x64-setup.exe` |
| tag, installer missing | `::error::` + exit 1 |
| dispatch, installer missing | `::warning::` + exit 0 |
| `GITHUB_REF_TYPE=tag` | `release_name=Rhema v0.3.0` |
| `GITHUB_REF_TYPE=branch` | `release_name=Rhema v0.3.0 (dev build)` |
