### PR TITLE
ci: stop a stalled apt from costing a release, guard download links

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -52,11 +52,29 @@ jobs:
         with:
           bun-version: "1.2.21"
 
+      # Bounded on purpose. An apt mirror stalling here has twice eaten the
+      # whole 45-minute job budget before Rust ever compiled (v0.2.0 and
+      # v0.3.1), which marks the job cancelled and skips the release. Ten
+      # minutes is ~4x the normal duration; the connection timeouts turn a hung
+      # mirror into an error instead of a hang, and the retry rides out a single
+      # flaky mirror.
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          APT_OPTS: >-
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=20
+            -o Acquire::https::Timeout=20
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get update $APT_OPTS || {
+            echo "::warning::apt-get update failed, retrying once"
+            sleep 5
+            sudo apt-get update $APT_OPTS
+          }
+
+          sudo apt-get install -y $APT_OPTS \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             librsvg2-dev \
@@ -226,6 +244,13 @@ jobs:
   release:
     name: Create GitHub Release
     needs: build
+    # Assemble a release from whatever platforms did build. `needs: build` alone
+    # skipped this job whenever one matrix leg failed or timed out, so a single
+    # stalled apt mirror threw away two good platform builds (v0.2.0, v0.3.1).
+    # The release is a draft and the notes list any missing platform, so a human
+    # decides whether to publish or re-run. `!cancelled()` still respects a
+    # manual cancel of the whole run.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     steps:
@@ -256,6 +281,7 @@ jobs:
           echo "Rhema version: $VERSION"
 
       - name: Prepare release assets
+        id: assets
         shell: bash
         run: |
           mkdir -p release-assets
@@ -299,16 +325,17 @@ jobs:
             fi
           done
 
