### PR TITLE
fix: remove explicit transformers library from model export commands

### DIFF
--- a/data/download-model.ts
+++ b/data/download-model.ts
@@ -14,11 +14,7 @@
  */
 
 import { join } from "node:path"
-import {
-  ensurePythonEnv,
-  getVenvBin,
-  PROJECT_ROOT,
-} from "./lib/python-env"
+import { ensurePythonEnv, getVenvBin, PROJECT_ROOT } from "./lib/python-env"
 
 const MODELS_DIR = join(PROJECT_ROOT, "models", "qwen3-embedding-0.6b")
 const MODELS_DIR_INT8 = join(
@@ -59,8 +55,6 @@ async function main() {
       "--task",
       "feature-extraction",
       MODELS_DIR,
-      "--library-name",
-      "transformers"
     ],
     {
       stdout: "inherit",
@@ -91,8 +85,6 @@ async function main() {
       "--arm64",
       "-o",
       MODELS_DIR_INT8,
-      "--library-name",
-      "transformers"
     ],
     {
       stdout: "inherit",

--- a/data/prepare-embeddings.ts
+++ b/data/prepare-embeddings.ts
@@ -156,8 +156,6 @@ async function main() {
         "--task",
         "feature-extraction",
         MODELS_DIR,
-        "--library-name",
-        "transformers",
       ])
       console.log(`  ✓ Model exported to ${MODELS_DIR}`)
     }
@@ -175,8 +173,6 @@ async function main() {
           "--arm64",
           "-o",
           MODELS_DIR_INT8,
-          "--library-name",
-          "transformers",
         ])
         console.log(`  ✓ INT8 model saved to ${MODELS_DIR_INT8}`)
       } catch {
@@ -225,9 +221,7 @@ async function main() {
   console.log("║   ✅ Setup complete!                          ║")
   console.log("╚══════════════════════════════════════════════╝")
   if (!withEmbedding) {
-    console.log(
-      "  Note: embedding re-ranking assets were skipped (optional)."
-    )
+    console.log("  Note: embedding re-ranking assets were skipped (optional).")
     console.log(
       "  Gain: better paraphrase search in the Context tab. Cost: ~2.5h build,"
     )


### PR DESCRIPTION
## Description

Remove the explicit `--library-name transformers` argument from the model export commands in `data/download-model.ts` and `data/prepare-embeddings.ts`.

The export tooling no longer needs the library to be specified explicitly, so this simplifies the model export configuration while preserving the existing model and INT8 export flow.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build / CI
- [ ] Performance improvement

## Areas affected

- [ ] Frontend (React / TypeScript)
- [ ] Backend (Rust / Tauri commands)
- [ ] Rust crate: <!-- specify which crate(s) -->
- [ ] Remote control (OSC / HTTP)
- [ ] Broadcast / NDI
- [ ] Theme Designer
- [ ] Bible data / search
- [ ] Audio / STT
- [x] CI/Build

## Checklist

- [ ] I have tested this change locally
- [ ] `bun run typecheck` passes
- [ ] `cargo clippy` passes without warnings
- [ ] `bun run test` passes (if applicable)
- [ ] I have added tests for new functionality (if applicable)
- [ ] UI changes include a screenshot or recording below

## Tested on

- [x] macOS
- [x] Windows (GitHub runner)
- [x] Linux (GitHub runner) 

## Screenshots / recordings

No UI changes.