### PR TITLE
ci: keep release notes in step with the attempt that produced them

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -432,3 +432,19 @@ jobs:
           overwrite_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub's "get release by tag" API excludes drafts, so the action above
+      # cannot find the draft a previous attempt created: it takes the "create"
+      # path, hits already-exists, uploads the new assets, and leaves the old
+      # body in place. On v0.3.1 that stranded a "Linux build missing" warning
+      # on a release that had just been completed by a re-run. Setting the body
+      # explicitly makes the notes describe the attempt that actually produced
+      # them. `gh` finds drafts by tag, which the action's lookup does not.
+      - name: Sync release notes to this attempt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "v${{ steps.version.outputs.version }}" \
+            --notes-file release-notes.md
+
+          echo "Release notes synced for v${{ steps.version.outputs.version }}."


### PR DESCRIPTION
Found while shipping v0.3.1. Re-running the failed Linux build completed the release — all 10 assets present, including `Rhema-linux-x86_64.AppImage` — but the notes still carried the **"Linux build missing"** warning from attempt 1, and its download table was missing the three Linux rows.

## Cause

GitHub's `GET /releases/tags/{tag}` **excludes draft releases**, so `softprops/action-gh-release` cannot find the draft an earlier attempt created. The attempt-2 log shows it taking the create path:

```
👩‍🏭 Creating new GitHub release for tag v0.3.1...
⬆️ Uploading Rhema-linux-x86_64.AppImage...
```

The create fails as already-exists, the action falls back to uploading assets to the existing release, and **the body is never updated**. Net effect: assets complete, notes stale — the worst combination, because the notes are what a maintainer reads before deciding whether it's safe to publish.

Confirmed only one release object exists (id `373377878`), so this is a body-update gap, not a duplicate-release problem.

## Fix

A `gh release edit --notes-file` step after the action. `gh` resolves drafts by tag, which the action's lookup cannot.

## Verification

Ran the exact command against the live v0.3.1 draft: the warning is gone, the Linux rows are present, and the release still reports `draft: true` with all 10 assets. YAML parses, `bash -n` clean, and the release job's step order is unchanged apart from the new final step.

## Note

This does not change v0.3.1 — I already corrected that draft's notes by hand. It stops the next release from repeating it.