+          # Record rather than fail: the release is a draft, and half a release
+          # beats none when one platform's build stalls. The notes carry the
+          # warning so nobody publishes a 404-ing download button by accident.
+          # Re-running the failed build and this job fills the gap in place
+          # (overwrite_files is on).
           if [[ ${#missing[@]} -gt 0 ]]; then
-            if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-              echo "::error::Missing artifacts for: ${missing[*]}. The site's download" \
-                   "buttons link to those filenames and would 404. Fix the failing" \
-                   "build and re-run this workflow — build artifacts are retained" \
-                   "for 7 days."
-              exit 1
-            fi
-            echo "::warning::Skipping stable aliases, artifacts missing: ${missing[*]}"
+            echo "::warning::Missing artifacts, no stable alias for: ${missing[*]}." \
+                 "The site's download buttons link to those filenames. Re-run the" \
+                 "failed build before publishing — artifacts are kept for 7 days."
           fi
+          echo "missing=${missing[*]}" >> "$GITHUB_OUTPUT"
 
           echo "Release assets:"
           ls -lh release-assets
@@ -316,6 +343,8 @@ jobs:
       - name: Generate release metadata
         id: metadata
         shell: bash
+        env:
+          MISSING_ALIASES: ${{ steps.assets.outputs.missing }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -337,6 +366,17 @@ jobs:
             echo ""
             echo "${SUMMARY}"
             echo ""
+
+            # Loud, in the draft, where the person clicking Publish will see it.
+            if [[ -n "${MISSING_ALIASES}" ]]; then
+              echo "> [!WARNING]"
+              echo "> Platform builds missing from this release:" \
+                   "\`${MISSING_ALIASES}\`."
+              echo "> The website's download buttons link to those filenames and"
+              echo "> will 404. Re-run the failed build job before publishing."
+              echo ""
+            fi
+
             echo "**Commit:** [\`${GITHUB_SHA:0:7}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
             echo ""
             echo "### Downloads"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -332,8 +332,10 @@ jobs:
           # (overwrite_files is on).
           if [[ ${#missing[@]} -gt 0 ]]; then
             echo "::warning::Missing artifacts, no stable alias for: ${missing[*]}." \
-                 "The site's download buttons link to those filenames. Re-run the" \
-                 "failed build before publishing — artifacts are kept for 7 days."
+                 "The site's download buttons link to those filenames. Use 'Re-run" \
+                 "failed jobs' on this run before publishing — not 'Re-run all" \
+                 "jobs', which deletes the artifacts the other platforms produced." \
+                 "Artifacts are kept for 7 days; after that, re-tag instead."
           fi
           echo "missing=${missing[*]}" >> "$GITHUB_OUTPUT"
 
@@ -373,7 +375,12 @@ jobs:
               echo "> Platform builds missing from this release:" \
                    "\`${MISSING_ALIASES}\`."
               echo "> The website's download buttons link to those filenames and"
-              echo "> will 404. Re-run the failed build job before publishing."
+              echo "> will 404. Before publishing, use **Re-run failed jobs** on"
+              echo "> this run — it rebuilds only the failed platform, keeps the"
+              echo "> artifacts the others already produced, and re-runs this"
+              echo "> release job to add the missing files to this same draft."
+              echo "> Do not use *Re-run all jobs*: that deletes the existing"
+              echo "> artifacts and rebuilds every platform from scratch."
               echo ""
             fi
 

--- a/.github/workflows/release-download-guard.yml
+++ b/.github/workflows/release-download-guard.yml
@@ -1,0 +1,77 @@
+name: Release Download Guard
+
+# The website's download buttons link to fixed filenames under
+# /releases/latest/download (web/app/_lib/site.ts), and the site is a static
+# export — it cannot check at runtime whether those files exist. GitHub resolves
+# /latest to the newest published, non-prerelease release, so publishing a
+# release that is missing one of those files silently breaks that platform's
+# download button for everyone.
+#
+# This runs the moment a release is published and reverts an incomplete one to
+# draft, which puts /latest back on the last complete release. Nothing is lost:
+# re-run the failed build job, then publish again.
+
+on:
+  release:
+    # Deliberately not `edited`: this job edits the release, which would
+    # retrigger itself.
+    types: [published, released]
+
+permissions:
+  contents: write
+
+jobs:
+  verify-download-targets:
+    name: Verify site download targets
+    # Prereleases are excluded from /releases/latest, so they cannot break the
+    # site's links.
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check every platform the site links to
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_ID: ${{ github.event.release.id }}
+        run: |
+          # Keep in sync with the `aliases` list in build-release.yml and the
+          # download* URLs in web/app/_lib/site.ts.
+          required=(
+            Rhema-windows-x64-setup.exe
+            Rhema-macos-arm64.dmg
+            Rhema-linux-x86_64.AppImage
+          )
+
+          # Never act on a failed lookup: an API hiccup would otherwise read as
+          # "every asset is missing" and unpublish a perfectly good release.
+          if ! assets=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
+            --paginate --jq '.[].name'); then
+            echo "::error::Could not list assets for ${TAG}. Leaving the release" \
+                 "as published and failing this check instead of guessing."
+            exit 1
+          fi
+
+          echo "Assets on ${TAG}:"
+          echo "${assets}" | sed 's/^/  /'
+
+          missing=()
+          for name in "${required[@]}"; do
+            grep -qxF "$name" <<< "${assets}" || missing+=("$name")
+          done
+
+          if [[ ${#missing[@]} -eq 0 ]]; then
+            echo "All ${#required[@]} site download targets present on ${TAG}."
+            exit 0
+          fi
+
+          echo "::error::${TAG} is missing ${missing[*]}, which the website's" \
+               "download buttons link to. Reverting the release to draft so" \
+               "/releases/latest stays on the last complete release. Re-run the" \
+               "failed build job in 'Build, Bundle and Release', then publish again."
+
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+            -F draft=true > /dev/null
+
+          echo "${TAG} reverted to draft."
+          exit 1

--- a/.github/workflows/release-download-guard.yml
+++ b/.github/workflows/release-download-guard.yml
@@ -67,8 +67,10 @@ jobs:
 
           echo "::error::${TAG} is missing ${missing[*]}, which the website's" \
                "download buttons link to. Reverting the release to draft so" \
-               "/releases/latest stays on the last complete release. Re-run the" \
-               "failed build job in 'Build, Bundle and Release', then publish again."
+               "/releases/latest stays on the last complete release. To fix: open" \
+               "the 'Build, Bundle and Release' run for ${TAG}, choose 'Re-run" \
+               "failed jobs' (not 'Re-run all jobs' — that discards the artifacts" \
+               "the other platforms already built), then publish again."
 
           gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
             -F draft=true > /dev/null


### PR DESCRIPTION
Two releases have now been lost to `apt`, not to a build failure. v0.3.1's run was cancelled with macOS already green and Windows still building.

## Why Linux hangs

From the v0.3.1 Linux job log — it is not a slow build, it is a stalled mirror:

| Time | Log |
|---|---|
| 21:24:07 | Microsoft/Google repos fetched fine |
| 21:24:07 → 21:26:20 | 2m13s stall, then `Ign:` on every `http://azure.archive.ubuntu.com` entry — runner's local mirror unreachable |
| 21:26:21 | apt falls back to public `https://archive.ubuntu.com` |
| 21:26:22 | `Get:5 … noble-security InRelease [126 kB]` — **last line it ever printed** |
| 21:38:20 | cancel lands, ~12 min of silence |

**Default apt has no network timeout**, so it waits forever. On the v0.2.0 re-run it burned all 45 minutes of the job budget in this one step. Healthy runs take 2–4 min:

| Run | apt step | Linux job |
|---|---|---|
| v0.2.0 (first, ok) | 3m39s | 13m12s |
| v0.3.0 (ok) | 2m08s | 13m14s |
| v0.2.0 (re-run) | **45m07s hung** | timed out |
| v0.3.1 | **~14m hung** | cancelled |

## Changes

**1. Bound the apt step** — `timeout-minutes: 10` (~3–5× normal, so healthy runs are untouched), plus `Acquire::http/https::Timeout=20`, `Acquire::Retries=3`, `DEBIAN_FRONTEND=noninteractive`, and one retry of `apt-get update`. A dead mirror now errors in seconds instead of hanging.

**2. Release job runs on `!cancelled()`** — a cancelled matrix leg used to skip it entirely, discarding two good platform builds. Now a draft is assembled from whatever built. Missing platforms are recorded instead of fatal, and the draft notes carry a `> [!WARNING]` block naming them, where whoever clicks Publish will see it. Re-running the failed job fills the gap in place (`overwrite_files` is on).

**3. New `Release Download Guard` workflow** — because #2 makes an incomplete release publishable, and missing assets aren't cosmetic: the site links to fixed filenames under `/releases/latest/download`, and it is `output: "export"` (a static export), so it cannot check at runtime whether those files exist. Publishing an incomplete release silently breaks that platform's button.

The guard runs on `release: published` and reverts an incomplete release to draft, putting `/releases/latest` back on the last complete release. A failed asset lookup fails the check *without* touching the release, so an API hiccup can never unpublish a good one.

**4. `actions/checkout@v4` → `@v5`**, clearing the Node 20 deprecation warning in the annotations.

## Verification

YAML parses for both workflows; every edited `run` block passes `bash -n`. Logic exercised locally against fake artifact trees and the real GitHub API:

| Case | Result |
|---|---|
| Aliases, all artifacts present | all three created, exit 0 |
| Aliases, mac missing on a tag | `::warning::`, `missing=Rhema-macos-arm64.dmg` output, exit 0 (draft still built) |
| Notes with a missing platform | `> [!WARNING]` block naming the file appears above the download table |
| Notes with nothing missing | no warning block |
| Guard vs **real v0.3.0** release | `All 3 site download targets present`, exit 0 |
| Guard vs incomplete release | reports `is missing Rhema-macos-arm64.dmg`, reverts to draft, exit 1 |
| Guard when asset lookup fails | **0 patch attempts**, fails with a clear error, release untouched |

## Next

Once this merges I'll re-tag `v0.3.1` — the current tag points at a commit whose workflow still has the unbounded apt step, and a tag push runs the workflow as it exists at the tagged commit.