### PR TITLE
fix(macos): microphone and NDI died under the hardened runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rhema",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "rhema"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "crossbeam-channel",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ missing_panics_doc = "allow"
 
 [package]
 name = "rhema"
-version = "0.3.1"
+version = "0.3.2"
 description = "Rhema - Real-Time AI Bible Verse Detection"
 authors = ["Faithful"]
 license = "MIT"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Merged into the generated Info.plist by the macOS bundler. Apple
+	     requires a purpose string for microphone access; it is the text shown
+	     in the permission prompt and in System Settings > Privacy & Security. -->
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Rhema listens to the message so it can follow along and put the scripture being read on screen.</string>
+</dict>
+</plist>

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Signing the bundle turns on the hardened runtime (Tauri's
+	     bundle.macOS.hardenedRuntime defaults to true), which denies both of
+	     these unless the entitlement is present. Without this file the app
+	     launches and looks healthy while its two core features are dead. -->
+
+	<!-- Microphone. Denied without this, and denied *silently*: TCC never
+	     prompts, CoreAudio still hands us a running input stream, and every
+	     frame is zeroes. Capture logs "started", the no-frames watchdog never
+	     trips, Deepgram accepts the silence and returns nothing, so the only
+	     symptom is a transcript that never appears. -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+
+	<!-- NDI. libndi.dylib is signed by NDI's team (W8U66ET244); library
+	     validation refuses to map a dylib whose Team ID differs from the
+	     process's, and dlopen fails with "different Team IDs". Ad-hoc
+	     re-signing the dylib does not help — two ad-hoc signatures still
+	     count as different teams — so the entitlement is the only way to
+	     load a third-party dylib we do not sign ourselves. -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rhema",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.openbezal.rhema",
   "build": {
     "frontendDist": "../build",
@@ -31,7 +31,9 @@
     "active": true,
     "targets": "all",
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "entitlements": "entitlements.plist",
+      "infoPlist": "Info.plist"
     },
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
**Regression from #167.** Code-signing the bundle turned on the hardened runtime (`bundle.macOS.hardenedRuntime` defaults to true), which gates microphone access and third-party dylib loading behind entitlements the app did not ship. So v0.3.1 installs and launches — and both core features are dead. That is arguably worse than the "damaged" dialog it fixed, because nothing announces itself.

## NDI

From the diagnostic log:

```
dlopen(…/libndi.dylib, 0x0005): code signature not valid for use in process:
mapping process and mapped file (non-platform) have different Team IDs
```

`libndi.dylib` is signed by NDI's team (`W8U66ET244`); library validation refuses to map a dylib whose Team ID differs from the process's. Ad-hoc re-signing the dylib would not help — two ad-hoc signatures still count as different teams — so the entitlement is the only route for a third-party dylib we don't sign.

Confirmed with one dlopen harness signed three ways against the shipped dylib:

| Signing | Result |
|---|---|
| Unsigned (pre-#167 equivalent) | **LOADED** |
| Ad-hoc + hardened runtime, no entitlements (**v0.3.1**) | **FAILED** — byte-identical error to the log |
| Ad-hoc + hardened runtime + `disable-library-validation` | **LOADED** |

## Microphone

Denied, and denied *silently*. Without `com.apple.security.device.audio-input`, TCC never prompts, CoreAudio still hands back a running input stream, and every frame is zeroes — capture logs "started", Deepgram connects and accepts the silence, and the only symptom is a transcript that never arrives. The log shows precisely that shape:

```
[AUDIO]   ✓ MATCH: 'MacBook Pro Microphone'
Audio capture started on fanout thread
DeepgramClient: connected to Deepgram
… 27 seconds, zero transcript events, then stop
```

Apple also requires a purpose string before it will prompt at all, so `NSMicrophoneUsageDescription` goes into a merged `src-tauri/Info.plist`.

## Verification

Built a bundle locally (`tauri build --debug --bundles app`):

| Check | Result |
|---|---|
| Embedded entitlements | `com.apple.security.cs.disable-library-validation` ✓, `com.apple.security.device.audio-input` ✓ |
| Bundled Info.plist | `NSMicrophoneUsageDescription` present |
| Hardened runtime | `flags=0x10002(adhoc,runtime)` |
| App launches | yes, Bible DB loaded |
| Signature after first launch | still valid — #167's read-only DB fix holds |

`plutil -lint` passes on both plists, and `infoPlist`/`entitlements` are valid keys in this Tauri version's `config.schema.json` (which rejects unknown fields).

## Includes the 0.3.2 bump

Deliberately in the same PR rather than a follow-up: the fix is worthless until it ships, and v0.3.1 is what users download right now.

## Note for testing

macOS may have cached a mic decision for `com.openbezal.rhema` from the broken build. If no permission prompt appears, run `tccutil reset Microphone com.openbezal.rhema` and relaunch.