### PR TITLE
feat: tell the operator when a newer release exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b --noEmit",
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -157,6 +157,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +464,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -608,6 +741,15 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1220,6 +1362,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1453,26 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -1475,6 +1664,19 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1898,6 +2100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2443,25 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3150,6 +3377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "open"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,6 +3437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3494,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3357,6 +3611,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3664,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,6 +4078,7 @@ dependencies = [
  "dotenvy",
  "fontdb",
  "log",
+ "reqwest 0.12.28",
  "rhema-api",
  "rhema-audio",
  "rhema-bible",
@@ -3814,6 +4094,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
+ "tauri-plugin-opener",
  "tauri-plugin-store",
  "tokio",
 ]
@@ -4922,6 +5203,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "url",
+ "windows 0.61.3",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5044,7 +5347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5521,6 +5824,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6671,6 +6985,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6755,3 +7139,44 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,10 @@ log.workspace = true
 tokio.workspace = true
 tauri = { version = "2.10.3", features = [] }
 tauri-plugin-log = "2"
+# Update-available check (commands/updates.rs). Same major as the stt crate's
+# client so the dependency tree keeps one reqwest.
+reqwest = { version = "0.12", features = ["json"] }
+tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 rhema-audio = { path = "crates/audio" }
 rhema-bible = { path = "crates/bible" }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,14 @@
     "dialog:default",
     "fs:default",
     "fs:allow-write-text-file",
-    "log:default"
+    "log:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        {
+          "url": "https://github.com/openbezal/rhema/*"
+        }
+      ]
+    }
   ]
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod diagnostics;
 pub mod fonts;
 pub mod remote;
 pub mod stt;
+pub mod updates;

