### PR TITLE
fix(macos): app reported as damaged, and one-click platform downloads

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -274,23 +274,40 @@ jobs:
             \) \
             -exec cp {} release-assets/ \;
 
-          # The site's download button links to a fixed filename under
-          # /releases/latest/download (web/app/_lib/site.ts). Tauri stamps the
-          # version into every bundle name, so ship a stable-named copy of the
-          # Windows installer alongside the versioned one — otherwise that link
-          # needs a hand re-upload after every release.
-          setup=$(find release-assets -maxdepth 1 -name "*_x64-setup.exe" | head -1)
+          # The site's download buttons link to fixed filenames under
+          # /releases/latest/download so a visitor gets the right file in one
+          # click (web/app/_lib/site.ts). Tauri stamps the version into every
+          # bundle name, so ship stable-named copies alongside the versioned
+          # ones — otherwise those links need a hand re-upload every release.
+          aliases=(
+            "*_x64-setup.exe:Rhema-windows-x64-setup.exe"
+            "*_aarch64.dmg:Rhema-macos-arm64.dmg"
+            "*_amd64.AppImage:Rhema-linux-x86_64.AppImage"
+          )
 
-          if [[ -n "$setup" ]]; then
-            cp "$setup" release-assets/Rhema-windows-x64-setup.exe
-            echo "Stable alias: Rhema-windows-x64-setup.exe -> $(basename "$setup")"
-          elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            echo "::error::No Windows x64 setup .exe among the artifacts. The site's" \
-                 "download link would 404. Fix the Windows build and re-run this" \
-                 "workflow — the build artifacts are retained for 7 days."
-            exit 1
-          else
-            echo "::warning::No Windows x64 setup .exe found; skipping the stable alias."
+          missing=()
+          for entry in "${aliases[@]}"; do
+            pattern="${entry%%:*}"
+            alias_name="${entry##*:}"
+            match=$(find release-assets -maxdepth 1 -name "$pattern" | head -1)
+
+            if [[ -n "$match" ]]; then
+              cp "$match" "release-assets/$alias_name"
+              echo "Stable alias: $alias_name -> $(basename "$match")"
+            else
+              missing+=("$alias_name")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+              echo "::error::Missing artifacts for: ${missing[*]}. The site's download" \
+                   "buttons link to those filenames and would 404. Fix the failing" \
+                   "build and re-run this workflow — build artifacts are retained" \
+                   "for 7 days."
+              exit 1
+            fi
+            echo "::warning::Skipping stable aliases, artifacts missing: ${missing[*]}"
           fi
 
           echo "Release assets:"

--- a/README.md
+++ b/README.md
@@ -10,17 +10,37 @@ Rhema listens to a live sermon audio feed, transcribes speech in real time, dete
 
 ## Download
 
