### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rhema",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "rhema"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "crossbeam-channel",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ missing_panics_doc = "allow"
 
 [package]
 name = "rhema"
-version = "0.3.0"
+version = "0.3.1"
 description = "Rhema - Real-Time AI Bible Verse Detection"
 authors = ["Faithful"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rhema",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.openbezal.rhema",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
Version bump ahead of cutting release tag `v0.3.1`. `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock` all read `0.3.1`; `cargo metadata` confirms manifest and lockfile agree.

Patch release, and the reason it needs cutting promptly: the macOS build has **never** been installable — Gatekeeper reported every dmg as damaged — and the fix in #167 only reaches users in a new build.

Ships once merged:

| PR | Change |
|---|---|
| #167 | macOS dmg is installable: ad-hoc code signing, and the bundled Bible DB no longer writes WAL files into the signed bundle |
| #167 | Download buttons link straight to the installer for the visitor's platform |

**Merge #167 first.** A tag push runs the workflow *as it exists at the tagged commit*, and more importantly a v0.3.1 built without #167 would ship the same broken dmg under a new version number.