### PR TITLE
fix(ci): gh release edit needs --repo, the release job has no checkout

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -444,7 +444,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # --repo is required: this job never checks out the repo (it only
+          # downloads artifacts), so gh has no git remote to infer from and
+          # fails with "not a git repository".
           gh release edit "v${{ steps.version.outputs.version }}" \
+            --repo "${GITHUB_REPOSITORY}" \
             --notes-file release-notes.md
 
           echo "Release notes synced for v${{ steps.version.outputs.version }}."


### PR DESCRIPTION
The notes-sync step I added in #170 failed on the v0.3.2 run:

```
Run gh release edit "v0.3.2" --notes-file release-notes.md
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Error: Process completed with exit code 1.
```

## Cause

The `release` job never checks out the repository — it only downloads build artifacts — so `gh` has no git remote to infer the repo from. `GH_TOKEN` alone isn't enough; `gh` still needs to know *which* repo. My verification for #170 ran the command locally inside a git repo, which masked the missing flag.

## Impact on v0.3.2: none to the release

All ten assets uploaded, all three stable aliases created, and the notes are correct (no missing-platform warning, all three Linux rows) — the action creates a fresh release with the right body, so the sync step was redundant on a first attempt. It only mattered on a *re-run*, which is the case #170 was written for. The failure just turned the run red.

## Fix

Pass `--repo "${GITHUB_REPOSITORY}"`, matching how the guard workflow already addresses the API (`gh api "repos/${GITHUB_REPOSITORY}/..."`).

## Verification

YAML parses, `bash -n` clean. The real proof is the next re-run of a release job, since that is the only path where this step changes anything.