-| Platform | |
-|---|---|
-| **Windows** | [**Rhema-windows-x64-setup.exe**](https://github.com/openbezal/rhema/releases/download/nightly/Rhema-windows-x64-setup.exe) — rebuilt from `main` on every merge |
-| macOS, Linux | No prebuilt binary yet — [build from source](#getting-started) |
+| Platform | | Requires |
+|---|---|---|
+| **Windows** | [**Rhema-windows-x64-setup.exe**](https://github.com/openbezal/rhema/releases/latest/download/Rhema-windows-x64-setup.exe) | Windows 10/11 x64 |
+| **macOS** | [**Rhema-macos-arm64.dmg**](https://github.com/openbezal/rhema/releases/latest/download/Rhema-macos-arm64.dmg) | macOS 11 Big Sur or newer, **Apple Silicon** |
+| **Linux** | [**Rhema-linux-x86_64.AppImage**](https://github.com/openbezal/rhema/releases/latest/download/Rhema-linux-x86_64.AppImage) | x86_64; `.deb` and `.rpm` on the [release page](https://github.com/openbezal/rhema/releases/latest) |
 
-The installer is unsigned, so Windows SmartScreen warns on first run (*More info → Run anyway*).
+There is no Intel Mac build — on an Intel Mac,
+[build from source](#getting-started).
 
-It also does **not** bundle the Bible database, embedding model, or Whisper
-model — together they exceed a gigabyte. The app starts without them, but verse
-detection and local speech-to-text stay inactive until you build from source and
-run `bun run setup:all`. All releases are listed at
+Every build is **unsigned** — there is no Apple Developer or Windows code
+signing certificate behind this project — so each OS warns on first run.
+
+**Windows:** SmartScreen warns — *More info → Run anyway*.
+
+**macOS:** drag `Rhema.app` to Applications first, then open it. Gatekeeper
+blocks unsigned apps that carry the browser's quarantine flag; on macOS 15 and
+newer the right-click → Open trick no longer works, so use:
+
+- **System Settings → Privacy & Security**, scroll to the blocked-app notice,
+  then **Open Anyway**, or
+- clear the quarantine flag yourself:
+
+  ```sh
+  xattr -cr /Applications/Rhema.app
+  ```
+
+Releases do **not** bundle the embedding model or the Whisper model — together
+they exceed a gigabyte. The Bible database ships inside the app, so reference
+detection and keyword search work out of the box; embedding re-ranking and local
+speech-to-text stay inactive until you build from source and run
+`bun run setup:all`. All releases are listed at
 [github.com/openbezal/rhema/releases](https://github.com/openbezal/rhema/releases).
 
 ## Features

--- a/src-tauri/crates/bible/src/db.rs
+++ b/src-tauri/crates/bible/src/db.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Mutex;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 use crate::error::BibleError;
 
@@ -15,12 +15,188 @@ impl std::fmt::Debug for BibleDb {
     }
 }
 
+/// Build a `SQLite` URI that opens `path` as immutable.
+///
+/// `immutable=1` tells `SQLite` the file cannot change underneath it, so it skips
+/// locking and never creates `-wal` / `-shm` companions. That matters because
+/// the bundled database lives inside `Rhema.app/Contents/Resources`, where any
+/// new file breaks the macOS code signature seal.
+fn immutable_uri(path: &Path) -> String {
+    // Windows separators are not valid in a URI path.
+    let raw = path.to_string_lossy().replace('\\', "/");
+
+    let mut encoded = String::with_capacity(raw.len() + 8);
+    for ch in raw.chars() {
+        match ch {
+            '%' => encoded.push_str("%25"),
+            '?' => encoded.push_str("%3f"),
+            '#' => encoded.push_str("%23"),
+            ' ' => encoded.push_str("%20"),
+            c => encoded.push(c),
+        }
+    }
+
+    // Absolute POSIX paths already start with `/`; Windows drive paths
+    // ("C:/...") need one added. Relative paths must stay relative, so they get
+    // no authority component at all.
+    let is_windows_drive = {
+        let bytes = encoded.as_bytes();
+        bytes.len() >= 2 && bytes[1] == b':'
+    };
+
+    if encoded.starts_with('/') {
+        format!("file://{encoded}?immutable=1")
+    } else if is_windows_drive {
+        format!("file:///{encoded}?immutable=1")
+    } else {
+        format!("file:{encoded}?immutable=1")
+    }
+}
+
 impl BibleDb {
+    /// Open the Bible database for reading.
+    ///
+    /// Read-only and immutable on purpose. In production this file is
+    /// `Rhema.app/Contents/Resources/rhema.db`, and the previous read-write
+    /// open with `journal_mode=WAL` wrote `rhema.db-wal` and `rhema.db-shm`
+    /// next to it on first launch — inside the signed bundle, which invalidates
+    /// the macOS code signature and makes Gatekeeper report the app as damaged.
+    /// Nothing at runtime writes to this database; it is built ahead of time by
+    /// `bun run build:bible`.
     pub fn open(path: &Path) -> Result<Self, BibleError> {
-        let conn = Connection::open(path)?;
-        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        let conn = Connection::open_with_flags(
+            immutable_uri(path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY
+                | OpenFlags::SQLITE_OPEN_URI
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
+    }
+
+    /// Open a database for writing. Only tooling that builds or fixtures a
+    /// database needs this; the shipped database is read-only at runtime.
+    pub fn open_writable(path: &Path) -> Result<Self, BibleError> {
+        Ok(Self {
+            conn: Mutex::new(Connection::open(path)?),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_path(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "rhema-db-test-{name}-{}-{:?}.db",
+            std::process::id(),
+            std::thread::current().id(),
+        ));
+        for suffix in ["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
+        }
+        path
+    }
+
+    /// Build a database the way the bundled one is built: WAL journal mode,
+    /// then closed so the WAL is checkpointed away.
+    fn write_bundled_style_db(path: &Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE verses (id INTEGER PRIMARY KEY, text TEXT);
+             INSERT INTO verses VALUES (1, 'In the beginning');",
+        )
+        .unwrap();
+        drop(conn);
+
+        let sidecars: Vec<String> = ["-wal", "-shm"]
+            .iter()
+            .map(|s| format!("{}{s}", path.display()))
+            .filter(|p| std::path::Path::new(p).exists())
+            .collect();
+        assert!(
+            sidecars.is_empty(),
+            "fixture should start clean, found {sidecars:?}"
+        );
+    }
+
+    fn sidecars(path: &Path) -> Vec<String> {
+        ["-wal", "-shm"]
+            .iter()
+            .map(|s| format!("{}{s}", path.display()))
+            .filter(|p| std::path::Path::new(p).exists())
+            .collect()
+    }
+
+    #[test]
+    fn open_writes_nothing_beside_the_database() {
+        let path = fixture_path("sidecars");
+        write_bundled_style_db(&path);
+
+        let db = BibleDb::open(&path).unwrap();
+        let count: i64 = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM verses", [], |r| r.get(0))
+            .unwrap();
+
+        assert_eq!(count, 1);
+        assert!(
+            sidecars(&path).is_empty(),
+            "opening the bundled database must not create files inside the app \
+             bundle — that breaks the macOS code signature seal; found {:?}",
+            sidecars(&path)
+        );
+    }
+
+    #[test]
+    fn open_rejects_writes() {
+        let path = fixture_path("readonly");
+        write_bundled_style_db(&path);
+
+        let db = BibleDb::open(&path).unwrap();
+        let result = db
+            .conn
+            .lock()
+            .unwrap()
+            .execute("INSERT INTO verses VALUES (2, 'and the earth')", []);
+
+        assert!(result.is_err(), "the bundled database must open read-only");
+    }
+
+    #[test]
+    fn open_writable_allows_schema_setup() {
+        let path = fixture_path("writable");
+
+        let db = BibleDb::open_writable(&path).unwrap();
+        db.conn
+            .lock()
+            .unwrap()
+            .execute_batch("CREATE TABLE verses (id INTEGER PRIMARY KEY);")
+            .unwrap();
+    }
+
+    #[test]
+    fn immutable_uri_encodes_reserved_characters() {
+        assert_eq!(
+            immutable_uri(Path::new("/Applications/My App.app/rhema.db")),
+            "file:///Applications/My%20App.app/rhema.db?immutable=1"
+        );
+        assert_eq!(
+            immutable_uri(Path::new("/tmp/wh#at?/db")),
+            "file:///tmp/wh%23at%3f/db?immutable=1"
+        );
+    }
+
+    #[test]
+    fn immutable_uri_keeps_relative_paths_relative() {
+        assert_eq!(
+            immutable_uri(Path::new("data/rhema.db")),
+            "file:data/rhema.db?immutable=1"
+        );
     }
 }

--- a/src-tauri/crates/bible/src/search.rs
+++ b/src-tauri/crates/bible/src/search.rs
@@ -120,11 +120,11 @@ const TRANSLATION_FANOUT: usize = 10;
 /// Grouped by verse reference so the LIMIT applies to UNIQUE verses: without
 /// the grouping, one verse matched in all 7 English translations consumed 7
 /// result slots, collapsing recall. Each verse keeps its best (lowest) BM25
-/// rank across translations; SQLite guarantees the bare columns come from
+/// rank across translations; `SQLite` guarantees the bare columns come from
 /// the row that produced the `MIN()` value.
 ///
 /// The CTE must be MATERIALIZED: FTS5's `bm25()` auxiliary function cannot
-/// run in an aggregate context, and without materialization SQLite flattens
+/// run in an aggregate context, and without materialization `SQLite` flattens
 /// the subquery into the outer aggregate ("unable to use function bm25 in
 /// the requested context").
 ///
@@ -430,7 +430,7 @@ mod tests {
             std::thread::current().id(),
         ));
         let _ = std::fs::remove_file(&path);
-        let db = BibleDb::open(&path).unwrap();
+        let db = BibleDb::open_writable(&path).unwrap();
         {
             let conn = db.conn.lock().unwrap();
             conn.execute_batch(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,6 +30,9 @@
     "resources": { "../data/rhema.db": "rhema.db" },
     "active": true,
     "targets": "all",
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/web/app/_components/sections/faq-section.data.ts
+++ b/web/app/_components/sections/faq-section.data.ts
@@ -51,4 +51,14 @@ export const FAQS: readonly Faq[] = [
     answer:
       "Yes. Rhema outputs broadcast-ready overlays via NDI, which integrates natively with OBS Studio, vMix, and other professional live production software.",
   },
+  {
+    question: "My computer warns me about Rhema on first launch. Is that normal?",
+    answer:
+      "Yes. Rhema is unsigned — there is no paid Apple or Windows certificate behind this free project — so both systems warn the first time. On Windows, choose More info, then Run anyway. On macOS, drag Rhema to your Applications folder, then open System Settings, go to Privacy & Security, and choose Open Anyway next to the notice about Rhema. You only do this once. If macOS instead says Rhema is damaged (releases up to v0.3.0), open Terminal and run: xattr -cr /Applications/Rhema.app",
+  },
+  {
+    question: "What are the system requirements?",
+    answer:
+      "Windows 10 or 11 on a 64-bit machine, macOS 11 Big Sur or newer on an Apple Silicon Mac, or a 64-bit Linux distribution. There is no Intel Mac build — Intel Mac owners can build Rhema from source on GitHub.",
+  },
 ];

--- a/web/app/_components/ui/download-button.tsx
+++ b/web/app/_components/ui/download-button.tsx
@@ -14,12 +14,12 @@ const COPY: Record<
   "mac" | "windows" | "linux" | "other" | "default",
   { label: string; icon: TablerIcon }
 > = {
-  // Windows is the only platform with a prebuilt installer today, so it is the
-  // only one that links straight to a file. Everyone else lands on the releases
-  // page rather than being handed a .exe they can't run.
-  mac: { label: "Download", icon: IconBrandApple },
+  // Each desktop platform links straight to its installer. "other" covers
+  // phones, tablets, and anything unrecognised, which land on the release page
+  // rather than being handed a file they cannot open.
+  mac: { label: "Download for macOS", icon: IconBrandApple },
   windows: { label: "Download for Windows", icon: IconBrandWindows },
-  linux: { label: "Download", icon: IconDownload },
+  linux: { label: "Download for Linux", icon: IconDownload },
   other: { label: "Download", icon: IconDownload },
   default: { label: "Download", icon: IconDownload },
 };

--- a/web/app/_lib/site.ts
+++ b/web/app/_lib/site.ts
@@ -17,13 +17,22 @@ export const SITE = {
     name: "rhema",
     url: "https://github.com/openbezal/rhema",
     releases: "https://github.com/openbezal/rhema/releases",
+    latestRelease: "https://github.com/openbezal/rhema/releases/latest",
     // `/releases/latest` resolves to the newest published, non-prerelease
-    // release, so this tracks each tagged release with no hand re-upload. The
-    // release workflow ships a copy of the Windows installer under this exact
-    // stable filename (Tauri's own bundle names carry the version); keep the
-    // two in sync or this link 404s.
+    // release, so these track each tagged release with no hand re-upload. The
+    // release workflow ships a copy of each installer under these exact stable
+    // filenames (Tauri's own bundle names carry the version); keep them in sync
+    // with the `aliases` list in .github/workflows/build-release.yml or these
+    // links 404.
     downloadWindows:
       "https://github.com/openbezal/rhema/releases/latest/download/Rhema-windows-x64-setup.exe",
+    // Apple Silicon only — the build matrix has no x86_64-apple-darwin target.
+    downloadMac:
+      "https://github.com/openbezal/rhema/releases/latest/download/Rhema-macos-arm64.dmg",
+    // AppImage runs on any distro without a package manager step, so it is the
+    // one-click choice; .deb and .rpm stay on the release page.
+    downloadLinux:
+      "https://github.com/openbezal/rhema/releases/latest/download/Rhema-linux-x86_64.AppImage",
     discussions: "https://github.com/openbezal/rhema/discussions",
     stars: { fallback: 221 },
   },
@@ -40,14 +49,22 @@ export const SITE = {
 } as const;
 
 /**
- * Where a "Download" CTA should point. Windows is the only platform with a
- * prebuilt installer, so it gets the file directly; everyone else lands on the
- * releases page instead of being handed a .exe they can't run.
+ * Where a "Download" CTA should point: straight at the installer for the
+ * visitor's platform. Church volunteers should not have to pick a file out of a
+ * GitHub release page. Unrecognised platforms still land on the release list,
+ * where every bundle (.msi, .deb, .rpm) is available.
  */
 export function downloadHref(platform: string | null | undefined): string {
-  return platform === "windows"
-    ? SITE.repo.downloadWindows
-    : SITE.repo.releases;
+  switch (platform) {
+    case "windows":
+      return SITE.repo.downloadWindows;
+    case "mac":
+      return SITE.repo.downloadMac;
+    case "linux":
+      return SITE.repo.downloadLinux;
+    default:
+      return SITE.repo.latestRelease;
+  }
 }
 
 export async function getGitHubStars(): Promise<number> {

--- a/web/app/_lib/use-platform.ts
+++ b/web/app/_lib/use-platform.ts
@@ -23,7 +23,13 @@ function detectPlatform(): Platform {
   ).userAgentData;
   const source = (uaData?.platform ?? nav.userAgent ?? "").toLowerCase();
 
-  if (/mac|darwin|iphone|ipad|ipod/.test(source)) return "mac";
+  // Phones and tablets first: the download CTA links straight to a desktop
+  // installer per platform, and "iPad" matches mac while Android's UA contains
+  // "Linux" — both would hand a mobile visitor a file they cannot open. They
+  // get the release page instead.
+  if (/iphone|ipad|ipod|android/.test(source)) return "other";
+
+  if (/mac|darwin/.test(source)) return "mac";
   if (/win/.test(source)) return "windows";
   if (/linux|x11|cros/.test(source)) return "linux";
   return "other";


### PR DESCRIPTION
The macOS build has never launched from a release — v0.1.0, v0.2.0 and v0.3.0 all fail with *"Rhema is damaged and can't be opened."*

## Root cause — two problems, both must be fixed

**1. The bundle was never code-signed.** `bundle.macOS` was absent from `tauri.conf.json` and every `APPLE_*` var in the release workflow is commented out, so Tauri's bundler skipped `codesign` entirely.

Evidence from the shipped v0.3.0 dmg:

| Check | Finding |
|---|---|
| dmg SHA-256 | matches release notes — the download is intact |
| `Contents/_CodeSignature/` | **absent**, while `Resources/` holds `rhema.db`, `sdk`, `icon.icns` |
| `codesign -dv` | `Signature=adhoc`, `flags=0x20002(adhoc,**linker-signed**)`, `Info.plist=not bound` |
| `codesign --verify` | `code has no resources but signature indicates they must be present` |
| binary | launches fine once quarantine is cleared |

The only signature present was the *linker's* automatic arm64 one, whose resource rules nothing satisfied. A quarantined app with a structurally invalid signature renders as "damaged" on Apple Silicon with no Open Anyway escape — which is why no amount of right-clicking helped.

Fixed with `"macOS": { "signingIdentity": "-" }` — Tauri's [documented ad-hoc signing](https://tauri.app/distribute/sign/macos), which needs no Apple Developer account. The app remains unnotarized, so users still get a Gatekeeper warning — but the **bypassable** kind rather than a dead end.

**2. Signing alone would have broken on first launch.** `BibleDb::open` opened the bundled `rhema.db` read-write with `journal_mode=WAL`, writing `rhema.db-wal` and `rhema.db-shm` into `Contents/Resources` — *inside the signed bundle*, invalidating the seal the moment the app ran. `codesign` named both files in testing. Nothing writes to that database at runtime (it's built by `bun run build:bible`; the only `INSERT`/`CREATE` in the crate are test fixtures), so it now opens read-only with `immutable=1` and SQLite creates no companions. Fixtures that build a database use the new `open_writable`.

## One-click downloads

Download CTAs pointed non-Windows visitors at the GitHub release page to pick a file out of a list of seven. Now every desktop platform links straight to its installer, via stable-named aliases the release job ships for all three platforms (previously Windows only, from #166).

Platform detection also had a gap that direct links turn into a bug: `"iPad"` matches mac and Android's UA contains `"Linux"`, so a phone visitor would be handed a `.dmg`/`.AppImage`. Mobile now goes to the release page.

## Verification

**TDD** — tests written first, watched fail for the right reason (`open` created both sidecars and accepted a write), then made to pass:

- `open_writes_nothing_beside_the_database`, `open_rejects_writes`, `open_writable_allows_schema_setup`, plus `immutable_uri` encoding cases (spaces, `#`, `?`, relative paths, Windows drive letters). `cargo test -p rhema-bible` → **20 passed**.

**End-to-end on a real signed bundle** (`bun run tauri build --debug --bundles app`):

| Check | Result |
|---|---|
| Tauri signed the bundle | `flags=0x10002(adhoc,runtime)`, `_CodeSignature/CodeResources` created |
| verify before launch | valid on disk, satisfies Designated Requirement |
| app launches | yes — loaded `rhema.db` from inside the bundle |
| sidecars after running | **none** |
| **verify after launch** | **still valid** — seal holds |

**Workflow** — YAML parses, `bash -n` clean, and the alias step exercised against a fake artifact tree: all three aliases created; a tag build missing the mac artifact fails with `::error::`; a dispatch build only warns.

**Everything else** — `cargo clippy -p rhema-bible --all-targets` clean, `cargo check -p rhema` clean, `bun run typecheck` clean, `bunx vitest run` 220 passed, web `tsc --noEmit` clean and `next build` succeeds. Repo-wide lint is unchanged at 130 pre-existing problems.

## Notes

- **macOS 11 Big Sur is the floor**, confirmed via `vtool -show-build` on the shipped binary (`minos 11.0`), and there is **no Intel Mac build** — the matrix only targets `aarch64-apple-darwin`. Both are now documented in the README and site FAQ.
- I backfilled `Rhema-macos-arm64.dmg` and `Rhema-linux-x86_64.AppImage` onto the v0.3.0 release (byte-identical copies, SHAs verified against the notes) so the new direct links resolve the moment this merges — all three return 200 today.
- Until a release is cut from this branch, the mac link still serves the unsigned v0.3.0 dmg, so the FAQ and README keep the `xattr -cr /Applications/Rhema.app` fallback for "damaged" alongside the Open Anyway instructions.