--- a/src-tauri/src/commands/updates.rs
+++ b/src-tauri/src/commands/updates.rs
@@ -1,0 +1,190 @@
+//! Tells the operator when a newer release exists.
+//!
+//! Deliberately only a notice: it never downloads or installs anything. The
+//! check runs here rather than in the webview because the app's CSP is
+//! `connect-src 'self'`, and a version string is not worth widening it for.
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+
+/// Where releases are published. `/releases/latest` excludes prereleases and
+/// drafts, so this only ever reports a release that is public and complete.
+const LATEST_RELEASE_API: &str =
+    "https://api.github.com/repos/openbezal/rhema/releases/latest";
+
+/// GitHub rejects requests without a User-Agent, and a slow network must never
+/// hold anything up — this is a background nicety, not a feature the operator
+/// is waiting on.
+const REQUEST_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateStatus {
+    /// The running app's version.
+    pub current: String,
+    /// The newest published release, without the `v` prefix.
+    pub latest: String,
+    /// Where a human goes to download it.
+    pub url: String,
+    /// Whether `latest` is actually ahead of `current`.
+    pub is_newer: bool,
+}
+
+/// The two fields we need out of GitHub's release payload. Everything else in
+/// the response is ignored, so new fields upstream cannot break parsing.
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+}
+
+/// Parse `0.3.2` or `v0.3.2` into comparable numbers.
+///
+/// Returns `None` for anything that is not purely numeric dotted components,
+/// which includes prerelease tags like `0.4.0-rc1`. Callers treat `None` as
+/// "do not claim this is newer": a version we cannot reason about should never
+/// nag the operator to install it.
+fn parse_version(raw: &str) -> Option<Vec<u32>> {
+    let trimmed = raw.trim().trim_start_matches(['v', 'V']);
+    if trimmed.is_empty() {
+        return None;
+    }
+    trimmed
+        .split('.')
+        .map(|part| part.parse::<u32>().ok())
+        .collect()
+}
+
+/// Whether `latest` is a higher version than `current`.
+///
+/// Ragged component counts compare as if the shorter were zero-padded, so
+/// `0.4` beats `0.3.9` and `0.3` ties with `0.3.0`.
+fn is_newer(latest: &str, current: &str) -> bool {
+    let (Some(latest), Some(current)) = (parse_version(latest), parse_version(current)) else {
+        return false;
+    };
+
+    let len = latest.len().max(current.len());
+    for i in 0..len {
+        let l = latest.get(i).copied().unwrap_or(0);
+        let c = current.get(i).copied().unwrap_or(0);
+        if l != c {
+            return l > c;
+        }
+    }
+    false
+}
+
+/// Ask GitHub for the newest release. Errors are for the caller to swallow:
+/// being offline is the normal case in a lot of church buildings.
+#[tauri::command]
+pub async fn check_for_update(app: AppHandle) -> Result<UpdateStatus, String> {
+    let current = app.package_info().version.to_string();
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .user_agent(format!("Rhema/{current}"))
+        .build()
+        .map_err(|e| format!("could not build HTTP client: {e}"))?;
+
+    let response = client
+        .get(LATEST_RELEASE_API)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("update check failed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("update check returned {}", response.status()));
+    }
+
+    let release: GithubRelease = response
+        .json()
+        .await
+        .map_err(|e| format!("could not read release info: {e}"))?;
+
+    let latest = release.tag_name.trim_start_matches(['v', 'V']).to_string();
+    let is_newer = is_newer(&latest, &current);
+
+    log::info!(
+        "[UPDATE] current={current} latest={latest} newer={is_newer}"
+    );
+
+    Ok(UpdateStatus {
+        current,
+        latest,
+        url: release.html_url,
+        is_newer,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn later_patch_minor_and_major_are_newer() {
+        assert!(is_newer("0.3.3", "0.3.2"));
+        assert!(is_newer("0.4.0", "0.3.9"));
+        assert!(is_newer("1.0.0", "0.9.9"));
+    }
+
+    #[test]
+    fn same_version_is_not_newer() {
+        assert!(!is_newer("0.3.2", "0.3.2"));
+    }
+
+    #[test]
+    fn older_version_is_not_newer() {
+        assert!(!is_newer("0.3.1", "0.3.2"));
+        assert!(!is_newer("0.2.9", "0.3.0"));
+    }
+
+    #[test]
+    fn the_v_prefix_is_ignored() {
+        assert!(is_newer("v0.3.3", "0.3.2"));
+        assert!(!is_newer("v0.3.2", "0.3.2"));
+    }
+
+    #[test]
+    fn ragged_component_counts_pad_with_zeroes() {
+        assert!(is_newer("0.4", "0.3.9"));
+        assert!(!is_newer("0.3", "0.3.0"));
+        assert!(!is_newer("0.3.0", "0.3"));
+    }
+
+    #[test]
+    fn double_digit_components_compare_numerically_not_alphabetically() {
+        assert!(is_newer("0.10.0", "0.9.0"));
+        assert!(!is_newer("0.9.0", "0.10.0"));
+    }
+
+    #[test]
+    fn unparseable_versions_never_prompt_an_update() {
+        assert!(!is_newer("0.4.0-rc1", "0.3.2"));
+        assert!(!is_newer("nightly", "0.3.2"));
+        assert!(!is_newer("", "0.3.2"));
+        assert!(!is_newer("0.3.3", "not-a-version"));
+    }
+
+    #[test]
+    fn release_payload_parses_and_ignores_unknown_fields() {
+        let payload = r#"{
+            "tag_name": "v0.3.2",
+            "html_url": "https://github.com/openbezal/rhema/releases/tag/v0.3.2",
+            "name": "Rhema v0.3.2",
+            "draft": false,
+            "prerelease": false,
+            "assets": [{"name": "Rhema-macos-arm64.dmg"}],
+            "some_field_github_adds_next_year": 42
+        }"#;
+
+        let release: GithubRelease = serde_json::from_str(payload).unwrap();
+
+        assert_eq!(release.tag_name, "v0.3.2");
+        assert_eq!(
+            release.html_url,
+            "https://github.com/openbezal/rhema/releases/tag/v0.3.2"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -88,6 +88,8 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        // Opens the release page when the operator acts on an update notice.
+        .plugin(tauri_plugin_opener::init())
         .manage(Mutex::new(state::AppState::new()))
         .manage(Mutex::new(rhema_detection::DetectionPipeline::new()))
         .manage(Mutex::new(rhema_broadcast::ndi::NdiRuntime::default()))
@@ -134,6 +136,7 @@ pub fn run() {
             commands::remote::stop_http,
             commands::remote::get_http_status,
             commands::remote::update_remote_status,
+            commands::updates::check_for_update,
         ])
         .setup(|app| {
             use tauri::Manager;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { Dashboard } from "@/components/layout/dashboard"
 import { useBroadcastOutputs } from "@/hooks/use-broadcast-outputs"
 import { useRemoteControl } from "@/hooks/use-remote-control"
+import { useUpdateNotice } from "@/hooks/use-update-notice"
 import { TutorialOverlay } from "@/components/tutorial/tutorial-overlay"
 import { Toaster } from "sonner"
 
 export function App() {
   useRemoteControl()
   useBroadcastOutputs()
+  useUpdateNotice()
   return (
     <>
       <Dashboard />

--- a/src/components/settings/diagnostics-section.tsx
+++ b/src/components/settings/diagnostics-section.tsx
@@ -6,7 +6,9 @@ import { getVersion } from "@tauri-apps/api/app"
 import { appLogDir } from "@tauri-apps/api/path"
 import { save } from "@tauri-apps/plugin-dialog"
 import { writeTextFile } from "@tauri-apps/plugin-fs"
+import { openUrl } from "@tauri-apps/plugin-opener"
 import { Button } from "@/components/ui/button"
+import { useUpdateCheck } from "@/hooks/use-update-check"
 import {
   Select,
   SelectContent,
@@ -33,6 +35,10 @@ export function DiagnosticsSection() {
   const [saving, setSaving] = useState(false)
   const [version, setVersion] = useState("")
   const [logDir, setLogDir] = useState("")
+  const update = useUpdateCheck()
+  // Narrowing on `update.status` does not survive into a callback, so bind the
+  // available release to a local the closure can capture.
+  const available = update.status?.isNewer ? update.status : null
 
   useEffect(() => {
     void getVersion().then(setVersion).catch(() => {})
@@ -123,6 +129,46 @@ export function DiagnosticsSection() {
             <span className="truncate font-mono text-[0.6875rem]" title={logDir}>
               {logDir || "—"}
             </span>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 border-t border-border pt-2">
+            <span className="text-xs text-muted-foreground">
+              {update.checking
+                ? "Checking for updates…"
+                : available
+                  ? `Rhema ${available.latest} is available`
+                  : update.status
+                    ? "Up to date"
+                    : "Update check unavailable"}
+            </span>
+
+            {available ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 shrink-0 px-2 text-xs"
+                onClick={() => {
+                  void openUrl(available.url).catch((error: unknown) => {
+                    toast.error("Could not open the release page", {
+                      description: String(error),
+                    })
+                  })
+                }}
+              >
+                <DownloadIcon className="mr-1 size-3" />
+                Download
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 shrink-0 px-2 text-xs"
+                disabled={update.checking}
+                onClick={() => void update.recheck()}
+              >
+                Check again
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/src/hooks/use-update-check.ts
+++ b/src/hooks/use-update-check.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from "react"
+import { fetchUpdateStatus } from "@/lib/update-check"
+import type { UpdateStatus } from "@/types"
+
+/**
+ * Asks the backend once per launch whether a newer release exists.
+ *
+ * A failed check resolves to `null` (see fetchUpdateStatus) so callers render
+ * nothing rather than surfacing a network error nobody can act on.
+ */
+export function useUpdateCheck(): {
+  status: UpdateStatus | null
+  checking: boolean
+  recheck: () => Promise<void>
+} {
+  const [status, setStatus] = useState<UpdateStatus | null>(null)
+  // The launch check is already in flight by first paint, so this starts true
+  // rather than being flipped synchronously inside the effect below.
+  const [checking, setChecking] = useState(true)
+
+  const recheck = useCallback(async () => {
+    setChecking(true)
+    try {
+      setStatus(await fetchUpdateStatus())
+    } finally {
+      setChecking(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    let unmounted = false
+
+    void (async () => {
+      const result = await fetchUpdateStatus()
+      if (unmounted) return
+      setStatus(result)
+      setChecking(false)
+    })()
+
+    return () => {
+      unmounted = true
+    }
+  }, [])
+
+  return { status, checking, recheck }
+}

--- a/src/hooks/use-update-notice.ts
+++ b/src/hooks/use-update-notice.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react"
+import { toast } from "sonner"
+import { openUrl } from "@tauri-apps/plugin-opener"
+import { useUpdateCheck } from "@/hooks/use-update-check"
+
+/**
+ * Tells the operator once per launch that a newer release exists.
+ *
+ * Deliberately a toast rather than a persistent banner: this app is on screen
+ * during live services, and a notice about an optional download must never
+ * compete with the verse being broadcast. Dismissed is dismissed — it is not
+ * shown again until the next launch, and Settings keeps the same information
+ * available for anyone who wants it later.
+ */
+export function useUpdateNotice(): void {
+  const { status } = useUpdateCheck()
+  // Toast IDs are per-launch, and a re-render must not stack duplicates.
+  const announced = useRef(false)
+
+  useEffect(() => {
+    if (!status?.isNewer || announced.current) return
+    announced.current = true
+
+    toast.info(`Rhema ${status.latest} is available`, {
+      description: `You are running ${status.current}.`,
+      duration: 15_000,
+      action: {
+        label: "Download",
+        onClick: () => {
+          void openUrl(status.url).catch((error: unknown) => {
+            console.warn("[UPDATE] could not open release page:", error)
+          })
+        },
+      },
+    })
+  }, [status])
+}

--- a/src/lib/update-check.test.ts
+++ b/src/lib/update-check.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { UpdateStatus } from "@/types"
+
+const mockInvoke = vi.fn()
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+import { fetchUpdateStatus } from "./update-check"
+
+const NEWER: UpdateStatus = {
+  current: "0.3.2",
+  latest: "0.3.3",
+  url: "https://github.com/openbezal/rhema/releases/tag/v0.3.3",
+  isNewer: true,
+}
+
+describe("fetchUpdateStatus", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset()
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  it("returns the backend's status", async () => {
+    mockInvoke.mockResolvedValue(NEWER)
+
+    await expect(fetchUpdateStatus()).resolves.toEqual(NEWER)
+    expect(mockInvoke).toHaveBeenCalledWith("check_for_update")
+  })
+
+  it("resolves to null when the check fails, rather than throwing", async () => {
+    mockInvoke.mockRejectedValue(new Error("offline"))
+
+    await expect(fetchUpdateStatus()).resolves.toBeNull()
+  })
+})

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -1,0 +1,18 @@
+import { invoke } from "@tauri-apps/api/core"
+import type { UpdateStatus } from "@/types"
+
+/**
+ * Ask the backend whether a newer release is published.
+ *
+ * Returns `null` instead of throwing when the check fails. Being offline is
+ * ordinary in a lot of church buildings, and a version lookup is never worth
+ * interrupting an operator over — callers render nothing when this is `null`.
+ */
+export async function fetchUpdateStatus(): Promise<UpdateStatus | null> {
+  try {
+    return await invoke<UpdateStatus>("check_for_update")
+  } catch (error) {
+    console.warn("[UPDATE] check failed:", error)
+    return null
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,3 +24,4 @@ export type {
   NdiSessionInfo,
   NdiStartRequest,
 } from "./ndi"
+export type { UpdateStatus } from "./updates"

--- a/src/types/updates.ts
+++ b/src/types/updates.ts
@@ -1,0 +1,11 @@
+/** Result of asking the backend whether a newer release is published. */
+export interface UpdateStatus {
+  /** The running app's version. */
+  current: string
+  /** Newest published release, without the `v` prefix. */
+  latest: string
+  /** Release page to send the operator to. */
+  url: string
+  /** Whether `latest` is actually ahead of `current`. */
+  isNewer: boolean
+}


### PR DESCRIPTION
Option A from the update discussion: **a notice, not an updater.** It never downloads or installs anything.

Today there is no update mechanism at all, so anyone who installed a broken build is stranded — v0.3.0 shows "damaged", v0.3.1 has a dead microphone, and neither will ever tell its user that v0.3.2 fixed it.

## What it does

- **Toast once per launch** when a newer release is published, with a **Download** action. A toast rather than a persistent banner because this app is on screen during live services; an optional download must not compete with the verse being broadcast. Dismissed is dismissed until next launch.
- **Settings → Diagnostics row** beside the existing version: "Up to date" / "Rhema 0.3.3 is available" / "Update check unavailable", with Download or "Check again".

## Design notes

- **The check runs in Rust, not the webview.** The app's CSP is `connect-src 'self'`; a version string isn't worth widening it for.
- **Failures render nothing.** `fetchUpdateStatus` resolves to `null` — being offline is ordinary in a church building, not an incident worth a dialog.
- **Unparseable versions never prompt.** Prerelease tags, `nightly`, garbage → "not newer", so a version we can't reason about can't nag anyone. `/releases/latest` already excludes prereleases and drafts.
- **`tauri-plugin-opener` was dead weight**: the JS package was a dependency but the Rust plugin was never initialised and had no capability entry, so opening a URL would have failed. Now registered, with its permission **scoped to `https://github.com/openbezal/rhema/*`** rather than arbitrary URLs.

## Verification

**Unit tests, then mutation-tested to prove they aren't decorative.** I wrote tests and implementation in one pass rather than test-first, so instead of claiming the discipline I checked the guarantee it's meant to provide — three deliberate mutations, each caught:

| Mutation | Tests failed |
|---|---|
| `is_newer` always returns false | 4 |
| comparison inverted (`l < c`) | 5 |
| `v` prefix no longer stripped | 1 |

Green again after restoring. 8 Rust tests cover patch/minor/major, `v` prefix, ragged component counts, double-digit components (`0.10.0 > 0.9.0`), unparseable input, and payload parsing with unknown fields. 2 frontend tests cover the silent-failure contract.

**End-to-end in a real signed bundle**, both paths, read from the log rather than assumed:

```
[UPDATE] current=0.3.2 latest=0.3.2 newer=false     ← no toast, correct
[UPDATE] current=0.3.0 latest=0.3.2 newer=true      ← toast shown
```

The second was forced by temporarily lowering the bundle version, and **I screenshotted the running app to confirm the toast actually renders**: *"Rhema 0.3.2 is available / You are running 0.3.0."* with a Download button. The temporary version change is reverted; `git diff` on `tauri.conf.json` is empty.

**Regression checks against the v0.3.2 fixes** (since signing/entitlements were the last two regressions):

| Check | Result |
|---|---|
| Entitlements still embedded | `disable-library-validation` ✓, `device.audio-input` ✓ |
| Mic usage string in Info.plist | present |
| Signature before launch | valid |
| Signature **after** launch | valid |
| NDI dylib loadable under these entitlements | LOADED |

**Suite:** 222 frontend tests, 23 Rust tests, `cargo clippy` clean on the new file, and **zero new lint problems** (145 with and without the change, via `stash -u`).

## Two process problems this surfaced

1. **`bun run typecheck` was a no-op.** `tsc --noEmit` against a solution `tsconfig.json` with `"files": []` checks **zero** project files — `--listFiles` confirms. It passed while this branch had a real type error, which only `bun run build`'s `tsc -b` caught. Changed to `tsc -b --noEmit` and verified by injecting a deliberate error and watching it fail.
2. **My first "no regressions" check was worthless** — the build had failed and I inspected the stale bundle. Caught by reading the build log rather than trusting the exit path.

## Not included (deliberately)

Auto-install, "skip this version" persistence, update channels. Full auto-update (`tauri-plugin-updater`) is worth doing once there's an Apple Developer ID — with ad-hoc signing, every auto-update would likely re-prompt for microphone permission, since macOS ties TCC decisions to signing identity.